### PR TITLE
fix: add prisma start event to orchestratePrisma function

### DIFF
--- a/packages/agent/src/orchestrate/prisma/orchestratePrisma.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrisma.ts
@@ -20,6 +20,12 @@ export const orchestratePrisma =
     props: IAutoBeApplicationProps,
   ): Promise<AutoBePrismaHistory | AutoBeAssistantMessageHistory> => {
     const start: Date = new Date();
+    ctx.dispatch({
+      type: "prismaStart",
+      created_at: start.toISOString(),
+      reason: props.reason,
+      step: ctx.state().analyze?.step ?? 0,
+    });
 
     // COMPONENTS
     const components:

--- a/test/src/features/prisma/internal/validate_agent_prisma.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma.ts
@@ -3,6 +3,7 @@ import { FileSystemIterator } from "@autobe/filesystem";
 import {
   AutoBeAssistantMessageHistory,
   AutoBePrismaHistory,
+  AutoBePrismaStartEvent,
   AutoBePrismaValidateEvent,
 } from "@autobe/interface";
 import { AutoBePrismaComponentsEvent } from "@autobe/interface/src/events/AutoBePrismaComponentsEvent";
@@ -15,6 +16,11 @@ export const validate_agent_prisma = async (owner: string, project: string) => {
   if (TestGlobal.env.CHATGPT_API_KEY === undefined) return false;
 
   const { agent } = await prepare_agent_prisma(owner, project);
+  const starts: AutoBePrismaStartEvent[] = [];
+  agent.on("prismaStart", (event) => {
+    starts.push(event);
+  });
+
   const validates: AutoBePrismaValidateEvent[] = [];
   agent.on("prismaValidate", (event) => {
     validates.push(event);
@@ -53,6 +59,7 @@ export const validate_agent_prisma = async (owner: string, project: string) => {
       "logs/tokenUsage.json": JSON.stringify(agent.getTokenUsage(), null, 2),
       "logs/components.json": JSON.stringify(components, null, 2),
       "logs/schemas.json": JSON.stringify(schemas, null, 2),
+      "logs/starts.json": JSON.stringify(starts, null, 2),
     },
   });
 };


### PR DESCRIPTION
## Description
- Add Prisma Start dispatch logic to `orchestratePrisma` function.
- Add the logic about logging the Prisms start event to `starts.json` in `validate_agent_prisma`.