### PR TITLE
Add compiler in context

### DIFF
--- a/packages/agent/src/AutoBeAgent.ts
+++ b/packages/agent/src/AutoBeAgent.ts
@@ -30,6 +30,7 @@ export class AutoBeAgent<Model extends ILlmSchema.Model> {
     this.context_ = {
       model: props.model,
       vendor: props.vendor,
+      compiler: props.compiler,
       usage: () => this.agentica_.getTokenUsage(),
       state: () => this.state_,
     };

--- a/packages/agent/src/context/AutoBeContext.ts
+++ b/packages/agent/src/context/AutoBeContext.ts
@@ -1,3 +1,4 @@
+import { IAutoBeCompiler } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
 
 import { IAutoBeVendor } from "../structures/IAutoBeVendor";
@@ -7,6 +8,7 @@ import { AutoBeTokenUsage } from "./AutoBeTokenUsage";
 export interface AutoBeContext<Model extends ILlmSchema.Model> {
   model: Model;
   vendor: IAutoBeVendor;
+  compiler: IAutoBeCompiler;
   usage: () => AutoBeTokenUsage;
   state: () => AutoBeState;
 }

--- a/packages/agent/src/structures/IAutoBeProps.ts
+++ b/packages/agent/src/structures/IAutoBeProps.ts
@@ -1,4 +1,4 @@
-import { AutoBeHistory } from "@autobe/interface";
+import { AutoBeHistory, IAutoBeCompiler } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
 
 import { IAutoBeConfig } from "./IAutoBeConfig";
@@ -7,6 +7,7 @@ import { IAutoBeVendor } from "./IAutoBeVendor";
 export interface IAutoBeProps<Model extends ILlmSchema.Model> {
   model: Model;
   vendor: IAutoBeVendor;
+  compiler: IAutoBeCompiler;
   histories?: AutoBeHistory[] | undefined;
   config?: IAutoBeConfig | undefined;
 }


### PR DESCRIPTION
This pull request introduces the `IAutoBeCompiler` property to the `AutoBeAgent` context and related interfaces, enhancing the agent's ability to handle compiler-related functionality. The changes include updates to the `AutoBeContext` and `IAutoBeProps` interfaces, as well as the addition of the `compiler` property to the `AutoBeAgent` class.

### Enhancements to the `AutoBeAgent` and related interfaces:

* [`packages/agent/src/AutoBeAgent.ts`](diffhunk://#diff-eb5845bde058399222e7eb37fcc40ccd00bee27a5d2531830decea25dc197e73R33): Added the `compiler` property to the `context_` object in the `AutoBeAgent` class to integrate compiler-related functionality.

* [`packages/agent/src/context/AutoBeContext.ts`](diffhunk://#diff-b2ebaf7729eba1f58dae1fc830579883304a624418d6e1c6bbe208b4d82f3a37R11): Updated the `AutoBeContext` interface to include the `compiler` property of type `IAutoBeCompiler`.

* [`packages/agent/src/structures/IAutoBeProps.ts`](diffhunk://#diff-d3033c698c6dc43f35f92aa0181318bb1bead6984e48bf94e1e568b7c71ffb9fR10): Added the `compiler` property to the `IAutoBeProps` interface, allowing it to be passed as part of the agent's properties.

### Import adjustments:

* [`packages/agent/src/context/AutoBeContext.ts`](diffhunk://#diff-b2ebaf7729eba1f58dae1fc830579883304a624418d6e1c6bbe208b4d82f3a37R1): Added an import for `IAutoBeCompiler` from the `@autobe/interface` module to support the new `compiler` property.

* [`packages/agent/src/structures/IAutoBeProps.ts`](diffhunk://#diff-d3033c698c6dc43f35f92aa0181318bb1bead6984e48bf94e1e568b7c71ffb9fL1-R1): Updated the imports to include `IAutoBeCompiler` from the `@autobe/interface` module.