### PR TITLE
fix(rpc): wrong import path

### DIFF
--- a/packages/rpc/src/AutoBeRpcService.ts
+++ b/packages/rpc/src/AutoBeRpcService.ts
@@ -1,3 +1,4 @@
+import { AutoBeAgent } from "@autobe/agent";
 import {
   AutoBeHistory,
   AutoBeUserMessageContent,
@@ -6,8 +7,6 @@ import {
   IAutoBeTokenUsageJson,
 } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
-
-import { AutoBeAgent } from "../../agent/src";
 
 export class AutoBeRpcService<Model extends ILlmSchema.Model>
   implements IAutoBeRpcService


### PR DESCRIPTION
This pull request updates the imports in the `AutoBeRpcService.ts` file to improve module resolution and align with the updated package structure.

### Import Updates:
* Changed the import path for `AutoBeAgent` to use the `@autobe/agent` package instead of a relative path, ensuring consistency with the updated module structure. [[1]](diffhunk://#diff-a04b770e10e58fd0b8b9115520a1975a142da73faa9b6d5c2e39ae7b8770eb59R1) [[2]](diffhunk://#diff-a04b770e10e58fd0b8b9115520a1975a142da73faa9b6d5c2e39ae7b8770eb59L10-L11)