### PR TITLE
Add ERDs on prisma compiler result

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -19,6 +19,7 @@
     "@prisma/generator-helper": "^6.7.0",
     "@prisma/internals": "^6.7.0",
     "@samchon/openapi": "catalog:samchon",
+    "prisma-markdown": "catalog:samchon",
     "tstl": "catalog:samchon",
     "typia": "catalog:samchon"
   },

--- a/packages/compiler/src/AutoBePrismaCompiler.ts
+++ b/packages/compiler/src/AutoBePrismaCompiler.ts
@@ -16,6 +16,7 @@ import {
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { IPrismaMarkdownChapter, PrismaMarkdown } from "prisma-markdown";
 
 export class AutoBePrismaCompiler implements IAutoBePrismaCompiler {
   public async compile(
@@ -88,12 +89,20 @@ export class AutoBePrismaCompiler implements IAutoBePrismaCompiler {
           "node_modules/@prisma/client/index.d.ts":
             "export * from '.prisma/client/default'",
         },
+        diagrams: this.compileDiagrams(document.datamodel),
       };
     } catch (error) {
       return out(this.catch(error));
     } finally {
       await clear();
     }
+  }
+
+  private compileDiagrams(model: DMMF.Datamodel): Record<string, string> {
+    const chapters: IPrismaMarkdownChapter[] = PrismaMarkdown.categorize(model);
+    return Object.fromEntries(
+      chapters.map((ch) => [ch.name, PrismaMarkdown.writeDiagram(ch.diagrams)]),
+    );
   }
 
   private catch(

--- a/packages/interface/src/compiler/IAutoBePrismaCompilerResult.ts
+++ b/packages/interface/src/compiler/IAutoBePrismaCompilerResult.ts
@@ -5,6 +5,7 @@ export type IAutoBePrismaCompilerResult =
 export namespace IAutoBePrismaCompilerResult {
   export interface ISuccess {
     type: "success";
+    diagrams: Record<string, string>;
     files: Record<string, string>;
   }
   export interface IFailure {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@samchon/openapi':
       specifier: ^4.3.0
       version: 4.3.0
+    prisma-markdown:
+      specifier: ^3.0.0
+      version: 3.0.0
     tstl:
       specifier: ^3.0.0
       version: 3.0.0
@@ -99,7 +102,7 @@ importers:
         version: 6.0.3(@nestia/fetcher@6.0.3(@samchon/openapi@4.3.0)(typia@9.3.0(@samchon/openapi@4.3.0)(typescript@5.8.3)))(@nestjs/common@11.1.0(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.0(@nestjs/common@11.1.0(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
       '@prisma/client':
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.8.3)
+        version: 6.7.0(prisma@6.8.1(typescript@5.8.3))(typescript@5.8.3)
       '@prisma/client-generator-js':
         specifier: ^6.7.0
         version: 6.7.0(typescript@5.8.3)
@@ -112,6 +115,9 @@ importers:
       '@samchon/openapi':
         specifier: catalog:samchon
         version: 4.3.0
+      prisma-markdown:
+        specifier: catalog:samchon
+        version: 3.0.0(@prisma/client@6.7.0(prisma@6.8.1(typescript@5.8.3))(typescript@5.8.3))(prisma@6.8.1(typescript@5.8.3))
       tstl:
         specifier: catalog:samchon
         version: 3.0.0
@@ -529,8 +535,14 @@ packages:
   '@prisma/config@6.7.0':
     resolution: {integrity: sha512-di8QDdvSz7DLUi3OOcCHSwxRNeW7jtGRUD2+Z3SdNE3A+pPiNT8WgUJoUyOwJmUr5t+JA2W15P78C/N+8RXrOA==}
 
+  '@prisma/config@6.8.1':
+    resolution: {integrity: sha512-8F8fPo32+L9pZ6iESJnFS/Q6R7jvKb5Bn8hsMcOYpkIRV4OQcdvCBQpLS60qol16F0TUAu2NXiE97a/hghex4Q==}
+
   '@prisma/debug@6.7.0':
     resolution: {integrity: sha512-RabHn9emKoYFsv99RLxvfG2GHzWk2ZI1BuVzqYtmMSIcuGboHY5uFt3Q3boOREM9de6z5s3bQoyKeWnq8Fz22w==}
+
+  '@prisma/debug@6.8.1':
+    resolution: {integrity: sha512-3HrYLFje+ngEUBKH9x6LWBiqpX8pQEB791RWFS+anWoklM9b6MFdWGzK0bika3rGIs0KOb0ZTKVXo6OmWvjryg==}
 
   '@prisma/dmmf@6.7.0':
     resolution: {integrity: sha512-Nabzf5H7KUwYV/1u8R5gTQ7x3ffdPIhtxVJsjhnLOjeuem8YzVu39jOgQbiOlfOvjU4sPYkV9wEXc5tIHumdUw==}
@@ -541,11 +553,20 @@ packages:
   '@prisma/engines-version@6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed':
     resolution: {integrity: sha512-EvpOFEWf1KkJpDsBCrih0kg3HdHuaCnXmMn7XFPObpFTzagK1N0Q0FMnYPsEhvARfANP5Ok11QyoTIRA2hgJTA==}
 
+  '@prisma/engines-version@6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e':
+    resolution: {integrity: sha512-Rkik9lMyHpFNGaLpPF3H5q5TQTkm/aE7DsGM5m92FZTvWQsvmi6Va8On3pWvqLHOt5aPUvFb/FeZTmphI4CPiQ==}
+
   '@prisma/engines@6.7.0':
     resolution: {integrity: sha512-3wDMesnOxPrOsq++e5oKV9LmIiEazFTRFZrlULDQ8fxdub5w4NgRBoxtWbvXmj2nJVCnzuz6eFix3OhIqsZ1jw==}
 
+  '@prisma/engines@6.8.1':
+    resolution: {integrity: sha512-QPU2uNA33MDn1V7Kp2jMm4Ik9f1A5MOPsHDfWDVsS4cYDRO51Kli7/4mjOilmbmaVbHsTjtcTPcZ7K08v46Siw==}
+
   '@prisma/fetch-engine@6.7.0':
     resolution: {integrity: sha512-zLlAGnrkmioPKJR4Yf7NfW3hftcvqeNNEHleMZK9yX7RZSkhmxacAYyfGsCcqRt47jiZ7RKdgE0Wh2fWnm7WsQ==}
+
+  '@prisma/fetch-engine@6.8.1':
+    resolution: {integrity: sha512-BaTTSTW0dKNQ4NYsm4qDYuP6wbqaqi1/wSjub4/PF9JBQ0sWspKknrpY7qKLrA/vNQjSfw6Hfd10HWtmT9Hq7g==}
 
   '@prisma/generator-helper@6.7.0':
     resolution: {integrity: sha512-z4ey7n8eUFx7Ol7RJCoEo9SVK2roy80qLXdrUFlmswcs0e/z03wDl4tpaA02BE2Yi9KCZl2Tkd6oMes81vUefA==}
@@ -555,6 +576,9 @@ packages:
 
   '@prisma/get-platform@6.7.0':
     resolution: {integrity: sha512-i9IH5lO4fQwnMLvQLYNdgVh9TK3PuWBfQd7QLk/YurnAIg+VeADcZDbmhAi4XBBDD+hDif9hrKyASu0hbjwabw==}
+
+  '@prisma/get-platform@6.8.1':
+    resolution: {integrity: sha512-wOBUB/wiY1m4MDq9VtIy1nVF5bRhd+e0LShR4bxb9oPdfotFubxB3ZkLTRbcSppDkFU2mVSPMPu6YLHXYl5wFg==}
 
   '@prisma/internals@6.7.0':
     resolution: {integrity: sha512-TeIw9cPf5y0ULw5yOUKxVK/p6J/lvCMIAFzQQ3aSjlg5+XaNxyK8S77J1C2T/kI50/xIPJXiytjv3baUKKVzlA==}
@@ -1247,6 +1271,10 @@ packages:
   javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1443,6 +1471,23 @@ packages:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  prisma-markdown@3.0.0:
+    resolution: {integrity: sha512-qU6wSFPK/uQKqCfOLglTmw/lEVxsHj2IwE3RGGaEp4I6jxR5pKUfl4LJu+Y8kFDbGNEaRTtjQswynt7Knl2vYQ==}
+    hasBin: true
+    peerDependencies:
+      '@prisma/client': '>= 6.0.0'
+      prisma: '>= 6.0.0'
+
+  prisma@6.8.1:
+    resolution: {integrity: sha512-CLDiNk1vYWsa3ZIMZcttG3pzVaRK63yrtPBDMpzhsgI4MiahpCvdM72AAzQc/PElWENoBUx0JAF/UkIFhcmaJw==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -2075,8 +2120,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@prisma/client@6.7.0(typescript@5.8.3)':
+  '@prisma/client@6.7.0(prisma@6.8.1(typescript@5.8.3))(typescript@5.8.3)':
     optionalDependencies:
+      prisma: 6.8.1(typescript@5.8.3)
       typescript: 5.8.3
 
   '@prisma/config@6.7.0':
@@ -2086,7 +2132,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@prisma/config@6.8.1':
+    dependencies:
+      jiti: 2.4.2
+
   '@prisma/debug@6.7.0': {}
+
+  '@prisma/debug@6.8.1': {}
 
   '@prisma/dmmf@6.7.0': {}
 
@@ -2096,6 +2148,8 @@ snapshots:
 
   '@prisma/engines-version@6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed': {}
 
+  '@prisma/engines-version@6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e': {}
+
   '@prisma/engines@6.7.0':
     dependencies:
       '@prisma/debug': 6.7.0
@@ -2103,11 +2157,24 @@ snapshots:
       '@prisma/fetch-engine': 6.7.0
       '@prisma/get-platform': 6.7.0
 
+  '@prisma/engines@6.8.1':
+    dependencies:
+      '@prisma/debug': 6.8.1
+      '@prisma/engines-version': 6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e
+      '@prisma/fetch-engine': 6.8.1
+      '@prisma/get-platform': 6.8.1
+
   '@prisma/fetch-engine@6.7.0':
     dependencies:
       '@prisma/debug': 6.7.0
       '@prisma/engines-version': 6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed
       '@prisma/get-platform': 6.7.0
+
+  '@prisma/fetch-engine@6.8.1':
+    dependencies:
+      '@prisma/debug': 6.8.1
+      '@prisma/engines-version': 6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e
+      '@prisma/get-platform': 6.8.1
 
   '@prisma/generator-helper@6.7.0':
     dependencies:
@@ -2120,6 +2187,10 @@ snapshots:
   '@prisma/get-platform@6.7.0':
     dependencies:
       '@prisma/debug': 6.7.0
+
+  '@prisma/get-platform@6.8.1':
+    dependencies:
+      '@prisma/debug': 6.8.1
 
   '@prisma/internals@6.7.0(typescript@5.8.3)':
     dependencies:
@@ -2795,6 +2866,8 @@ snapshots:
 
   javascript-natural-sort@0.7.1: {}
 
+  jiti@2.4.2: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
@@ -2950,6 +3023,19 @@ snapshots:
   pluralize@8.0.0: {}
 
   prettier@3.5.3: {}
+
+  prisma-markdown@3.0.0(@prisma/client@6.7.0(prisma@6.8.1(typescript@5.8.3))(typescript@5.8.3))(prisma@6.8.1(typescript@5.8.3)):
+    dependencies:
+      '@prisma/client': 6.7.0(prisma@6.8.1(typescript@5.8.3))(typescript@5.8.3)
+      '@prisma/generator-helper': 6.7.0
+      prisma: 6.8.1(typescript@5.8.3)
+
+  prisma@6.8.1(typescript@5.8.3):
+    dependencies:
+      '@prisma/config': 6.8.1
+      '@prisma/engines': 6.8.1
+    optionalDependencies:
+      typescript: 5.8.3
 
   process-nextick-args@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ catalogs:
     "@nestia/sdk": ^6.0.3
   samchon:
     "@samchon/openapi": ^4.3.0
+    prisma-markdown: ^3.0.0
     tgrid: ^1.1.0
     tstl: ^3.0.0
     typia: ^9.3.0

--- a/test/src/features/compiler/test_compiler_facade_bbs.ts
+++ b/test/src/features/compiler/test_compiler_facade_bbs.ts
@@ -4,6 +4,7 @@ import {
   IAutoBeTypeScriptCompilerResult,
 } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
 
 import { TestRepositoryUtil } from "../../utils/TestRepositoryUtil";
 
@@ -21,4 +22,5 @@ export const test_compiler_facade_bbs = async (): Promise<void> => {
     package: "@samchon/bbs-api",
   });
   TestValidator.equals("result")(result.type)("success");
+  typia.assertEquals(result);
 };

--- a/test/src/features/compiler/test_compiler_facade_shopping.ts
+++ b/test/src/features/compiler/test_compiler_facade_shopping.ts
@@ -4,6 +4,7 @@ import {
   IAutoBeTypeScriptCompilerResult,
 } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
 
 import { TestRepositoryUtil } from "../../utils/TestRepositoryUtil";
 
@@ -21,4 +22,5 @@ export const test_compiler_facade_shopping = async (): Promise<void> => {
     package: "@samchon/shopping-api",
   });
   TestValidator.equals("result")(result.type)("success");
+  typia.assertEquals(result);
 };

--- a/test/src/features/compiler/test_compiler_prisma_correct.ts
+++ b/test/src/features/compiler/test_compiler_prisma_correct.ts
@@ -2,6 +2,7 @@ import { AutoBePrismaCompiler } from "@autobe/compiler";
 import { IAutoBePrismaCompilerResult } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
 import fs from "fs";
+import typia from "typia";
 
 import { TestGlobal } from "../../TestGlobal";
 
@@ -16,4 +17,5 @@ export const test_compiler_prisma_correct = async (): Promise<void> => {
       },
     });
   TestValidator.equals("result")(result.type)("success");
+  typia.assertEquals(result);
 };

