### PR TITLE
feat(bump): `embed-prisma` upgrade for escaping color codes.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ catalogs:
       specifier: ^4.3.3
       version: 4.3.3
     embed-prisma:
-      specifier: ^1.0.2
-      version: 1.0.2
+      specifier: ^1.1.0
+      version: 1.1.0
     embed-typescript:
       specifier: ^1.0.1
       version: 1.0.1
@@ -183,7 +183,7 @@ importers:
         version: 5.2.2(prettier@3.5.3)
       embed-prisma:
         specifier: catalog:samchon
-        version: 1.0.2(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)
+        version: 1.1.0(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)
       embed-typescript:
         specifier: catalog:samchon
         version: 1.0.1(typescript@5.8.3)
@@ -1800,8 +1800,8 @@ packages:
   elkjs@0.8.2:
     resolution: {integrity: sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==}
 
-  embed-prisma@1.0.2:
-    resolution: {integrity: sha512-2jFddvEiFLVY3dnIwPn+fqAuBXoORdQNyAZDczIleOjh5nHYgcFBsY4MqXCNxHbGBD72EDd9NudessMdopUNwA==}
+  embed-prisma@1.1.0:
+    resolution: {integrity: sha512-3U7Kw0dxXa+z8SaM2VbR46BGR7yUcWsWesPi3k/A9qDYbYq85SDCKbtzUWHi6C8ao/nxbEpQOKtx8rFwaiuJdg==}
 
   embed-typescript@1.0.1:
     resolution: {integrity: sha512-8H9ZQyXA9Cz3nqU0/3FaiLFiYwKT5H06WetdyAICaGHXHZLjYSsvM62vDm5ge3T2DPMn8cdowRPo6xsmcDWr7Q==}
@@ -4519,7 +4519,7 @@ snapshots:
 
   elkjs@0.8.2: {}
 
-  embed-prisma@1.0.2(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3):
+  embed-prisma@1.1.0(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@prisma/client': 6.8.2(prisma@6.8.2(typescript@5.8.3))(typescript@5.8.3)
       '@prisma/client-generator-js': 6.8.2(typescript@5.8.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalogs:
     "@nestia/migrate": ^6.0.6
     "@nestia/sdk": ^6.0.6
     "@samchon/openapi": ^4.3.3
-    embed-prisma: ^1.0.2
+    embed-prisma: ^1.1.0
     embed-typescript: ^1.0.1
     prisma-markdown: ^3.0.0
     tgrid: ^1.1.0


### PR DESCRIPTION
This pull request updates the `embed-prisma` package from version `1.0.2` to `1.1.0` across multiple files to ensure compatibility with the latest features and improvements. The changes primarily affect dependency specifications and resolution integrity in `pnpm-lock.yaml` and `pnpm-workspace.yaml`.

### Dependency Updates:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL30-R31): Updated the `embed-prisma` package version from `1.0.2` to `1.1.0` in the `catalogs`, `importers`, `packages`, and `snapshots` sections. This includes changes to the version specifier, resolution integrity hash, and dependency references. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL30-R31) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL186-R186) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1803-R1804) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4522-R4522)

* [`pnpm-workspace.yaml`](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL18-R18): Updated the `embed-prisma` package version from `^1.0.2` to `^1.1.0` in the `catalogs` section to align with the updated version in `pnpm-lock.yaml`.