### PR TITLE
feat(agent): bump up dependencies for `JSON.parse()` error feedback r…

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,25 +7,25 @@ settings:
 catalogs:
   agentica:
     '@agentica/core':
-      specifier: ^0.29.2
-      version: 0.29.2
+      specifier: ^0.30.1
+      version: 0.30.1
   libs:
     openai:
       specifier: ^5.2.0
       version: 5.2.0
   samchon:
     '@nestia/core':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.0.1
+      version: 7.0.1
     '@nestia/e2e':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.0.1
+      version: 7.0.1
     '@nestia/migrate':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.0.1
+      version: 7.0.1
     '@samchon/openapi':
-      specifier: ^4.3.3
-      version: 4.3.3
+      specifier: ^4.4.1
+      version: 4.4.1
     embed-prisma:
       specifier: ^1.1.0
       version: 1.1.0
@@ -42,8 +42,8 @@ catalogs:
       specifier: ^3.0.0
       version: 3.0.0
     typia:
-      specifier: ^9.3.1
-      version: 9.3.1
+      specifier: ^9.4.0
+      version: 9.4.0
   typescript:
     ts-node:
       specifier: ^10.9.2
@@ -82,7 +82,7 @@ importers:
     dependencies:
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.3.3
+        version: 4.4.1
       tstl:
         specifier: catalog:samchon
         version: 3.0.0