--- a/test/src/features/compiler/test_compiler_prisma_failure.ts
+++ b/test/src/features/compiler/test_compiler_prisma_failure.ts
@@ -2,6 +2,7 @@ import { AutoBePrismaCompiler } from "@autobe/compiler";
 import { IAutoBePrismaCompilerResult } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
 import fs from "fs";
+import typia from "typia";
 
 import { TestGlobal } from "../../TestGlobal";
 
@@ -25,4 +26,5 @@ export const test_compiler_prisma_failure = async (): Promise<void> => {
       result.reason.includes("ASDFGHJ") &&
       result.reason.includes("ZXCVBNM"),
   );
+  typia.assertEquals(result);
 };

--- a/test/src/features/compiler/test_compiler_typescript_failure.ts
+++ b/test/src/features/compiler/test_compiler_typescript_failure.ts
@@ -3,7 +3,7 @@ import { IAutoBeTypeScriptCompilerResult } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
 import { MigrateApplication } from "@nestia/migrate";
 import fs from "fs";
-import { IValidation } from "typia";
+import typia, { IValidation } from "typia";
 
 import { TestGlobal } from "../../TestGlobal";
 
@@ -56,4 +56,5 @@ export const test_compiler_typescript_failure = async (): Promise<void> => {
       result.diagnostics.length === 1 &&
       !!result.diagnostics[0]?.messageText.includes("asdfasdfasfewfds"),
   );
