### PR TITLE
fix(agent): life checking on prisma corrector.

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
@@ -18,9 +18,9 @@ import { transformInterfaceHistories } from "./transformInterfaceHistories";
 export function orchestrateInterfaceComplement<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   document: AutoBeOpenApi.IDocument,
-  retry: number = 8,
+  life: number = 8,
 ): Promise<AutoBeOpenApi.IComponents> {
-  return step(ctx, document, retry);
+  return step(ctx, document, life);
 }
 
 async function step<Model extends ILlmSchema.Model>(

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
@@ -11,7 +11,7 @@ import { transformPrismaCorrectHistories } from "./transformPrismaCorrectHistori
 export function orchestratePrismaCorrect<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   application: AutoBePrisma.IApplication,
-  retry: number = 8,
+  life: number = 8,
 ): Promise<IAutoBePrismaValidation> {
   const unique: Set<string> = new Set();
   for (const file of application.files)
@@ -21,7 +21,7 @@ export function orchestratePrismaCorrect<Model extends ILlmSchema.Model>(
       return true;
     });
   application.files = application.files.filter((f) => f.models.length !== 0);
-  return step(ctx, application, retry);
+  return step(ctx, application, life);
 }
 
 async function step<Model extends ILlmSchema.Model>(
@@ -31,7 +31,9 @@ async function step<Model extends ILlmSchema.Model>(
 ): Promise<IAutoBePrismaValidation> {
   const result: IAutoBePrismaValidation =
     await ctx.compiler.prisma.validate(application);
-  if (result.success) return result; // SUCCESS
+  if (result.success)
+    return result; // SUCCESS
+  else if (life <= 0) return result; // FAILURE
 
   // VALIDATION FAILED
   const schemas: Record<string, string> =

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
@@ -11,7 +11,7 @@ import { transformPrismaCorrectHistories } from "./transformPrismaCorrectHistori
 export function orchestratePrismaCorrect<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   application: AutoBePrisma.IApplication,
-  life: number = 8,
+  life: number = 4,
 ): Promise<IAutoBePrismaValidation> {
   const unique: Set<string> = new Set();
   for (const file of application.files)

--- a/packages/agent/src/orchestrate/test/orchestrateTestCorrect.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestCorrect.ts
@@ -15,7 +15,7 @@ import { transformTestCorrectHistories } from "./transformTestCorrectHistories";
 export async function orchestrateTestCorrect<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   codes: AutoBeTestProgressEvent[],
-  retry = 8,
+  life: number = 4,
 ): Promise<AutoBeTestValidateEvent> {
   // 1) Build map of new test files from progress events
   const testFiles = Object.fromEntries(
@@ -43,7 +43,7 @@ export async function orchestrateTestCorrect<Model extends ILlmSchema.Model>(
   );
 
   // 4) Ask the LLM to correct the filtered file set
-  const response = await step(ctx, files, retry);
+  const response = await step(ctx, files, life);
 
   // 5) Combine original + corrected files and dispatch event
   const event: AutoBeTestValidateEvent = {


### PR DESCRIPTION
This pull request updates the `orchestratePrismaCorrect` function in `packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts` to improve clarity and handle failure cases more explicitly. The most important changes include renaming a parameter for better readability, updating references to the renamed parameter, and adding a failure condition when retries are exhausted.

### Parameter Renaming and Usage Updates:
* Renamed the `retry` parameter to `life` in the `orchestratePrismaCorrect` function to better reflect its purpose. Updated all references to this parameter accordingly. [[1]](diffhunk://#diff-ef86dd4305e40242004412ee7909671fd0ffa7985080fe9b62574ab1f1b0fdafL14-R14) [[2]](diffhunk://#diff-ef86dd4305e40242004412ee7909671fd0ffa7985080fe9b62574ab1f1b0fdafL24-R24)

### Failure Handling:
* Added a new condition in the `step` function to return the result as a failure if the `life` parameter reaches zero, improving error handling for retry exhaustion.