### PR TITLE
fix(agent): Correct typo in pagination information description

### DIFF
--- a/packages/agent/prompts/INTERFACE_SCHEMA.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA.md
@@ -70,7 +70,7 @@ For paginated results, use the standard `IPage<T>` interface:
 /**
  * A page.
  *
- * Collection of records with pagination indformation.
+ * Collection of records with pagination information.
  *
  * @author Samchon
  */


### PR DESCRIPTION
Corrected typos in the agent prompt.