### PR TITLE
fix: use external tokenUsage

### DIFF
--- a/packages/agent/src/AutoBeAgent.ts
+++ b/packages/agent/src/AutoBeAgent.ts
@@ -124,6 +124,7 @@ export class AutoBeAgent<Model extends ILlmSchema.Model> {
           execute: () => transformFacadeStateMessage(this.state_),
         },
       },
+      tokenUsage: props.tokenUsage,
       controllers: [
         createAutoBeController({
           model: props.model,


### PR DESCRIPTION
This pull request makes a small addition to the `AutoBeAgent` class in `packages/agent/src/AutoBeAgent.ts`. It introduces a new `tokenUsage` property to the `AutoBeAgent` configuration.

* [`packages/agent/src/AutoBeAgent.ts`](diffhunk://#diff-eb5845bde058399222e7eb37fcc40ccd00bee27a5d2531830decea25dc197e73R127): Added `tokenUsage` to the `AutoBeAgent` class to allow tracking or configuration related to token usage.