### PR TITLE
Consider business value when writing test scenarios

### DIFF
--- a/packages/agent/prompts/TEST.md
+++ b/packages/agent/prompts/TEST.md
@@ -13,6 +13,15 @@ Generate all possible scenarios that real users might experience with a single g
 - Do NOT create scenarios that require multiple API calls or dependencies on other endpoints
 - Each user journey must be self-contained and complete within this single endpoint interaction
 
+### Practicality Constraint for Scenario Quantity
+
+- Do NOT generate an excessive number of test scenarios for trivial endpoints.
+- If the endpoint is a simple read-only operation that returns a static or predictable object (e.g. `{ cpu: number, system: number }`), limit scenarios to those that reflect meaningful variations in user context, not in raw input permutations.
+- Avoid producing multiple user error or edge case scenarios when they provide no additional business insight.
+- Prioritize business relevance over theoretical input diversity.
+- The goal is to maximize scenario value, not quantity.
+
+
 ## Scenario Generation Principles
 
 ### 1. Pure User-Centric Perspective

--- a/packages/agent/src/orchestrate/analyze/AutoBeAnalyzeAgent.ts
+++ b/packages/agent/src/orchestrate/analyze/AutoBeAnalyzeAgent.ts
@@ -43,10 +43,8 @@ export class AutoBeAnalyzeAgent<Model extends ILlmSchema.Model> {
         vendor: ctx.vendor,
         config: {
           locale: ctx.config?.locale,
-          systemPrompt: {
-            describe: () => {
-              return "Answer only 'completion' or 'failure'.";
-            },
+          executor: {
+            describe: null,
           },
         },
         tokenUsage: ctx.usage(),

--- a/packages/agent/src/orchestrate/analyze/AutoBeAnalyzeReviewer.ts
+++ b/packages/agent/src/orchestrate/analyze/AutoBeAnalyzeReviewer.ts
@@ -14,10 +14,8 @@ export const AutoBeAnalyzeReviewer = <Model extends ILlmSchema.Model>(
     vendor: ctx.vendor,
     controllers: [],
     config: {
-      systemPrompt: {
-        describe: () => {
-          return "Answer only 'completion' or 'failure'.";
-        },
+      executor: {
+        describe: null,
       },
       locale: ctx.config?.locale,
     },

--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyze.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyze.ts
@@ -49,6 +49,9 @@ export const orchestrateAnalyze =
       controllers: [controller],
       config: {
         locale: ctx.config?.locale,
+        executor: {
+          describe: null,
+        },
         systemPrompt: {
           common: () => AutoBeSystemPromptConstant.ANALYZE_PLANNER,
         },

--- a/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
@@ -4,9 +4,7 @@ import { AutoBeTestScenarioEvent } from "@autobe/interface/src/events/AutoBeTest
 import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
-import { v4 } from "uuid";
 
-import { AutoBeSystemPromptConstant } from "../../constants/AutoBeSystemPromptConstant";
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
 import { transformTestScenarioHistories } from "./transformTestScenarioHistories";
@@ -14,7 +12,7 @@ import { transformTestScenarioHistories } from "./transformTestScenarioHistories
 export async function orchestrateTestScenario<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
 ): Promise<AutoBeTestScenarioEvent> {
-  const testFiles = Object.entries(ctx.state().interface?.files ?? {})
+  const files = Object.entries(ctx.state().interface?.files ?? {})
     .filter(([filename]) => {
       return filename.startsWith("test/features/api/");
     })
@@ -42,12 +40,12 @@ export async function orchestrateTestScenario<Model extends ILlmSchema.Model>(
 
   const scenarios: AutoBeTest.IScenario[][] = await Promise.all(
     endpoints.map(async (endpoint, i, arr) => {
-      const otherOperations = arr.filter((_el, j) => i !== j);
+      const endponits = arr.filter((_el, j) => i !== j);
       const rows: AutoBeTest.IScenario[] = await process(
         ctx,
         endpoint,
-        otherOperations,
-        testFiles,
+        endponits,
+        files,
       );
       ctx.dispatch({
         type: "testScenario",
@@ -74,8 +72,8 @@ export async function orchestrateTestScenario<Model extends ILlmSchema.Model>(
 async function process<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   endpoint: AutoBeOpenApi.IEndpoint,
-  others: AutoBeOpenApi.IEndpoint[],
-  testFiles: Record<string, string>,
+  endpoints: AutoBeOpenApi.IEndpoint[],
+  files: Record<string, string>,
 ): Promise<AutoBeTest.IScenario[]> {
   const pointer: IPointer<AutoBeTest.IScenario[] | null> = {
     value: null,
@@ -94,42 +92,7 @@ async function process<Model extends ILlmSchema.Model>(
     },
     tokenUsage: ctx.usage(),
     histories: [
-      ...transformTestScenarioHistories(ctx.state()),
-      {
-        id: v4(),
-        created_at: new Date().toISOString(),
-        type: "systemMessage",
-        text: AutoBeSystemPromptConstant.TEST,
-      },
-      {
-        id: v4(),
-        created_at: new Date().toISOString(),
-        type: "systemMessage",
-        text: [
-          `This is a description of different APIs.`,
-          `Different APIs may have to be called to create one.`,
-          `Check which functions have been developed.`,
-          "```json",
-          JSON.stringify(others, null, 2),
-          "```",
-        ].join("\n"),
-      },
-      {
-        id: v4(),
-        created_at: new Date().toISOString(),
-        type: "systemMessage",
-        text: [
-          "Below is basically the generated test code,",
-          "which is a test to verify that the API is simply called and successful.",
-          "Since there is already an automatically generated API,",
-          "when a user requests to create a test scenario, two or more APIs must be combined,",
-          "but a test in which the currently given endpoint is the main must be created.",
-          '"Input Test Files" should be selected from the list of files here.',
-          "```json",
-          JSON.stringify(testFiles, null, 2),
-          "```",
-        ].join("\n"),
-      },
+      ...transformTestScenarioHistories(ctx.state(), endpoints, files),
     ],
     controllers: [
       createApplication({

--- a/packages/agent/src/orchestrate/test/transformTestScenarioHistories.ts
+++ b/packages/agent/src/orchestrate/test/transformTestScenarioHistories.ts
@@ -1,4 +1,5 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
+import { AutoBeOpenApi } from "@autobe/interface";
 import { v4 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../constants/AutoBeSystemPromptConstant";
@@ -6,6 +7,8 @@ import { AutoBeState } from "../../context/AutoBeState";
 
 export const transformTestScenarioHistories = (
   state: AutoBeState,
+  endponits: AutoBeOpenApi.IEndpoint[],
+  files: Record<string, string>,
 ): Array<
   IAgenticaHistoryJson.IAssistantMessage | IAgenticaHistoryJson.ISystemMessage
 > => {
@@ -139,6 +142,41 @@ export const transformTestScenarioHistories = (
         `## OpenAPI Document`,
         "```json",
         JSON.stringify(state.interface.document),
+        "```",
+      ].join("\n"),
+    },
+    {
+      id: v4(),
+      created_at: new Date().toISOString(),
+      type: "systemMessage",
+      text: AutoBeSystemPromptConstant.TEST,
+    },
+    {
+      id: v4(),
+      created_at: new Date().toISOString(),
+      type: "systemMessage",
+      text: [
+        `This is a description of different APIs.`,
+        `Different APIs may have to be called to create one.`,
+        `Check which functions have been developed.`,
+        "```json",
+        JSON.stringify(endponits, null, 2),
+        "```",
+      ].join("\n"),
+    },
+    {
+      id: v4(),
+      created_at: new Date().toISOString(),
+      type: "systemMessage",
+      text: [
+        "Below is basically the generated test code,",
+        "which is a test to verify that the API is simply called and successful.",
+        "Since there is already an automatically generated API,",
+        "when a user requests to create a test scenario, two or more APIs must be combined,",
+        "but a test in which the currently given endpoint is the main must be created.",
+        '"Input Test Files" should be selected from the list of files here.',
+        "```json",
+        JSON.stringify(files, null, 2),
         "```",
       ].join("\n"),
     },

--- a/packages/agent/src/orchestrate/test/transformTestScenarioHistories.ts
+++ b/packages/agent/src/orchestrate/test/transformTestScenarioHistories.ts
@@ -90,19 +90,16 @@ export const transformTestScenarioHistories = (
     {
       id: v4(),
       created_at: new Date().toISOString(),
-      type: "assistantMessage",
+      type: "systemMessage",
       text: [
-        "Requirement analysis and Prisma DB schema generation are ready.",
+        "# Result of Analyze Agent",
+        "- The following document contains the user requirements that were extracted through conversations with the user by the Analyze Agent.",
+        "- The database schema was designed based on these requirements, so you may refer to this document when writing test code or reviewing the schema.",
         "",
-        "Call the provided tool function to generate the OpenAPI document",
-        "referencing below requirement analysis and Prisma DB schema.",
-        "",
-        // User Request
         `## User Request`,
         "",
-        state.analyze.reason,
+        `- ${state.analyze.reason}`,
         "",
-        // Requirement Analysis Report
         `## Requirement Analysis Report`,
         "",
         "```json",
@@ -113,9 +110,12 @@ export const transformTestScenarioHistories = (
     {
       id: v4(),
       created_at: new Date().toISOString(),
-      type: "assistantMessage",
+      type: "systemMessage",
       text: [
-        "Database schema and entity relationship diagrams are ready.",
+        "# Result of Prisma Agent",
+        "- Given the following database schema and entity-relationship diagram, write appropriate test code to validate the constraints and relationships defined in the schema. For example, if there is a unique column, include a test that ensures its uniqueness.",
+        "- The test code should strictly adhere to the schema and relationships—no violations of constraints should occur.",
+        "- Use the information from the schema and diagram to design meaningful and accurate test cases.",
         "",
         "## Prisma DB Schema",
         "```json",
@@ -131,14 +131,14 @@ export const transformTestScenarioHistories = (
     {
       id: v4(),
       created_at: new Date().toISOString(),
-      type: "assistantMessage",
+      type: "systemMessage",
       text: [
-        "OpenAPI document generation is ready.",
+        "# Result of Interfaced Agent",
+        "- OpenAPI document generation is ready.",
         "",
         "Call the provided tool function to generate the user scenarios",
         "referencing below OpenAPI document.",
         "",
-        // OpenAPI Document
         `## OpenAPI Document`,
         "```json",
         JSON.stringify(state.interface.document),

--- a/test/src/features/test/internal/validate_agent_test_schenario.ts
+++ b/test/src/features/test/internal/validate_agent_test_schenario.ts
@@ -7,7 +7,7 @@ import { prepare_agent_test } from "./prepare_agent_test";
 
 export const validate_agent_test_scenario = async (
   _owner: string,
-  project: string,
+  project: "bbs",
 ) => {
   if (TestGlobal.env.CHATGPT_API_KEY === undefined) return false;
 

--- a/test/src/features/test/test_agent_test_scenario_bbs.ts
+++ b/test/src/features/test/test_agent_test_scenario_bbs.ts
@@ -1,4 +1,4 @@
 import { validate_agent_test_scenario } from "./internal/validate_agent_test_schenario";
 
 export const test_agent_test_scenario_bbs = () =>
-  validate_agent_test_scenario("samchon", "bbs-backend");
+  validate_agent_test_scenario("samchon", "bbs");


### PR DESCRIPTION
To prevent agents from writing more than 10 meaningless test codes, even in simple object return APIs, we have modified the prompts to provide a wealth of information from proposals to schema information, and to focus on quality rather than quantity in consideration of business value.