### PR TITLE
feat(playground): add semaphore input

### DIFF
--- a/packages/interface/src/rpc/IAutoBeRpcVendor.ts
+++ b/packages/interface/src/rpc/IAutoBeRpcVendor.ts
@@ -57,4 +57,25 @@ export interface IAutoBeRpcVendor {
    * endpoint based on the configured model and vendor detection.
    */
   baseURL?: string;
+
+  /**
+   * Maximum number of concurrent API requests allowed.
+   *
+   * Controls the concurrency level for AI API calls to prevent rate limiting,
+   * manage resource consumption, and optimize system performance. The vibe
+   * coding pipeline may make multiple parallel requests during development
+   * phases, and this setting ensures controlled resource utilization.
+   *
+   * A reasonable default provides balanced performance while respecting typical
+   * API rate limits. Lower values reduce resource consumption but may slow
+   * development progress, while higher values can improve performance but risk
+   * hitting rate limits or overwhelming the AI service.
+   *
+   * Set to undefined to disable concurrency limiting, allowing unlimited
+   * parallel requests (use with caution based on your API limits and
+   * infrastructure capacity).
+   *
+   * @default 16
+   */
+  semaphore?: number | undefined;
 }

--- a/packages/playground-server/src/executable/server.ts
+++ b/packages/playground-server/src/executable/server.ts
@@ -30,6 +30,7 @@ const main = async () => {
                 baseURL: acceptor.header.vendor.baseURL,
               }),
               model: acceptor.header.vendor.model,
+              semaphore: acceptor.header.vendor.semaphore,
             },
             config: {
               locale: acceptor.header.locale,

--- a/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatSideMovie.tsx
+++ b/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatSideMovie.tsx
@@ -28,6 +28,7 @@ export function AutoBePlaygroundChatSideMovie(
         <li>Model: {props.header.model}</li>
         <li>Locale: {props.header.locale}</li>
         <li>Timezone: {props.header.timezone}</li>
+        <li>Sempahore: {props.header.vendor.semaphore ?? 16}</li>
       </ul>
       <br />
       <br />

--- a/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatSideMovie.tsx
+++ b/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatSideMovie.tsx
@@ -28,7 +28,7 @@ export function AutoBePlaygroundChatSideMovie(
         <li>Model: {props.header.model}</li>
         <li>Locale: {props.header.locale}</li>
         <li>Timezone: {props.header.timezone}</li>
-        <li>Sempahore: {props.header.vendor.semaphore ?? 16}</li>
+        <li>Semaphore: {props.header.vendor.semaphore ?? 16}</li>
       </ul>
       <br />
       <br />

--- a/packages/playground-ui/src/movies/configure/AutoBePlaygroundConfigureMovie.tsx
+++ b/packages/playground-ui/src/movies/configure/AutoBePlaygroundConfigureMovie.tsx
@@ -34,6 +34,7 @@ export function AutoBePlaygroundConfigureMovie(
   const [vendorConfig, setVendorConfig] = useState<IAutoBeRpcVendor>({
     model: "gpt-4.1",
     apiKey: "",
+    semaphore: 16,
   });
 
   const [progress, setProgress] = useState(false);

--- a/packages/playground-ui/src/movies/configure/AutoBePlaygroundConfigureVendorMovie.tsx
+++ b/packages/playground-ui/src/movies/configure/AutoBePlaygroundConfigureVendorMovie.tsx
@@ -10,6 +10,9 @@ export function AutoBePlaygroundConfigureVendorMovie(
   const [apiKey, setApiKey] = useState<string>(props.config.apiKey);
   const [model, setModel] = useState<string>(props.config.model);
   const [baseURL, setBaseURL] = useState<string>(props.config.baseURL ?? "");
+  const [semaphore, setSemaphore] = useState<number>(
+    props.config.semaphore ?? 16,
+  );
 
   const handleApiKey = (value: string) => {
     setApiKey(value);
@@ -33,6 +36,15 @@ export function AutoBePlaygroundConfigureVendorMovie(
       model,
       apiKey,
       baseURL: value.length !== 0 ? value : undefined,
+    });
+  };
+  const handleSemaphore = (value: number) => {
+    setSemaphore(value);
+    props.onChange({
+      model,
+      apiKey,
+      baseURL,
+      semaphore: value,
     });
   };
 
@@ -67,6 +79,14 @@ export function AutoBePlaygroundConfigureVendorMovie(
             baseURL || "http://localhost:8000",
           ) === false
         }
+      />
+      <br />
+      <TextField
+        type="number"
+        label="Semaphore"
+        defaultValue={semaphore}
+        fullWidth
+        onChange={(e) => handleSemaphore(Number(e.target.value))}
       />
     </>
   );


### PR DESCRIPTION
This pull request introduces a new `semaphore` property to the `IAutoBeRpcVendor` interface and integrates it across the application to manage the concurrency level for API requests. The changes ensure that the `semaphore` value is configurable, displayed in the UI, and passed correctly through the system.

### Addition of the `semaphore` property:

* **`IAutoBeRpcVendor` interface**: Added the `semaphore` property to specify the maximum number of concurrent API requests. Includes detailed documentation and a default value of 16. (`packages/interface/src/rpc/IAutoBeRpcVendor.ts`, [packages/interface/src/rpc/IAutoBeRpcVendor.tsR60-R80](diffhunk://#diff-e05ebd6a22410f2b4f0ffe66e4dbf532fa046360706ed8b92c493a09b9158e56R60-R80))

### Backend integration:

* **Server configuration**: Updated the `server.ts` file to pass the `semaphore` value from the vendor configuration to the backend logic. (`packages/playground-server/src/executable/server.ts`, [packages/playground-server/src/executable/server.tsR33](diffhunk://#diff-0263cbd38ddf92331a96ca21d77cd5829c8a49aa33c595d7cea3fb667eb217cbR33))

### Frontend updates:

* **Display in the UI**: Modified the `AutoBePlaygroundChatSideMovie` component to display the `semaphore` value in the UI, defaulting to 16 if undefined. (`packages/playground-ui/src/movies/chat/AutoBePlaygroundChatSideMovie.tsx`, [packages/playground-ui/src/movies/chat/AutoBePlaygroundChatSideMovie.tsxR31](diffhunk://#diff-6a32d02210cfccfa0a27443d6e7b61c688e16743a8c65001e8a7cb96f424b010R31))
* **Default configuration**: Updated the `AutoBePlaygroundConfigureMovie` component to initialize the `semaphore` value to 16 in the vendor configuration. (`packages/playground-ui/src/movies/configure/AutoBePlaygroundConfigureMovie.tsx`, [packages/playground-ui/src/movies/configure/AutoBePlaygroundConfigureMovie.tsxR37](diffhunk://#diff-a9ba7e8a51ba1154ede41b32734e39567385da941fc3c50c2eef10b0b897d435R37))
* **Vendor configuration UI**: Enhanced the `AutoBePlaygroundConfigureVendorMovie` component to allow users to set the `semaphore` value through a new input field, with appropriate state management and change handling. (`packages/playground-ui/src/movies/configure/AutoBePlaygroundConfigureVendorMovie.tsx`, [[1]](diffhunk://#diff-82cafca8e389a7c675e3ffa9ca9b2c3a979cb390437adefecf1cda7546438b6dR13-R15) [[2]](diffhunk://#diff-82cafca8e389a7c675e3ffa9ca9b2c3a979cb390437adefecf1cda7546438b6dR41-R49) [[3]](diffhunk://#diff-82cafca8e389a7c675e3ffa9ca9b2c3a979cb390437adefecf1cda7546438b6dR83-R90)