### PR TITLE
rename: 'root' to 'facade'

### DIFF
--- a/packages/agent/src/AutoBeAgent.ts
+++ b/packages/agent/src/AutoBeAgent.ts
@@ -132,7 +132,7 @@ export class AutoBeAgent<Model extends ILlmSchema.Model> {
           execute: () => transformFacadeStateMessage(this.state_),
         },
       },
-      tokenUsage: props.tokenUsage?.root,
+      tokenUsage: props.tokenUsage?.facade,
       controllers: [
         createAutoBeController({
           model: props.model,

--- a/packages/agent/src/context/AutoBeTokenUsage.ts
+++ b/packages/agent/src/context/AutoBeTokenUsage.ts
@@ -7,7 +7,7 @@ import {
 import { IAutoBeApplication } from "./IAutoBeApplication";
 
 export class AutoBeTokenUsage {
-  public readonly root: AgenticaTokenUsage;
+  public readonly facade: AgenticaTokenUsage;
   public readonly analyze: AgenticaTokenUsage;
   public readonly prisma: AgenticaTokenUsage;
   public readonly interface: AgenticaTokenUsage;
@@ -16,7 +16,7 @@ export class AutoBeTokenUsage {
 
   public constructor(props?: IAutoBeTokenUsageJson) {
     if (props === undefined) {
-      this.root = new AgenticaTokenUsage();
+      this.facade = new AgenticaTokenUsage();
       this.analyze = new AgenticaTokenUsage();
       this.prisma = new AgenticaTokenUsage();
       this.interface = new AgenticaTokenUsage();
@@ -25,7 +25,7 @@ export class AutoBeTokenUsage {
       return;
     }
 
-    this.root = new AgenticaTokenUsage(props.root);
+    this.facade = new AgenticaTokenUsage(props.facade);
     this.analyze = new AgenticaTokenUsage(props.analyze);
     this.prisma = new AgenticaTokenUsage(props.prisma);
     this.interface = new AgenticaTokenUsage(props.interface);
@@ -37,7 +37,7 @@ export class AutoBeTokenUsage {
     usage: AgenticaTokenUsage,
     additionalStages: (keyof IAutoBeApplication)[] = [],
   ) {
-    this.root.increment(usage);
+    this.facade.increment(usage);
     additionalStages.forEach((stage) => {
       this[stage].increment(usage);
     });
@@ -52,7 +52,7 @@ export class AutoBeTokenUsage {
 
   public static plus(usageA: AutoBeTokenUsage, usageB: AutoBeTokenUsage) {
     return new AutoBeTokenUsage({
-      root: AgenticaTokenUsage.plus(usageA.root, usageB.root),
+      facade: AgenticaTokenUsage.plus(usageA.facade, usageB.facade),
       analyze: AgenticaTokenUsage.plus(usageA.analyze, usageB.analyze),
       prisma: AgenticaTokenUsage.plus(usageA.prisma, usageB.prisma),
       interface: AgenticaTokenUsage.plus(usageA.interface, usageB.interface),
@@ -63,7 +63,7 @@ export class AutoBeTokenUsage {
 
   public toJSON(): IAutoBeTokenUsageJson {
     return {
-      root: this.root.toJSON(),
+      facade: this.facade.toJSON(),
       analyze: this.analyze.toJSON(),
       prisma: this.prisma.toJSON(),
       interface: this.interface.toJSON(),
@@ -73,18 +73,18 @@ export class AutoBeTokenUsage {
   }
 
   /** @internal */
-  private static keys(): ("root" | keyof IAutoBeApplication)[] {
-    return ["root", "analyze", "prisma", "interface", "test", "realize"];
+  private static keys(): ("facade" | keyof IAutoBeApplication)[] {
+    return ["facade", "analyze", "prisma", "interface", "test", "realize"];
   }
 }
 
 /** Type check statements */
 1 as unknown as AutoBeTokenUsage satisfies {
-  [key in "root" | keyof IAutoBeApplication]: AgenticaTokenUsage;
+  [key in "facade" | keyof IAutoBeApplication]: AgenticaTokenUsage;
 };
 
 1 as unknown as IAutoBeTokenUsageJson satisfies {
-  [key in "root" | keyof IAutoBeApplication]: IAutoBeInternalTokenUsageJson;
+  [key in "facade" | keyof IAutoBeApplication]: IAutoBeInternalTokenUsageJson;
 };
 
 1 as unknown as IAutoBeInternalTokenUsageJson satisfies IAgenticaTokenUsageJson;

--- a/packages/interface/src/json/IAutoBeTokenUsageJson.ts
+++ b/packages/interface/src/json/IAutoBeTokenUsageJson.ts
@@ -26,7 +26,7 @@ export interface IAutoBeTokenUsageJson {
    * development pipeline. This aggregate view enables overall cost assessment
    * and resource utilization analysis for complete project automation.
    */
-  root: IAutoBeInternalTokenUsageJson;
+  facade: IAutoBeInternalTokenUsageJson;
 
   /** Token usage for the analysis phase */
   analyze: IAutoBeInternalTokenUsageJson;

--- a/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatTokenUsageMovie.tsx
+++ b/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatTokenUsageMovie.tsx
@@ -27,25 +27,25 @@ export function AutoBePlaygroundChatTokenUsageMovie(
           <TableRow>
             <TableCell>Total</TableCell>
             <TableCell>
-              {props.tokenUsage.root.aggregate.total.toLocaleString()}
+              {props.tokenUsage.facade.aggregate.total.toLocaleString()}
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Input</TableCell>
             <TableCell>
-              {props.tokenUsage.root.aggregate.input.total.toLocaleString()}
+              {props.tokenUsage.facade.aggregate.input.total.toLocaleString()}
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Input (Cached)</TableCell>
             <TableCell>
-              {props.tokenUsage.root.aggregate.input.cached.toLocaleString()}
+              {props.tokenUsage.facade.aggregate.input.cached.toLocaleString()}
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Output</TableCell>
             <TableCell>
-              {props.tokenUsage.root.aggregate.output.total.toLocaleString()}
+              {props.tokenUsage.facade.aggregate.output.total.toLocaleString()}
             </TableCell>
           </TableRow>
         </TableBody>

--- a/test/src/benchmarks/report.ts
+++ b/test/src/benchmarks/report.ts
@@ -55,7 +55,7 @@ ${(["analyze", "prisma", "interface"] as const)
 - Total Token Usage
 ${(
   [
-    ["Total", "root"],
+    ["Total", "facade"],
     ["Analyze", "analyze"],
     ["Prisma", "prisma"],
     ["Interface", "interface"],

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -120,9 +120,9 @@ async function main(): Promise<void> {
 
   console.log("Token Usage");
   console.table({
-    Total: tokenUsage.root.aggregate.total.toLocaleString("en-US"),
-    Input: tokenUsage.root.aggregate.input.total.toLocaleString("en-US"),
-    Output: tokenUsage.root.aggregate.output.total.toLocaleString("en-US"),
+    Total: tokenUsage.facade.aggregate.total.toLocaleString("en-US"),
+    Input: tokenUsage.facade.aggregate.input.total.toLocaleString("en-US"),
+    Output: tokenUsage.facade.aggregate.output.total.toLocaleString("en-US"),
     Analyze: tokenUsage.analyze.aggregate.total.toLocaleString("en-US"),
     Prisma: tokenUsage.prisma.aggregate.total.toLocaleString("en-US"),
     Interface: tokenUsage.interface.aggregate.total.toLocaleString("en-US"),


### PR DESCRIPTION
This pull request introduces a significant refactor of the `AutoBeTokenUsage` class and its related components, replacing the `root` token usage property with `facade` throughout the codebase. This change enhances clarity and aligns the terminology with the intended functionality. The updates span multiple files, ensuring consistency across the application.

### Refactor of `AutoBeTokenUsage`:

* Replaced the `root` property with `facade` in the `AutoBeTokenUsage` class, affecting its constructor, methods, and serialization logic (`packages/agent/src/context/AutoBeTokenUsage.ts`). [[1]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971L10-R10) [[2]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971L19-R19) [[3]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971L28-R28) [[4]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971L40-R40) [[5]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971L55-R55) [[6]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971L66-R66) [[7]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971L76-R87)

### Updates to Interfaces and JSON Structures:

* Updated the `IAutoBeTokenUsageJson` interface to use `facade` instead of `root` for token usage representation (`packages/interface/src/json/IAutoBeTokenUsageJson.ts`).

### Adjustments in Application Logic:

* Modified the `AutoBeAgent` class to reference `facade` instead of `root` for token usage (`packages/agent/src/AutoBeAgent.ts`).

### UI and Reporting Changes:

* Updated the `AutoBePlaygroundChatTokenUsageMovie` component to display `facade` token usage in the UI (`packages/playground-ui/src/movies/chat/AutoBePlaygroundChatTokenUsageMovie.tsx`).
* Adjusted test and benchmark reporting to reflect the `facade` terminology (`test/src/benchmarks/report.ts`, `test/src/index.ts`). [[1]](diffhunk://#diff-f67fcfa1ea68fa775bee089a49e2b656f86ffb38f9f829540162d393de58d89dL58-R58) [[2]](diffhunk://#diff-ecfaaff51b5918af495fc6567267f0209e361d75365794b43290a19884354d09L123-R125)