### PR TITLE
feat(website): add snapshot plan

### DIFF
--- a/website/pages/docs/roadmap/beta.mdx
+++ b/website/pages/docs/roadmap/beta.mdx
@@ -101,7 +101,10 @@ export async function test_api_shoppings_customers_sales_questions_comments_upda
 }
 ```
 
-### 3.2. Review Agent
+### 3.2. Snapshot Logic
+Implement comprehensive snapshot logic in the Interface Agent to ensure that OpenAPI documents and generated SDKs/e2e tests are properly validated against requirements analysis documents and Prisma DB schema definitions.
+
+### 3.3. Review Agent
 Develop a comprehensive review agent that verifies whether the OpenAPI document (API interface) written by AI properly follows the requirements analysis document and DB schema definition, identifying any missing or vague descriptions.
 
 This review agent will implement sophisticated validation mechanisms including requirements traceability to verify that every requirement from the analysis document is properly addressed in the API interface. The system ensures schema consistency by confirming that API endpoints align with the defined database schema and maintain referential integrity. Completeness validation identifies missing CRUD operations, authentication endpoints, and data validation rules, while documentation quality assessment evaluates the completeness and clarity of API documentation, including parameter descriptions, response schemas, and error handling. Security review verifies that appropriate authentication, authorization, and data validation mechanisms are implemented, and performance considerations assess API design for potential performance bottlenecks and suggest optimizations. Finally, standardization compliance ensures adherence to RESTful API design principles and OpenAPI specification standards.

--- a/website/pages/docs/websocket/index.mdx
+++ b/website/pages/docs/websocket/index.mdx
@@ -1,0 +1,71 @@
+## `@autobe/rpc`
+
+
+
+
+## Setup
+### NestJS Server
+### NodeJS Server
+### Client Application
+
+
+
+
+## Remote Procedure Call
+```mermaid
+sequenceDiagram
+box Client Application
+  actor User
+  participant Driver as Driver<Listener>
+  participant Connector as Communicator (Client)
+end
+box Server Application
+  participant Acceptor as Communicator (Server)
+  actor Provider
+end
+User->>Driver: 1. calls a function
+Activate User
+Activate Driver
+Driver->>Connector: 2. delivers the function call
+Activate Connector
+Deactivate Driver
+Connector-->>Acceptor: 3. sends a protocolized<br/>network message<br/>meaning a function call
+Deactivate Connector
+Activate Acceptor
+Acceptor->>Provider: 4. calls the function
+Provider->>Acceptor: 5. returns a value
+Acceptor-->>Connector: 6. sends a protocolized<br/>network message<br/>meaning a return value
+Deactivate Acceptor
+Activate Connector
+Connector->>Driver: 7. delivers the return value
+Deactivate Connector
+Activate Driver
+Driver->>User: 8. returns the value
+Deactivate Driver
+Deactivate User
+```
+
+WebSocket protocol with RPC paradigm for AI chatbot.
+
+### Header
+Header value delivered from client to server after the connection.
+
+In [`TGrid`](https://tgrid.com)'s RPC (Remote Procedure Call) paradigm, header means a value that is delivered after the connection from a client to the server. And header is used in most cases to authenticate the connecting client.
+
+In the above example project, `IAuthorizationHeader` is the header type, and is used by server to determine whether to accept the client's connection or not. If the client's header is not valid, the server would reject the connection.
+
+### Provider
+Functions provided from remote system.
+
+Provider is an object instance containing some functions provided for the remote system for RPC (Remote Procedure Call). In many cases, the provide becomes a class instance containing some methods to be called, but it is okay that composing the provider by just an interface type.
+
+Also, the opposite remote system will call provider's functions by the [`Driver<Remote>`](#driver) instance. In the above example, client application is providing `IAgenticaRpcListener` to the server, and server is providing `AgenticaRpcService` (`IAgenticaRpcService`) to the client.
+
+### Driver
+Driver of RPC (Remote Procedure Call).
+
+`Driver` is a proxy instance designed to call functions of the remote system. It has a generic argument `Remote` which means the type of remote system's [Provider](#provider), and you can remotely call the functions of the [Provider](#provider) asynchronously through the `Drive<Remote>` instance.
+
+When you call some function of remote [Provider](#provider) by the `Driver<Listener>` instance, it hooks the function call expression, and delivers the function name and arguments (parameter values) to the remote system through the [Communicator](#communicator). If the remote system succeeded to reply the result of the function call, [Communicator](#communicator) resolves the promise of the function call expression with the result, so that makes `Driver<Remote>` working.
+
+In the above example, client application is calling `IAgenticaRpcService.conversate()` function remotely through the `Driver<IAgenticaRpcService>` typed instance. In that case, `IAgenticaRpcService` is the [Provider](#provider) instance from server to client.

--- a/website/template/AutoBeRoadmapPreface.mdx
+++ b/website/template/AutoBeRoadmapPreface.mdx
@@ -14,8 +14,9 @@ gantt
   SQLite Support:       planned, 2025-06-16,  7d
 
   section Interface Agent
-  Keyworded SDK: done,    2025-06-01, 10d
-  Review Agent:  planned, 2025-07-02, 30d
+  Keyworded SDK:  done,    2025-06-01, 10d
+  Snapshot Logic: planned, 2025-06-23, 7d
+  Review Agent:   planned, 2025-07-02, 30d
 
   section Test Agent
   Scenario Agent:       done,    2025-06-01, 10d        


### PR DESCRIPTION
This pull request introduces updates to documentation and project planning, focusing on enhancing roadmap clarity, adding new features, and providing detailed technical explanations. Key changes include the introduction of snapshot logic in the roadmap, a detailed explanation of an RPC-based WebSocket implementation, and updates to the Gantt chart timeline.

### Roadmap and Planning Updates:
* Updated the roadmap in `website/pages/docs/roadmap/beta.mdx` to include a new "Snapshot Logic" section under "3.2. Snapshot Logic," detailing the implementation of comprehensive validation mechanisms for OpenAPI documents, SDKs, and database schema definitions.
* Added "Snapshot Logic" as a planned task in the Gantt chart for the Interface Agent, scheduled for June 2025.

### Documentation Enhancements:
* Added a new section in `website/pages/docs/websocket/index.mdx` to document the `@autobe/rpc` library. This includes setup instructions for NestJS and NodeJS servers, a detailed explanation of the Remote Procedure Call (RPC) paradigm using a sequence diagram, and descriptions of key concepts such as `Header`, `Provider`, and `Driver`.