### PR TITLE
feat(test): reduce test coding agent's context size.

### DIFF
--- a/packages/agent/src/orchestrate/test/orchestrateTestProgress.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestProgress.ts
@@ -1,6 +1,14 @@
 import { IAgenticaController, MicroAgentica } from "@agentica/core";
-import { AutoBeTest, AutoBeTestProgressEvent } from "@autobe/interface";
-import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
+import {
+  AutoBeOpenApi,
+  AutoBeTest,
+  AutoBeTestProgressEvent,
+} from "@autobe/interface";
+import {
+  ILlmApplication,
+  ILlmSchema,
+  OpenApiTypeChecker,
+} from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
 
@@ -59,30 +67,17 @@ async function process<Model extends ILlmSchema.Model>(
   const pointer: IPointer<ICreateTestCodeProps | null> = {
     value: null,
   };
-
-  const apiFiles = Object.entries(ctx.state().interface?.files ?? {})
-    .filter(([filename]) => {
-      return filename.startsWith("src/api/");
-    })
-    .reduce<Record<string, string>>((acc, [filename, content]) => {
-      return Object.assign(acc, { [filename]: content });
-    }, {});
-
-  const dtoFiles = Object.entries(ctx.state().interface?.files ?? {})
-    .filter(([filename]) => {
-      return filename.startsWith("src/api/structures/");
-    })
-    .reduce<Record<string, string>>((acc, [filename, content]) => {
-      return Object.assign(acc, { [filename]: content });
-    }, {});
-
+  const document: AutoBeOpenApi.IDocument = filterDocument(
+    scenario,
+    ctx.state().interface!.document,
+  );
   const agentica = new MicroAgentica({
     model: ctx.model,
     vendor: ctx.vendor,
     config: {
       ...(ctx.config ?? {}),
     },
-    histories: transformTestProgressHistories(apiFiles, dtoFiles),
+    histories: transformTestProgressHistories(document),
     controllers: [
       createApplication({
         model: ctx.model,
@@ -105,6 +100,41 @@ async function process<Model extends ILlmSchema.Model>(
   );
   if (pointer.value === null) throw new Error("Failed to create test code.");
   return pointer.value;
+}
+
+function filterDocument(
+  scneario: AutoBeTest.Scenario,
+  document: AutoBeOpenApi.IDocument,
+): AutoBeOpenApi.IDocument {
+  const operations: AutoBeOpenApi.IOperation[] = document.operations.filter(
+    (op) =>
+      scneario.endpoints.find(
+        (o) => o.method === op.method && o.path === op.path,
+      ) !== undefined,
+  );
+  const components: AutoBeOpenApi.IComponents = {
+    schemas: {},
+  };
+  const visit = (typeName: string) => {
+    OpenApiTypeChecker.visit({
+      components: document.components,
+      schema: { $ref: `#/components/schemas/${typeName}` },
+      closure: (s) => {
+        if (OpenApiTypeChecker.isReference(s)) {
+          const key: string = s.$ref.split("/").pop()!;
+          components.schemas[key] = document.components.schemas[key];
+        }
+      },
+    });
+  };
+  for (const op of operations) {
+    if (op.requestBody) visit(op.requestBody.typeName);
+    if (op.responseBody) visit(op.responseBody.typeName);
+  }
+  return {
+    operations,
+    components,
+  };
 }
 
 function createApplication<Model extends ILlmSchema.Model>(props: {

--- a/packages/agent/src/orchestrate/test/transformTestProgressHistories.ts
+++ b/packages/agent/src/orchestrate/test/transformTestProgressHistories.ts
@@ -1,11 +1,11 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
+import { AutoBeOpenApi } from "@autobe/interface";
 import { v4 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../constants/AutoBeSystemPromptConstant";
 
 export const transformTestProgressHistories = (
-  apiFiles: Record<string, string>,
-  dtoFiles: Record<string, string>,
+  document: AutoBeOpenApi.IDocument,
 ): Array<
   IAgenticaHistoryJson.IAssistantMessage | IAgenticaHistoryJson.ISystemMessage
 > => {
@@ -32,18 +32,16 @@ export const transformTestProgressHistories = (
         "- Do not invent new helpers or use utilities that are not explicitly shown.",
         "- Keep all tests deterministic and reliable.",
         "",
-        "## File References",
-        "### API Files",
-        "```typescript",
-        JSON.stringify(apiFiles, null, 2),
+        "## OpenAPI Like Document",
+        "```json",
+        JSON.stringify(document),
         "```",
         "",
-        "### DTO Files",
-        "```typescript",
-        JSON.stringify(dtoFiles, null, 2),
-        "```",
+        "Here is the OpenAPI like document only about the API functions and DTOs",
+        "related to the scenario. Use all of them to generate the E2E test code.",
         "",
         "Now generate the E2E test function based on the given scenario.",
+        "",
         "Only output a single `async function` named `test_api_{...}`. No explanation, no commentary.",
       ].join("\n"),
     },

--- a/packages/interface/src/test/AutoBeTestScenario.ts
+++ b/packages/interface/src/test/AutoBeTestScenario.ts
@@ -279,5 +279,8 @@ export namespace AutoBeTest {
      * - Maintain consistency in perspective throughout the description
      */
     scenario: string;
+
+    /** Collection of API endpoints that this scenario interacts with. */
+    endpoints: AutoBeOpenApi.IEndpoint[];
   }
 }

--- a/test/src/features/test/internal/prepare_agent_test_main.ts
+++ b/test/src/features/test/internal/prepare_agent_test_main.ts
@@ -50,9 +50,8 @@ export const prepare_agent_test_main = async (
     vendor: {
       api: new OpenAI({
         apiKey: TestGlobal.env.CHATGPT_API_KEY,
-        baseURL: "https://openrouter.ai/api/v1",
       }),
-      model: "openai/gpt-4.1",
+      model: "gpt-4.1",
       semaphore: 16,
     },
     compiler: new AutoBeCompiler(),


### PR DESCRIPTION
Reduced test coding agent's token consumption size by filtering API endpoints and components schemas just by filtering only what the scenario needs.

------------------

This pull request refactors the orchestration of test progress in the `agent` package by streamlining how OpenAPI documents are processed and integrated. The changes replace the previous approach of handling API and DTO files with a more structured use of OpenAPI-like documents, improving maintainability and clarity.

### Refactoring OpenAPI document handling:

* [`packages/agent/src/orchestrate/test/orchestrateTestProgress.ts`](diffhunk://#diff-5fa246c250e94450074ff2987900db576851ba5f11b58cfbe27ec483722a6f83L62-R80): Replaced the use of `apiFiles` and `dtoFiles` with a new `filterDocument` function that extracts relevant operations and components from the OpenAPI document based on the scenario. This function ensures only the necessary parts of the document are used. [[1]](diffhunk://#diff-5fa246c250e94450074ff2987900db576851ba5f11b58cfbe27ec483722a6f83L62-R80) [[2]](diffhunk://#diff-5fa246c250e94450074ff2987900db576851ba5f11b58cfbe27ec483722a6f83R105-R139)

* [`packages/agent/src/orchestrate/test/transformTestProgressHistories.ts`](diffhunk://#diff-a11750359dd9742136cbdb59205c4598c5dc0b9b7a4cb1038d543c7fe14228c5R2-R8): Updated `transformTestProgressHistories` to accept a single OpenAPI document instead of separate API and DTO files. The function now includes the filtered document in the generated test progress history. [[1]](diffhunk://#diff-a11750359dd9742136cbdb59205c4598c5dc0b9b7a4cb1038d543c7fe14228c5R2-R8) [[2]](diffhunk://#diff-a11750359dd9742136cbdb59205c4598c5dc0b9b7a4cb1038d543c7fe14228c5L35-R44)

### Enhancements to scenario definitions:

* [`packages/interface/src/test/AutoBeTestScenario.ts`](diffhunk://#diff-4ac12f338bdbef955d626c7453f75a0d400f941c2ed717c1d5b7b17c89f1f8a2R282-R284): Added an `endpoints` field to scenarios, defining the collection of API endpoints relevant to each scenario. This enables precise filtering of OpenAPI documents.

### Minor updates:

* [`test/src/features/test/internal/prepare_agent_test_main.ts`](diffhunk://#diff-3cf7ad5d7575a03b6b800761ee9022f4fb4c32dc2a92a94f546850b5088e4ae4L53-R54): Simplified the configuration for the OpenAI model by removing the `baseURL` and adjusting the model identifier.