### PR TITLE
fix(agent): emit interfaceStart event on orchestrateInterface

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
@@ -22,6 +22,13 @@ export const orchestrateInterface =
   ): Promise<AutoBeAssistantMessageHistory | AutoBeInterfaceHistory> => {
     // ENDPOINTS
     const start: Date = new Date();
+    ctx.dispatch({
+      type: "interfaceStart",
+      created_at: start.toISOString(),
+      reason: props.reason,
+      step: ctx.state().analyze?.step ?? 0,
+    });
+
     const init: AutoBeAssistantMessageHistory | AutoBeInterfaceEndpointsEvent =
       await orchestrateInterfaceEndpoints(ctx);
     if (init.type === "assistantMessage") {


### PR DESCRIPTION
This pull request introduces a small but important change to the `orchestrateInterface` function in `orchestrateInterface.ts`. It adds a new dispatch event to log the start of an interface operation with relevant metadata, such as the timestamp, reason, and current step.

* [`packages/agent/src/orchestrate/interface/orchestrateInterface.ts`](diffhunk://#diff-9011b0c160648b4ccca5ed6c13b2bff42bfd46562d883e13b90885f3e3dcd84eR25-R31): Added a `ctx.dispatch` call to log the start of the interface operation, capturing the event type, creation timestamp, reason, and step from the current state.