@@ -113,13 +113,13 @@ importers:
         version: link:../../packages/rpc
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.0.0(@nestia/fetcher@7.0.0(@samchon/openapi@4.3.3)(typia@9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
+        version: 7.0.1(@nestia/fetcher@7.0.0(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
       '@nestia/e2e':
         specifier: catalog:samchon
-        version: 7.0.0
+        version: 7.0.1
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.0.0
+        version: 7.0.1
       '@nestjs/common':
         specifier: ^11.1.3
         version: 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -128,7 +128,7 @@ importers:
         version: 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.3.3
+        version: 4.4.1
       openai:
         specifier: catalog:libs
         version: 5.2.0(zod@3.25.57)
@@ -137,7 +137,7 @@ importers:
         version: 1.1.0
       typia:
         specifier: catalog:samchon
-        version: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
     devDependencies:
       '@types/node':
         specifier: ^22.15.17
@@ -153,7 +153,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.29.2(@samchon/openapi@4.3.3)(openai@5.2.0(zod@3.25.57))(typia@9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3))
+        version: 0.30.1(@samchon/openapi@4.4.1)(openai@5.2.0(zod@3.25.57))(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))
       '@autobe/interface':
         specifier: workspace:^
         version: link:../interface
@@ -165,7 +165,7 @@ importers:
         version: 6.1.0(rollup@4.41.0)
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.3.3
+        version: 4.4.1
       '@types/node':
         specifier: ^22.15.18
         version: 22.15.19
@@ -180,7 +180,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -223,13 +223,13 @@ importers:
         version: link:../interface
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.0.0(@nestia/fetcher@7.0.0(@samchon/openapi@4.3.3)(typia@9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
+        version: 7.0.1(@nestia/fetcher@7.0.0(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.0.0
+        version: 7.0.1
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.3.3
+        version: 4.4.1
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.2
         version: 5.2.2(prettier@3.5.3)
@@ -256,7 +256,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
     devDependencies:
       '@autobe/filesystem':
         specifier: workspace:^
@@ -284,10 +284,10 @@ importers:
     dependencies:
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.3.3
+        version: 4.4.1
       typia:
         specifier: catalog:samchon
-        version: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -312,7 +312,7 @@ importers:
         version: link:../rpc
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.3.3
+        version: 4.4.1
       openai:
         specifier: catalog:libs
         version: 5.2.0(zod@3.25.57)
@@ -324,7 +324,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -355,7 +355,7 @@ importers:
         version: 7.1.0(@emotion/react@11.14.0(@types/react@19.1.5)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.5)(react@19.1.0))(@types/react@19.1.5)(react@19.1.0))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.3.3
+        version: 4.4.1
       '@stackblitz/sdk':
         specifier: ^1.11.0
         version: 1.11.0
@@ -434,10 +434,10 @@ importers:
         version: link:../interface
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.3.3
+        version: 4.4.1
       typia:
         specifier: catalog:samchon
-        version: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -465,16 +465,16 @@ importers:
         version: link:../packages/interface
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.0.0(@nestia/fetcher@7.0.0(@samchon/openapi@4.3.3)(typia@9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
+        version: 7.0.1(@nestia/fetcher@7.0.0(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
       '@nestia/e2e':
         specifier: catalog:samchon
-        version: 7.0.0
+        version: 7.0.1
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.0.0
+        version: 7.0.1
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.3.3
+        version: 4.4.1
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -489,7 +489,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -564,12 +564,12 @@ importers:
 
 packages:
 
-  '@agentica/core@0.29.2':
-    resolution: {integrity: sha512-FgGyQEQoFB4SSDscZS6EmpmnjsPyevXstgQKlXB6sZxk9Cw3MCX9yw/XEF5TTGIB3UtOO36tePTkLJ/3dEpdvg==}
+  '@agentica/core@0.30.1':
+    resolution: {integrity: sha512-cZnOHU69P/fuDVV04Kg5Y6B82apy6AK+CT7b5iPnA0eTcL6THMaybfAnXyb06tykuIMaoqomX7GOGBG460px9Q==}
     peerDependencies:
-      '@samchon/openapi': ^4.3.3
+      '@samchon/openapi': ^4.4.1
       openai: ^5.2.0
-      typia: ^9.3.1
+      typia: ^9.4.0
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1280,17 +1280,17 @@ packages:
     resolution: {integrity: sha512-jMxvwzkKzd3cXo2EB9GM2ic0eYo2rP/BS6gJt6HnWbsDO1O8GSD4k7o2Cpr2YERtMpGF/MGcDfsfj2EbQPtrXw==}
     engines: {node: '>= 10'}
 
-  '@nestia/core@7.0.0':
-    resolution: {integrity: sha512-gwf7oti9QCcRsvAkC2vDb5zaVfj5VIbTkvGxxGM1WXuxTxrTfBZ6A2Qs19AUtlfqgZKN3/u6v2aidQnoEpkDAw==}
+  '@nestia/core@7.0.1':
+    resolution: {integrity: sha512-7c2Sud23G+7dqmzqh0pScaPu1i5+2itOIUkfBnfnRSJZ46p8f2BvHg50cfWXAiV/YSzqgGzpIy+pWMv6GkZDxw==}
     peerDependencies:
-      '@nestia/fetcher': '>=7.0.0'
+      '@nestia/fetcher': '>=7.0.1'
       '@nestjs/common': '>=7.0.1'
       '@nestjs/core': '>=7.0.1'
       reflect-metadata: '>=0.1.12'
       rxjs: '>=6.0.3'
 
-  '@nestia/e2e@7.0.0':
-    resolution: {integrity: sha512-Bdf/Zo/9ikgIfii/tPkqyd6tSTuwFRn9lj8Q+9hDk9G5/HNsytnQlRz4kQlMYsiGdpcvBH/LkPGUAMyIu8XtVQ==}
+  '@nestia/e2e@7.0.1':
+    resolution: {integrity: sha512-J8IEQWtnQSI5cAM/YJHfuKQfoyJUkKb1zkRUNIKkM63B7iMq9+6+bD8OCIFBtjj0OLvA5Z6P3e5LNF0cfB4iCA==}
 
   '@nestia/fetcher@7.0.0':
     resolution: {integrity: sha512-CBCOV6C3D5usEVRYREbfQA73AchoQch7KrTrbGwq2cmGnGGFdZveFJNDdtwPXuAl6ZLp3iComS7NA7TQc8yF1w==}
@@ -1298,8 +1298,8 @@ packages:
       '@samchon/openapi': '>=4.3.3 <5.0.0'
       typia: '>=9.3.1 <10.0.0'
 
-  '@nestia/migrate@7.0.0':
-    resolution: {integrity: sha512-/y5FCbFHHe0cRmdXfiXi9SISfzw0JxPZd/wER34hqYv+AcKDKE2gVv2yX5H3JZnlyaaTpHeEJKBKlEFrDf7IEg==}
+  '@nestia/migrate@7.0.1':
+    resolution: {integrity: sha512-nm1XI518/o4v4EA0LxHsCsS85iBUBVRCVx5L3aJLA3qsUNZpkz9fFDI2PI9ltC7o2j/ronIjQfp4y0zg8wkBRQ==}
     hasBin: true
 
   '@nestjs/common@11.1.3':
@@ -1690,8 +1690,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@samchon/openapi@4.3.3':
-    resolution: {integrity: sha512-jCyp1YZsFBIWXjHBfjYGlRXTGf5h5jrvGiAhKFI4Yxs8wg4YoVHMaDeC2AWcpo4L9KYVQ2uuePMM56g0jzK8sA==}
+  '@samchon/openapi@4.4.1':
+    resolution: {integrity: sha512-RMcHrR1Atw9XUhgMh1EAt81ZBnMXiOIEET7aGpW3c4PVUqJyCm8F5yFjWIp81yicGn5IgzkrOz68F4sSeAitew==}
 
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
@@ -4579,11 +4579,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typia@9.3.1:
-    resolution: {integrity: sha512-a3rqaWE3j5ynK3nmBPEMngLfVP7FH3OrgC4xO4A4QQdcgdVL/nxTxdEqYuEjRCdcOgZCIqOt3CNoQaorOITArg==}
+  typia@9.4.0:
+    resolution: {integrity: sha512-LfnK5xYvTJxBzAK40uU4TlE/1hRZAqGWWTivSYraGIDZAu4BJbPxNjtfzUIV71P30Le8ZpXMyYWbzHoBbApghQ==}
     hasBin: true
     peerDependencies:
-      '@samchon/openapi': '>=4.3.1 <5.0.0'
+      '@samchon/openapi': '>=4.4.1 <5.0.0'
       typescript: '>=4.8.0 <5.9.0'
 
   uc.micro@2.1.0:
@@ -4879,12 +4879,12 @@ packages:
 
 snapshots:
 
-  '@agentica/core@0.29.2(@samchon/openapi@4.3.3)(openai@5.2.0(zod@3.25.57))(typia@9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3))':
+  '@agentica/core@0.30.1(@samchon/openapi@4.4.1)(openai@5.2.0(zod@3.25.57))(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))':
     dependencies:
-      '@samchon/openapi': 4.3.3
+      '@samchon/openapi': 4.4.1
       openai: 5.2.0(zod@3.25.57)
       tstl: 3.0.0
-      typia: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
       uuid: 11.1.0
 
   '@ampproject/remapping@2.3.0':
@@ -5564,12 +5564,12 @@ snapshots:
       '@napi-rs/simple-git-win32-arm64-msvc': 0.1.19
       '@napi-rs/simple-git-win32-x64-msvc': 0.1.19
 
-  '@nestia/core@7.0.0(@nestia/fetcher@7.0.0(@samchon/openapi@4.3.3)(typia@9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)':
+  '@nestia/core@7.0.1(@nestia/fetcher@7.0.0(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)':
     dependencies:
-      '@nestia/fetcher': 7.0.0(@samchon/openapi@4.3.3)(typia@9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3))
+      '@nestia/fetcher': 7.0.0(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))
       '@nestjs/common': 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@samchon/openapi': 4.3.3
+      '@samchon/openapi': 4.4.1
       detect-ts-node: 1.0.5
       get-function-location: 2.0.0
       glob: 7.2.3
@@ -5578,30 +5578,30 @@ snapshots:
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tgrid: 1.1.0
-      typia: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
 
-  '@nestia/e2e@7.0.0': {}
+  '@nestia/e2e@7.0.1': {}
 
-  '@nestia/fetcher@7.0.0(@samchon/openapi@4.3.3)(typia@9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3))':
+  '@nestia/fetcher@7.0.0(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))':
     dependencies:
-      '@samchon/openapi': 4.3.3
-      typia: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+      '@samchon/openapi': 4.4.1
+      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
 
-  '@nestia/migrate@7.0.0':
+  '@nestia/migrate@7.0.1':
     dependencies:
-      '@samchon/openapi': 4.3.3
+      '@samchon/openapi': 4.4.1
       commander: 10.0.0
       inquirer: 8.2.5
       prettier: 3.5.3
       prettier-plugin-jsdoc: 1.3.2(prettier@3.5.3)
       tstl: 3.0.0
       typescript: 5.8.3
-      typia: 9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3)
+      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5959,7 +5959,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.41.0':
     optional: true
 
-  '@samchon/openapi@4.3.3': {}
+  '@samchon/openapi@4.4.1': {}
 
   '@shikijs/core@2.5.0':
     dependencies:
@@ -9685,9 +9685,9 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typia@9.3.1(@samchon/openapi@4.3.3)(typescript@5.8.3):
+  typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3):
     dependencies:
-      '@samchon/openapi': 4.3.3
+      '@samchon/openapi': 4.4.1
       '@standard-schema/spec': 1.0.0
       commander: 10.0.0
       comment-json: 4.2.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,23 +7,23 @@ packages:
   - website
 catalogs:
   agentica:
-    "@agentica/core": ^0.29.2
-    "@agentica/rpc": ^0.29.2
+    "@agentica/core": ^0.30.1
+    "@agentica/rpc": ^0.30.1
   samchon:
-    "@nestia/benchmark": ^7.0.0
-    "@nestia/core": ^7.0.0
-    "@nestia/e2e": ^7.0.0
-    "@nestia/editor": ^7.0.0
-    "@nestia/fetcher": ^7.0.0
-    "@nestia/migrate": ^7.0.0
-    "@nestia/sdk": ^7.0.0
-    "@samchon/openapi": ^4.3.3
+    "@nestia/benchmark": ^7.0.1
+    "@nestia/core": ^7.0.1
+    "@nestia/e2e": ^7.0.1
+    "@nestia/editor": ^7.0.1
+    "@nestia/fetcher": ^7.0.1
+    "@nestia/migrate": ^7.0.1
+    "@nestia/sdk": ^7.0.1
+    "@samchon/openapi": ^4.4.1
     embed-prisma: ^1.1.0
     embed-typescript: ^1.0.1
     prisma-markdown: ^3.0.0
     tgrid: ^1.1.0
     tstl: ^3.0.0
-    typia: ^9.3.1
+    typia: ^9.4.0
   typescript:
     ts-node: ^10.9.2
     ts-patch: ^3.3.0


### PR DESCRIPTION
This pull request updates several dependencies in `pnpm-lock.yaml` and `pnpm-workspace.yaml` to newer versions. The changes primarily involve upgrading packages across multiple catalogs, ensuring compatibility and improvements. These updates affect both direct dependencies and their transitive peer dependencies.

### Dependency Updates:

#### Agentica Catalog:
* Updated `@agentica/core` and `@agentica/rpc` from version `0.29.2` to `0.30.1`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R28) [[2]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL10-R26)

#### Samchon Catalog:
* Updated `@samchon/openapi` from version `4.3.3` to `4.4.1`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL85-R85) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL131-R131) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL168-R168) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL315-R315) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL358-R358) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL567-R572) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1693-R1694) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5962-R5962)
* Updated `typia` from version `9.3.1` to `9.4.0`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL45-R46) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL140-R140) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL327-R327) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4582-R4586) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9688-R9690)
* Updated `@nestia/core`, `@nestia/e2e`, `@nestia/migrate`, and other related packages from version `7.0.0` to `7.0.1`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL116-R122) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL226-R232) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL468-R477) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1283-R1302) [[5]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL10-R26)

#### Transitive Peer Dependencies:
* Adjusted peer dependencies to align with the updated versions. For example, `@samchon/openapi` is now compatible with `>=4.4.1 <5.0.0`, and `typia` aligns with `>=9.4.0`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL567-R572) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4582-R4586) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9688-R9690)

These updates improve dependency compatibility and ensure the project remains up-to-date with the latest versions.…eason.