### PR TITLE
fix(agent): bug of function-calling validate-feedback

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   agentica:
     '@agentica/core':
-      specifier: ^0.30.1
-      version: 0.30.1
+      specifier: ^0.30.2
+      version: 0.30.2
   libs:
     openai:
       specifier: ^5.2.0
@@ -153,7 +153,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.30.1(@samchon/openapi@4.4.1)(openai@5.2.0(zod@3.25.57))(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))
+        version: 0.30.2(@samchon/openapi@4.4.1)(openai@5.2.0(zod@3.25.57))(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))
       '@autobe/interface':
         specifier: workspace:^
         version: link:../interface
@@ -564,8 +564,8 @@ importers:
 
 packages:
 
-  '@agentica/core@0.30.1':
-    resolution: {integrity: sha512-cZnOHU69P/fuDVV04Kg5Y6B82apy6AK+CT7b5iPnA0eTcL6THMaybfAnXyb06tykuIMaoqomX7GOGBG460px9Q==}
+  '@agentica/core@0.30.2':
+    resolution: {integrity: sha512-lOaiIaYgnVibipI2IiOldDtWuOBW/PovyDbNvs4KuZRnqDeQ3/kUjwNX+JIuSrOU8JZ6bYLwHjWAdq4ZvZEjSA==}
     peerDependencies:
       '@samchon/openapi': ^4.4.1
       openai: ^5.2.0
@@ -4879,7 +4879,7 @@ packages:
 
 snapshots:
 
-  '@agentica/core@0.30.1(@samchon/openapi@4.4.1)(openai@5.2.0(zod@3.25.57))(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))':
+  '@agentica/core@0.30.2(@samchon/openapi@4.4.1)(openai@5.2.0(zod@3.25.57))(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))':
     dependencies:
       '@samchon/openapi': 4.4.1
       openai: 5.2.0(zod@3.25.57)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,8 @@ packages:
   - website
 catalogs:
   agentica:
-    "@agentica/core": ^0.30.1
-    "@agentica/rpc": ^0.30.1
+    "@agentica/core": ^0.30.2
+    "@agentica/rpc": ^0.30.2
   samchon:
     "@nestia/benchmark": ^7.0.1
     "@nestia/core": ^7.0.1


### PR DESCRIPTION
This pull request updates the `@agentica/core` and `@agentica/rpc` dependencies to version `0.30.2` across the project configuration files. These changes ensure compatibility with the latest features and improvements of the `agentica` libraries.

Dependency version updates:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R11): Updated `@agentica/core` dependency from `0.30.1` to `0.30.2` in multiple sections, including `settings`, `importers`, `packages`, and `snapshots`. This includes updating the integrity hash for the new version. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R11) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL156-R156) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL567-R568) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4882-R4882)
* [`pnpm-workspace.yaml`](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL10-R11): Updated both `@agentica/core` and `@agentica/rpc` dependencies from `0.30.1` to `0.30.2` under the `catalogs` section.