### PR TITLE
fix(rpc): event tracing on RpcService

### DIFF
--- a/packages/rpc/src/AutoBeRpcService.ts
+++ b/packages/rpc/src/AutoBeRpcService.ts
@@ -40,6 +40,12 @@ export class AutoBeRpcService<Model extends ILlmSchema.Model>
     agent.on("prismaStart", (event) => {
       listener.prismaStart!(event).catch(() => {});
     });
+    agent.on("prismaComponents", (event) => {
+      listener.prismaComponents!(event).catch(() => {});
+    });
+    agent.on("prismaSchemas", (event) => {
+      listener.prismaSchemas!(event).catch(() => {});
+    });
     agent.on("prismaComplete", (event) => {
       listener.prismaComplete!(event).catch(() => {});
     });


### PR DESCRIPTION
This pull request introduces additional event listeners to the `AutoBeRpcService` class to handle new Prisma-related events. These changes expand the service's capabilities for managing Prisma components and schemas.

Enhancements to event handling:

* [`packages/rpc/src/AutoBeRpcService.ts`](diffhunk://#diff-a04b770e10e58fd0b8b9115520a1975a142da73faa9b6d5c2e39ae7b8770eb59R43-R48): Added new event listeners for `prismaComponents` and `prismaSchemas` to invoke corresponding methods on the `listener` object. These additions complement the existing Prisma-related events (`prismaStart` and `prismaComplete`) for more comprehensive event handling.