### PR TITLE
fix(agent): state and history dispatching

### DIFF
--- a/packages/agent/src/orchestrate/orchestrateAnalyze.ts
+++ b/packages/agent/src/orchestrate/orchestrateAnalyze.ts
@@ -61,12 +61,14 @@ export const orchestrateAnalyze =
         created_at,
         completed_at: new Date().toISOString(),
       };
+      ctx.histories().push(history);
       ctx.dispatch({
         type: "analyzeComplete",
         files: pointer.value.files,
         step,
         created_at,
       });
+      ctx.state().analyze = history;
       return history;
     }
     const history: AutoBeAssistantMessageHistory = {


### PR DESCRIPTION
This pull request updates the `orchestrateAnalyze` function to improve state management and ensure analysis history is properly recorded.

State management improvements:

* [`packages/agent/src/orchestrate/orchestrateAnalyze.ts`](diffhunk://#diff-0760076d2713c7b74179a23fe6dfd2a97aa15f908f6752174db0d94d521dc9bcR64-R71): Added a call to `ctx.histories().push(history)` to append the analysis history to the histories array and updated `ctx.state().analyze` to store the current analysis history.