### PR TITLE
feat(websocket-server): new module for playground setup.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,5 @@
   "[markdown]": {
     "editor.wordWrap": "on",
     "editor.formatOnSave": true,
-  }
+  },
 }

--- a/packages/websocket-server/package.json
+++ b/packages/websocket-server/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@autobe/websocket-server",
+  "version": "0.0.0",
+  "description": "AI backend server code generator",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "rimraf lib && tsc && rollup -c",
+    "dev": "rimraf lib && tsc --watch",
+    "prepack": "pnpm run build"
+  },
+  "keywords": [],
+  "author": "Wrtn Technologies",
+  "license": "MIT",
+  "files": [
+    "lib",
+    "src",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts"
+  },
+  "dependencies": {
+    "@autobe/agent": "workspace:^",
+    "@autobe/interface": "workspace:^",
+    "@autobe/rpc": "workspace:^",
+    "@samchon/openapi": "catalog:samchon",
+    "tgrid": "catalog:samchon"
+  },
+  "devDependencies": {
+    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^12.1.2",
+    "rimraf": "^6.0.1",
+    "rollup": "^4.40.1",
+    "typescript": "catalog:typescript"
+  }
+}

--- a/packages/websocket-server/rollup.config.js
+++ b/packages/websocket-server/rollup.config.js
@@ -1,0 +1,31 @@
+const terser = require("@rollup/plugin-terser");
+const typescript = require("@rollup/plugin-typescript");
+const json = require("@rollup/plugin-json");
+
+module.exports = {
+  input: "./src/index.ts",
+  output: {
+    dir: "lib",
+    format: "esm",
+    entryFileNames: "[name].mjs",
+    sourcemap: true,
+  },
+  plugins: [
+    typescript({
+      tsconfig: "tsconfig.json",
+      module: "ES2020",
+      target: "ES2020",
+    }),
+    terser({
+      format: {
+        comments: "some",
+        beautify: true,
+        ecma: "2020",
+      },
+      compress: false,
+      mangle: false,
+      module: true,
+    }),
+    json(),
+  ],
+};

--- a/packages/websocket-server/src/AutoBeWebSocketServer.ts
+++ b/packages/websocket-server/src/AutoBeWebSocketServer.ts
@@ -1,0 +1,42 @@
+import { IAutoBeRpcListener, IAutoBeRpcService } from "@autobe/interface";
+import { AutoBeRpcService } from "@autobe/rpc";
+import { ILlmSchema } from "@samchon/openapi";
+import { WebSocketServer } from "tgrid";
+
+import { IAutoBeWebSocketServerProps } from "./IAutoBeWebSocketServerProps";
+
+export class AutoBeWebSocketServer<Model extends ILlmSchema.Model> {
+  private readonly server: WebSocketServer<
+    any,
+    IAutoBeRpcService,
+    IAutoBeRpcListener
+  >;
+
+  public constructor(
+    private readonly props: IAutoBeWebSocketServerProps<Model>,
+  ) {
+    this.server = new WebSocketServer();
+  }
+
+  public async open(port: number): Promise<void> {
+    await this.server.open(port, async (acceptor) => {
+      const agent = await this.props.agent(acceptor);
+      if (agent === null) await acceptor.reject();
+      else
+        await acceptor.accept(
+          new AutoBeRpcService({
+            agent,
+            listener: acceptor.getDriver(),
+          }),
+        );
+    });
+  }
+
+  public async close(): Promise<void> {
+    await this.server.close();
+  }
+
+  public get state() {
+    return this.server.state;
+  }
+}

--- a/packages/websocket-server/src/IAutoBeWebSocketServerProps.ts
+++ b/packages/websocket-server/src/IAutoBeWebSocketServerProps.ts
@@ -1,0 +1,10 @@
+import { AutoBeAgent } from "@autobe/agent";
+import { IAutoBeRpcListener, IAutoBeRpcService } from "@autobe/interface";
+import { ILlmSchema } from "@samchon/openapi";
+import { WebSocketAcceptor } from "tgrid";
+
+export interface IAutoBeWebSocketServerProps<Model extends ILlmSchema.Model> {
+  agent(
+    acceptor: WebSocketAcceptor<any, IAutoBeRpcService, IAutoBeRpcListener>,
+  ): Promise<AutoBeAgent<Model> | null>;
+}

--- a/packages/websocket-server/src/index.ts
+++ b/packages/websocket-server/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./AutoBeWebSocketServer";
+export * from "./IAutoBeWebSocketServerProps";

--- a/packages/websocket-server/tsconfig.json
+++ b/packages/websocket-server/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../internals/config/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib",
+  },
+  "include": ["src"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ catalogs:
     prisma-markdown:
       specifier: ^3.0.0
       version: 3.0.1
+    tgrid:
+      specifier: ^1.1.0
+      version: 1.1.0
     tstl:
       specifier: ^3.0.0
       version: 3.0.0
@@ -247,6 +250,40 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      typescript:
+        specifier: catalog:typescript
+        version: 5.8.3
+
+  packages/websocket-server:
+    dependencies:
+      '@autobe/agent':
+        specifier: workspace:^
+        version: link:../agent
+      '@autobe/interface':
+        specifier: workspace:^
+        version: link:../interface
+      '@autobe/rpc':
+        specifier: workspace:^
+        version: link:../rpc
+      '@samchon/openapi':
+        specifier: catalog:samchon
+        version: 4.3.3
+      tgrid:
+        specifier: catalog:samchon
+        version: 1.1.0
+    devDependencies:
+      '@rollup/plugin-terser':
+        specifier: ^0.4.4
+        version: 0.4.4(rollup@4.41.0)
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.2
+        version: 12.1.2(rollup@4.41.0)(tslib@2.8.1)(typescript@5.8.3)
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      rollup:
+        specifier: ^4.40.1
+        version: 4.41.0
       typescript:
         specifier: catalog:typescript
         version: 5.8.3


### PR DESCRIPTION
This pull request introduces a new `@autobe/websocket-server` package and includes related configuration, implementation, and dependency updates. The changes add functionality for a WebSocket server that integrates with existing `@autobe` components and external libraries. Additionally, a minor fix was made in the `.vscode/settings.json` file.

### New `@autobe/websocket-server` package:

* **Package setup**:
  - Added a `package.json` file defining the package metadata, scripts, dependencies, and publishing configuration for the new WebSocket server package.
  - Created a `rollup.config.js` file to bundle the package using Rollup with TypeScript and Terser plugins for ES2020 output.
  - Added a `tsconfig.json` file extending a shared configuration and specifying output and included files.

* **Core implementation**:
  - Implemented the `AutoBeWebSocketServer` class in `src/AutoBeWebSocketServer.ts`, which provides methods to open and close the WebSocket server and integrates with the `@autobe/rpc` service.
  - Defined the `IAutoBeWebSocketServerProps` interface in `src/IAutoBeWebSocketServerProps.ts` to specify the required properties for the server, including an agent function.
  - Exported the main server class and interface in `src/index.ts`.

* **Dependency updates**:
  - Updated `pnpm-lock.yaml` to include dependencies and devDependencies for the new package, such as `@rollup/plugin-typescript`, `rimraf`, and `tgrid`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR38-R40) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR257-R290)

### Miscellaneous:

* Fixed a trailing comma issue in `.vscode/settings.json` to ensure proper JSON formatting.