### PR TITLE
fix(compiler): paths with baseUrl

### DIFF
--- a/packages/compiler/src/AutoBeTypeScriptCompiler.ts
+++ b/packages/compiler/src/AutoBeTypeScriptCompiler.ts
@@ -39,11 +39,6 @@ export class AutoBeTypeScriptCompiler implements IAutoBeTypeScriptCompiler {
     props: IAutoBeTypeScriptCompilerProps,
   ): Promise<IAutoBeTypeScriptCompilerResult> {
     const alias: string = props.package ?? "@ORGANIZATION/PROJECT-api";
-    console.log({
-      [alias]: ["./src/api"],
-      [`${alias}/lib/`]: ["./src/api"],
-      [`${alias}/lib/*`]: ["./src/api/*"],
-    });
     const compiler: EmbedTypeScript = new EmbedTypeScript({
       external: EXTERNAL as Record<string, string>,
       compilerOptions: {

--- a/packages/compiler/src/AutoBeTypeScriptCompiler.ts
+++ b/packages/compiler/src/AutoBeTypeScriptCompiler.ts
@@ -3,6 +3,7 @@ import {
   IAutoBeTypeScriptCompilerProps,
   IAutoBeTypeScriptCompilerResult,
 } from "@autobe/interface";
+import nestiaCoreTransform from "@nestia/core/lib/transform";
 import { EmbedTypeScript } from "embed-typescript";
 import ts from "typescript";
 import typiaTransform from "typia/lib/transform";
@@ -59,6 +60,13 @@ export class AutoBeTypeScriptCompiler implements IAutoBeTypeScriptCompiler {
       transformers: (program, diagnostics) => ({
         before: [
           typiaTransform(
+            program,
+            {},
+            {
+              addDiagnostic: (input) => diagnostics.push(input),
+            },
+          ),
+          nestiaCoreTransform(
             program,
             {},
             {

--- a/packages/compiler/src/AutoBeTypeScriptCompiler.ts
+++ b/packages/compiler/src/AutoBeTypeScriptCompiler.ts
@@ -3,7 +3,6 @@ import {
   IAutoBeTypeScriptCompilerProps,
   IAutoBeTypeScriptCompilerResult,
 } from "@autobe/interface";
-import nestiaCoreTransform from "@nestia/core/lib/transform";
 import { EmbedTypeScript } from "embed-typescript";
 import ts from "typescript";
 import typiaTransform from "typia/lib/transform";
@@ -40,15 +39,20 @@ export class AutoBeTypeScriptCompiler implements IAutoBeTypeScriptCompiler {
     props: IAutoBeTypeScriptCompilerProps,
   ): Promise<IAutoBeTypeScriptCompilerResult> {
     const alias: string = props.package ?? "@ORGANIZATION/PROJECT-api";
+    console.log({
+      [alias]: ["./src/api"],
+      [`${alias}/lib/`]: ["./src/api"],
+      [`${alias}/lib/*`]: ["./src/api/*"],
+    });
     const compiler: EmbedTypeScript = new EmbedTypeScript({
       external: EXTERNAL as Record<string, string>,
       compilerOptions: {
         target: ts.ScriptTarget.ESNext,
         module: ts.ModuleKind.CommonJS,
         downlevelIteration: true,
+        baseUrl: "./",
         paths: {
           [alias]: ["./src/api"],
-          [`${alias}/lib/`]: ["./src/api"],
           [`${alias}/lib/*`]: ["./src/api/*"],
         },
         strict: true,
@@ -60,13 +64,6 @@ export class AutoBeTypeScriptCompiler implements IAutoBeTypeScriptCompiler {
       transformers: (program, diagnostics) => ({
         before: [
           typiaTransform(
-            program,
-            {},
-            {
-              addDiagnostic: (input) => diagnostics.push(input),
-            },
-          ),
-          nestiaCoreTransform(
             program,
             {},
             {

--- a/test/src/features/compiler/test_compiler_typescript_alias.ts
+++ b/test/src/features/compiler/test_compiler_typescript_alias.ts
@@ -1,0 +1,22 @@
+import { AutoBeTypeScriptCompiler } from "@autobe/compiler";
+import { TestValidator } from "@nestia/e2e";
+
+export const test_compiler_typescript_import = async () => {
+  await process("ISomething", "success");
+  await process("ISomethingX", "failure");
+};
+
+const process = async (name: string, expected: "success" | "failure") => {
+  const compiler: AutoBeTypeScriptCompiler = new AutoBeTypeScriptCompiler();
+  const result = await compiler.compile({
+    files: {
+      "src/api/structures/ISomething.ts": "export interface ISomething {}",
+      "src/main.ts": `
+        import { ${name} } from "@ORGANIZATION/PROJECT-api/lib/structures/ISomething";
+        const x: ${name} = {};
+        console.log(x);
+      `,
+    },
+  });
+  TestValidator.equals("result")(result.type)(expected);
+};


### PR DESCRIPTION
This pull request includes changes to the `AutoBeTypeScriptCompiler` implementation and introduces new test coverage for TypeScript alias imports. The most significant updates involve removing the `nestiaCoreTransform` dependency, updating compiler options, and adding a new test to validate TypeScript alias behavior.

### Changes to `AutoBeTypeScriptCompiler`:

* Removed the `nestiaCoreTransform` dependency from the imports and the `transformers` array, simplifying the compiler's setup. (`packages/compiler/src/AutoBeTypeScriptCompiler.ts`) [[1]](diffhunk://#diff-cad54d4ee71a3f3f3d525f73ad52fb3d133c03bb52d73b2812dfd8aaf4bfd481L6) [[2]](diffhunk://#diff-cad54d4ee71a3f3f3d525f73ad52fb3d133c03bb52d73b2812dfd8aaf4bfd481L69-L75)
* Updated the `paths` configuration in the `compilerOptions` to include a `baseUrl` and adjusted alias mappings for better compatibility. (`packages/compiler/src/AutoBeTypeScriptCompiler.ts`)

### Testing improvements:

* Added a new test file `test_compiler_typescript_alias.ts` to verify the behavior of TypeScript alias imports. This includes a test for successful and failing imports based on interface availability. (`test/src/features/compiler/test_compiler_typescript_alias.ts`)