### PR TITLE
feat(core): reduce return value size of facade controller

### DIFF
--- a/packages/agent/src/context/IAutoBeApplicationResult.ts
+++ b/packages/agent/src/context/IAutoBeApplicationResult.ts
@@ -1,3 +1,3 @@
 export interface IAutoBeApplicationResult {
-  success: boolean;
+  type: "success" | "failure" | "exception" | "in-progress";
 }

--- a/packages/agent/src/factory/createAutoBeApplication.ts
+++ b/packages/agent/src/factory/createAutoBeApplication.ts
@@ -24,12 +24,62 @@ export const createAutoBeController = <Model extends ILlmSchema.Model>(props: {
     name: "autobe",
     application,
     execute: {
-      analyze: orchestrateAnalyze(props.context),
-      prisma: orchestratePrisma(props.context),
-      interface: orchestrateInterface(props.context),
-      test: orchestrateTest(props.context),
-      realize: orchestrateRealize(props.context),
-    },
+      analyze: async (next) => {
+        const r = await orchestrateAnalyze(props.context)(next);
+        if (r.type === "analyze")
+          return {
+            type: "success",
+          };
+        else
+          return {
+            type: "in-progress",
+          };
+      },
+      prisma: async (next) => {
+        const r = await orchestratePrisma(props.context)(next);
+        if (r.type === "prisma")
+          return {
+            type: r.result.type,
+          };
+        else
+          return {
+            type: "in-progress",
+          };
+      },
+      interface: async (next) => {
+        const r = await orchestrateInterface(props.context)(next);
+        if (r.type === "interface")
+          return {
+            type: "success",
+          };
+        else
+          return {
+            type: "in-progress",
+          };
+      },
+      test: async (next) => {
+        const r = await orchestrateTest(props.context)(next);
+        if (r.type === "test")
+          return {
+            type: r.result.type,
+          };
+        else
+          return {
+            type: "in-progress",
+          };
+      },
+      realize: async (next) => {
+        const r = await orchestrateRealize(props.context)(next);
+        if (r.type === "realize")
+          return {
+            type: r.result.type,
+          };
+        else
+          return {
+            type: "in-progress",
+          };
+      },
+    } satisfies IAutoBeApplication,
   };
 };
 


### PR DESCRIPTION
This pull request introduces changes to improve the flexibility and granularity of the `IAutoBeApplicationResult` interface and refactors the execution logic in the `createAutoBeController` function to handle intermediate states and results more effectively.

### Interface Update for Result Types:
* [`packages/agent/src/context/IAutoBeApplicationResult.ts`](diffhunk://#diff-32d98e942a0de5e775a39978a00f0eb939f2cf0d603d5894b38eb513a8fbd0baL2-R2): Updated the `IAutoBeApplicationResult` interface to replace the `success` boolean with a more descriptive `type` field, allowing for multiple states: `"success"`, `"failure"`, `"exception"`, and `"in-progress"`.

### Refactoring Execution Logic:
* [`packages/agent/src/factory/createAutoBeApplication.ts`](diffhunk://#diff-b4b816ae53adb777348450af4cc7797bd03febfe06fa4b9197ea5232f54bf137L27-R82): Refactored the `execute` methods (`analyze`, `prisma`, `interface`, `test`, `realize`) to use asynchronous functions that return detailed result types (`"success"`, `"in-progress"`, or other specific types). This ensures better handling of intermediate states and aligns with the updated `IAutoBeApplicationResult` interface.