### PR TITLE
fix(agent): compile error of analyze agent

### DIFF
--- a/packages/agent/src/analyze/Planning.ts
+++ b/packages/agent/src/analyze/Planning.ts
@@ -64,7 +64,7 @@ export class Planning implements IPlanning {
     delete this.fileMap[input.filename];
   }
 
-  abort(input: { reason: string }): "OK" {
+  abort(_input: { reason: string }): "OK" {
     return "OK";
   }
 

--- a/packages/agent/src/orchestrate/orchestrateAnalyze.ts
+++ b/packages/agent/src/orchestrate/orchestrateAnalyze.ts
@@ -31,7 +31,7 @@ export const orchestrateAnalyze =
       );
     }
 
-    const started_at = new Date().toISOString();
+    const created_at = new Date().toISOString();
     const agent = new AnalyzeAgent(createReviewerAgent, ctx, pointer);
     const response = await agent.conversate(
       [
@@ -49,7 +49,7 @@ export const orchestrateAnalyze =
         description: "",
         reason: "",
         files: pointer.value?.files,
-        started_at,
+        created_at,
         step: 0,
         type: "analyze",
       } satisfies AutoBeAnalyzeHistory;
@@ -58,7 +58,7 @@ export const orchestrateAnalyze =
       id: randomUUID(),
       type: "assistantMessage",
       text: response,
-      started_at,
+      created_at,
       completed_at: new Date().toISOString(),
     } satisfies AutoBeAssistantMessageHistory;
   };

--- a/packages/compiler/src/AutoBeInterfaceCompiler.ts
+++ b/packages/compiler/src/AutoBeInterfaceCompiler.ts
@@ -45,7 +45,6 @@ export class AutoBeInterfaceCompiler implements IAutoBeInterfaceCompiler {
 
 async function beautify(script: string) {
   try {
-    const jsDoc = await import("prettier-plugin-jsdoc");
     return await format(script, {
       parser: "typescript",
       plugins: [sortImport, await import2("prettier-plugin-jsdoc")],


### PR DESCRIPTION
This pull request introduces several updates to the `packages/agent` and `packages/compiler` modules, focusing on improving naming consistency, simplifying method signatures, and optimizing plugin imports. Below is a summary of the most important changes:

### Improvements to naming consistency:
* In `packages/agent/src/orchestrate/orchestrateAnalyze.ts`, renamed the `started_at` variable to `created_at` for better alignment with naming conventions. This change is reflected in multiple locations where the variable is used. [[1]](diffhunk://#diff-0760076d2713c7b74179a23fe6dfd2a97aa15f908f6752174db0d94d521dc9bcL34-R34) [[2]](diffhunk://#diff-0760076d2713c7b74179a23fe6dfd2a97aa15f908f6752174db0d94d521dc9bcL52-R52) [[3]](diffhunk://#diff-0760076d2713c7b74179a23fe6dfd2a97aa15f908f6752174db0d94d521dc9bcL61-R61)

### Simplification of method signatures:
* In `packages/agent/src/analyze/Planning.ts`, updated the `abort` method to use an unused parameter `_input` instead of `input`, signaling that the parameter is intentionally not used.

### Optimization of plugin imports:
* In `packages/compiler/src/AutoBeInterfaceCompiler.ts`, removed a redundant `prettier-plugin-jsdoc` import and replaced it with an inline dynamic import using `import2`, streamlining the code.