+  typia.assertEquals(result);
 };

--- a/test/src/features/compiler/test_compiler_typescript_fs.ts
+++ b/test/src/features/compiler/test_compiler_typescript_fs.ts
@@ -1,6 +1,7 @@
 import { AutoBeTypeScriptCompiler } from "@autobe/compiler";
 import { IAutoBeTypeScriptCompilerResult } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
 
 export const test_compiler_typescript_fs = async (): Promise<void> => {
   const compiler: AutoBeTypeScriptCompiler = new AutoBeTypeScriptCompiler();
@@ -10,6 +11,7 @@ export const test_compiler_typescript_fs = async (): Promise<void> => {
     },
   });
   TestValidator.equals("result")(result.type)("success");
+  typia.assertEquals(result);
 };
 
 const FILE = `

--- a/test/src/features/compiler/test_compiler_typescript_migrate.ts
+++ b/test/src/features/compiler/test_compiler_typescript_migrate.ts
@@ -3,7 +3,7 @@ import { IAutoBeTypeScriptCompilerResult } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
 import { MigrateApplication } from "@nestia/migrate";
 import fs from "fs";
-import { IValidation } from "typia";
+import typia, { IValidation } from "typia";
 
 import { TestGlobal } from "../../TestGlobal";
 
@@ -48,4 +48,5 @@ export const test_compiler_typescript_migrate = async (): Promise<void> => {
     ),
   });
   TestValidator.equals("result")(result.type)("success");
+  typia.assertEquals(result);
 };


### PR DESCRIPTION
Related PR: samchon/prisma-markdown#33

-----------

This pull request introduces the integration of the `prisma-markdown` library into the `AutoBePrismaCompiler`, adds diagram generation functionality, and updates test cases to include additional validation using the `typia` library. It also updates dependencies in the `pnpm-lock.yaml` file to support these changes.

### Integration of `prisma-markdown` and Diagram Generation:
* Added the `prisma-markdown` library as a dependency in `package.json` and `pnpm-lock.yaml` for diagram generation functionality. (`[[1]](diffhunk://#diff-11f1c967e7b88e8bb1ad9292bc77da6ad6ac034c264ce56eed069eb1e19865deR22)`, `[[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR27-R29)`, `[[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1475-R1491)`)
* Introduced a new private method `compileDiagrams` in `AutoBePrismaCompiler` to generate diagrams from Prisma datamodels using `prisma-markdown`. (`[packages/compiler/src/AutoBePrismaCompiler.tsR101-R107](diffhunk://#diff-d6cc06050633dd3a054dd6e368a8003c0beb80baee512d052e5609438f994649R101-R107)`)
* Updated the `ISuccess` interface in `IAutoBePrismaCompilerResult` to include a `diagrams` field for storing generated diagrams. (`[packages/interface/src/compiler/IAutoBePrismaCompilerResult.tsR8](diffhunk://#diff-f612751d4e6296fac249488b1c631a091273b293b0406de5deacec1fe51a7610R8)`)

### Dependency Updates:
* Updated various Prisma-related dependencies in `pnpm-lock.yaml` to version `6.8.1`, including `@prisma/config`, `@prisma/debug`, and `@prisma/engines`. (`[[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR538-R546)`, `[[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR556-R570)`, `[[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR580-R582)`)
* Added the `jiti` library as a dependency in `pnpm-lock.yaml` for enhanced module loading. (`[pnpm-lock.yamlR1274-R1277](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1274-R1277)`)

### Test Enhancements:
* Added `typia.assertEquals` validation to multiple test cases, ensuring that test results conform to expected types and structures. (`[[1]](diffhunk://#diff-3a56ab6c82f37e232b8d29cac317d2724cf7e2a3a7b33541a9545aa70827c6a4R25)`, `[[2]](diffhunk://#diff-bdb779feaa5a404167f32905ae048722289a2efe2e24ca4c08f8d536f77150a0R25)`, `[[3]](diffhunk://#diff-83381aba5ad6065ca17d4744c9ab734486e36f721ca331aa4a7116aa63d1d68dR20)`, `[[4]](diffhunk://#diff-89d5b6fd42ed8e8b78511c5d273b361f9ed9c96a88072cdce521989fb3028cc5R29)`, `[[5]](diffhunk://#diff-15bcb22aced2f7d0564bd1bf929e89d570c44b398257f517e7039a2b362e4535R59)`, `[[6]](diffhunk://#diff-c6fc53bb2ac82923521e900aae692de526222b0d96f80ac2ebd9c054738b868aR14)`, `[[7]](diffhunk://#diff-bd3ffd49291520ae8fbc18e6e3d8026eb240de8d93e66530b19f6cebce775c89L6-R6)`)