### PR TITLE
feat(agent): change JSON schema title generation rule for JSDoc comments

### DIFF
--- a/internals/nestjs-dependencies/package-lock.json
+++ b/internals/nestjs-dependencies/package-lock.json
@@ -9,19 +9,19 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@nestia/benchmark": "^7.0.3",
-        "@nestia/core": "^7.0.3",
-        "@nestia/e2e": "^7.0.3",
-        "@nestia/editor": "^7.0.3",
-        "@nestia/fetcher": "^7.0.3",
-        "@nestia/sdk": "^7.0.3",
+        "@nestia/benchmark": "^7.1.0",
+        "@nestia/core": "^7.1.0",
+        "@nestia/e2e": "^7.1.0",
+        "@nestia/editor": "^7.1.0",
+        "@nestia/fetcher": "^7.1.0",
+        "@nestia/sdk": "^7.1.0",
         "@nestjs/common": "^11.1.0",
         "@nestjs/core": "^11.1.0",
         "@nestjs/platform-express": "^11.1.0",
         "@nestjs/platform-fastify": "^11.1.0",
         "@nestjs/swagger": "^11.1.5",
         "@prisma/client": "^6.6.0",
-        "@samchon/openapi": "^4.4.1",
+        "@samchon/openapi": "^4.5.0",
         "@types/express": "^5.0.1",
         "@types/inquirer": "^9.0.7",
         "@types/jsonwebtoken": "^9.0.9",
@@ -37,7 +37,7 @@
         "serialize-error": "^4.1.0",
         "tgrid": "^1.1.0",
         "typescript": "~5.8.3",
-        "typia": "^9.4.0"
+        "typia": "^9.5.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -852,28 +852,28 @@
       }
     },
     "node_modules/@nestia/benchmark": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@nestia/benchmark/-/benchmark-7.0.3.tgz",
-      "integrity": "sha512-HQaa5R1DRbWEk9PZ+75T8daWqM0/hMmGTFM1kCC/+FDTuW54LnUANtCLZ8W2L2f1vwlUqlEXDnEUY6OnnZ/JiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nestia/benchmark/-/benchmark-7.1.0.tgz",
+      "integrity": "sha512-0SlP+T+NjcKmc5Rg3fCzny1OlnVIz6NTuQPSHoE9KdLJbywV0fijzxAtBgx/GbQlj5ByBEJYg9KdKGTsNpu1FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nestia/fetcher": "^7.0.3",
+        "@nestia/fetcher": "^7.1.0",
         "tgrid": "^1.1.0",
         "tstl": "^3.0.0"
       }
     },
     "node_modules/@nestia/core": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@nestia/core/-/core-7.0.3.tgz",
-      "integrity": "sha512-AvQPsLjWQkdpdBkpa/+3OMio0ABYxVgxULzxwsQ4a3B4Dd4np9XKqPoEfKsMVaK46JYyq3laLYPr+u7ZU4Di9w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nestia/core/-/core-7.1.0.tgz",
+      "integrity": "sha512-vWT0gDuxgGDd9okAlc5SdSEfFuZih55ompZZc7WgIfWdTBDEaxk8gPW76pu2egZFGYQ70Dg8d3WpwMRmSF1A0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nestia/fetcher": "^7.0.3",
+        "@nestia/fetcher": "^7.1.0",
         "@nestjs/common": ">=7.0.1",
         "@nestjs/core": ">=7.0.1",
-        "@samchon/openapi": "^4.3.3",
+        "@samchon/openapi": "^4.5.0",
         "detect-ts-node": "^1.0.5",
         "get-function-location": "^2.0.0",
         "glob": "^7.2.0",
@@ -882,143 +882,85 @@
         "reflect-metadata": ">=0.1.12",
         "rxjs": ">=6.0.3",
         "tgrid": "^1.1.0",
-        "typia": "^9.3.1",
+        "typia": "^9.5.0",
         "ws": "^7.5.3"
       },
       "peerDependencies": {
-        "@nestia/fetcher": ">=7.0.3",
+        "@nestia/fetcher": ">=7.1.0",
         "@nestjs/common": ">=7.0.1",
         "@nestjs/core": ">=7.0.1",
+        "@samchon/openapi": ">=4.5.0 <5.0.0",
         "reflect-metadata": ">=0.1.12",
-        "rxjs": ">=6.0.3"
+        "rxjs": ">=6.0.3",
+        "typia": ">=9.5.0 <10.0.0"
       }
     },
     "node_modules/@nestia/e2e": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@nestia/e2e/-/e2e-7.0.3.tgz",
-      "integrity": "sha512-QPRmj9kdIAHvimegxHLXCC0JSyt+l7Up9xacCFPG5N4y13Xoxt+teMm76FLJuLRtPb111ODS2O7d1D0RABaVxQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nestia/e2e/-/e2e-7.1.0.tgz",
+      "integrity": "sha512-vNonr5l0N+ugfDDnyDgBXKuluJgmdOXcDFVY1iNu/ATDJRYraR85yvN5DVhJy+3vcO+kKEHqF7/jyYQQDWx/Jg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@nestia/editor": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@nestia/editor/-/editor-7.0.3.tgz",
-      "integrity": "sha512-lXuf0g7QSgchsvLqYHPKHZRjO7GgkG22mL9J9sUS2NKTy/oBTnTiXR2rARydt0dRzHjPO5oaE5Bfisz4nzX7bw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nestia/editor/-/editor-7.1.0.tgz",
+      "integrity": "sha512-+ZwaS33UyJzIxpUCD1Yg3dBcIZ1Ce06KaHTN8pZpUBzwSfnjFb0RyjiAuRIEEn1viscbZ6FOl4ldQj2WYBbdQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mui/material": "^5.15.6",
-        "@nestia/migrate": "^7.0.3",
-        "@samchon/openapi": "^4.3.3",
+        "@nestia/migrate": "^7.1.0",
+        "@samchon/openapi": "^4.5.0",
         "@stackblitz/sdk": "^1.11.0",
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "js-yaml": "^4.1.0",
         "prettier": "3.3.3",
         "prettier-plugin-jsdoc": "^1.3.2",
         "react-mui-fileuploader": "^0.5.2",
-        "typia": "^9.3.1"
+        "typia": "^9.5.0"
       }
     },
     "node_modules/@nestia/fetcher": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@nestia/fetcher/-/fetcher-7.0.3.tgz",
-      "integrity": "sha512-cId6hyq1A3vr4YtKzm32KWwcabpy5cYULrwEKczOFFnvXO1a4mn00dtXmUdTSMUxrNKbefvrZVKifKvxx2LqzQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nestia/fetcher/-/fetcher-7.1.0.tgz",
+      "integrity": "sha512-gPcp7Tt6pcLd9yyDroGy54fI3xlcWRHBefwxygyQIAV9lRQsC7fD/hg24eYhNpUfFBbc2MP8V4dy39nAZ8RKsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@samchon/openapi": "^4.3.3",
-        "typia": "^9.3.1"
-      },
-      "peerDependencies": {
-        "@samchon/openapi": ">=4.3.3 <5.0.0",
-        "typia": ">=9.3.1 <10.0.0"
+        "@samchon/openapi": "^4.5.0"
       }
     },
     "node_modules/@nestia/migrate": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@nestia/migrate/-/migrate-7.0.3.tgz",
-      "integrity": "sha512-rU60DlLvxO/ZjBILoY5I3vqdJmcOZIdqOgtVBNUp/y027Rx9x5mEjxqHqCjPfJESsn1XrXagwl9ltMiNbr+AuA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nestia/migrate/-/migrate-7.1.0.tgz",
+      "integrity": "sha512-osb9TXhguXQA1y1DBKyzPgrDvNtyVwFcC3bFSVoU0HUfk+2gcAKaQOEWEDrMOJaAMkdntX+xK4wYtp/XVdQ3xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@samchon/openapi": "^4.3.3",
+        "@samchon/openapi": "^4.5.0",
         "commander": "10.0.0",
         "inquirer": "8.2.5",
         "prettier": "^3.3.3",
         "prettier-plugin-jsdoc": "^1.3.2",
         "tstl": "^3.0.0",
         "typescript": "~5.8.3",
-        "typia": "^9.3.1"
+        "typia": "^9.5.0"
       },
       "bin": {
         "migrate": "lib/executable/migrate.js"
       }
     },
-    "node_modules/@nestia/migrate/node_modules/commander": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
-      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@nestia/migrate/node_modules/inquirer": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
-      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.1",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "0.0.8",
-        "ora": "^5.4.1",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.5.5",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@nestia/migrate/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@nestia/sdk": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@nestia/sdk/-/sdk-7.0.3.tgz",
-      "integrity": "sha512-ugw5p6FWnH/+viEJF5MytZFc6V6cV9YqQQHoL8EJFS50W/eFE90oj64rtJjKzoKMNsEdaDcIxFCdoMGdwViS6w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nestia/sdk/-/sdk-7.1.0.tgz",
+      "integrity": "sha512-5/YKvH/gW+tirbUnqjB08JL9PtHiAUezT6cd7YXKBLcIzgqnSv4q3dTAbrTCoYWnfSp85daJ8sSn7XumI7lBcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nestia/core": "^7.0.3",
-        "@nestia/fetcher": "^7.0.3",
-        "@samchon/openapi": "^4.3.3",
+        "@nestia/core": "^7.1.0",
+        "@nestia/fetcher": "^7.1.0",
+        "@samchon/openapi": "^4.5.0",
         "cli": "^1.0.1",
         "get-function-location": "^2.0.0",
         "glob": "^7.2.0",
@@ -1028,18 +970,13 @@
         "tsconfck": "^2.1.2",
         "tsconfig-paths": "^4.1.1",
         "tstl": "^3.0.0",
-        "typia": "^9.3.1"
+        "typia": "^9.5.0"
       },
       "bin": {
         "sdk": "lib/executable/sdk.js"
       },
       "peerDependencies": {
-        "@nestia/core": ">=7.0.3",
-        "@nestia/fetcher": ">=7.0.3",
-        "@nestjs/common": ">=7.0.1",
-        "@nestjs/core": ">=7.0.1",
-        "reflect-metadata": ">=0.1.12",
-        "ts-node": ">=10.6.0"
+        "@nestia/core": ">=7.1.0"
       }
     },
     "node_modules/@nestia/sdk/node_modules/path-to-regexp": {
@@ -1287,9 +1224,9 @@
       }
     },
     "node_modules/@samchon/openapi": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@samchon/openapi/-/openapi-4.4.1.tgz",
-      "integrity": "sha512-RMcHrR1Atw9XUhgMh1EAt81ZBnMXiOIEET7aGpW3c4PVUqJyCm8F5yFjWIp81yicGn5IgzkrOz68F4sSeAitew==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@samchon/openapi/-/openapi-4.5.0.tgz",
+      "integrity": "sha512-zowWJBjoKC7PUjHGIGUz6Ka3UFkvHagJ/LrdW8hGMp+4JlKmyuN9BPggK+VnH5bf8V68fPqSGVLZppcFQDBNPQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2182,9 +2119,9 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3271,9 +3208,9 @@
       "license": "ISC"
     },
     "node_modules/inquirer": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3291,7 +3228,7 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6",
-        "wrap-ansi": "^6.0.1"
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5667,13 +5604,13 @@
       }
     },
     "node_modules/typia": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-9.4.0.tgz",
-      "integrity": "sha512-LfnK5xYvTJxBzAK40uU4TlE/1hRZAqGWWTivSYraGIDZAu4BJbPxNjtfzUIV71P30Le8ZpXMyYWbzHoBbApghQ==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-9.5.0.tgz",
+      "integrity": "sha512-HVQ5BR95NAmlEO+NGRqKz+EOEXktAqjKdelhms1rIj68mdDI1TzA7MUfNa4D6Ois95PcDdCgq9gwZiO+HXFC/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@samchon/openapi": "^4.4.1",
+        "@samchon/openapi": "^4.5.0",
         "@standard-schema/spec": "^1.0.0",
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",
@@ -5685,7 +5622,6 @@
         "typia": "lib/executable/typia.js"
       },
       "peerDependencies": {
-        "@samchon/openapi": ">=4.4.1 <5.0.0",
         "typescript": ">=4.8.0 <5.9.0"
       }
     },
@@ -5781,9 +5717,9 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5792,7 +5728,10 @@
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/internals/nestjs-dependencies/package.json
+++ b/internals/nestjs-dependencies/package.json
@@ -5,19 +5,19 @@
   "author": "Wrtn Technologies",
   "license": "MIT",
   "devDependencies": {
-    "@nestia/benchmark": "^7.0.3",
-    "@nestia/core": "^7.0.3",
-    "@nestia/e2e": "^7.0.3",
-    "@nestia/editor": "^7.0.3",
-    "@nestia/fetcher": "^7.0.3",
-    "@nestia/sdk": "^7.0.3",
+    "@nestia/benchmark": "^7.1.0",
+    "@nestia/core": "^7.1.0",
+    "@nestia/e2e": "^7.1.0",
+    "@nestia/editor": "^7.1.0",
+    "@nestia/fetcher": "^7.1.0",
+    "@nestia/sdk": "^7.1.0",
     "@nestjs/common": "^11.1.0",
     "@nestjs/core": "^11.1.0",
     "@nestjs/platform-express": "^11.1.0",
     "@nestjs/platform-fastify": "^11.1.0",
     "@nestjs/swagger": "^11.1.5",
     "@prisma/client": "^6.6.0",
-    "@samchon/openapi": "^4.4.1",
+    "@samchon/openapi": "^4.5.0",
     "@types/express": "^5.0.1",
     "@types/inquirer": "^9.0.7",
     "@types/jsonwebtoken": "^9.0.9",
@@ -33,6 +33,6 @@
     "serialize-error": "^4.1.0",
     "tgrid": "^1.1.0",
     "typescript": "~5.8.3",
-    "typia": "^9.4.0"
+    "typia": "^9.5.0"
   }
 }

--- a/internals/test-dependencies/package-lock.json
+++ b/internals/test-dependencies/package-lock.json
@@ -9,40 +9,35 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@nestia/e2e": "^7.0.3",
-        "@nestia/fetcher": "^7.0.3",
-        "@samchon/openapi": "^4.4.1",
+        "@nestia/e2e": "^7.1.0",
+        "@nestia/fetcher": "^7.1.0",
+        "@samchon/openapi": "^4.5.0",
         "@types/node": "^22.15.3",
         "typescript": "~5.8.3",
-        "typia": "^9.4.0"
+        "typia": "^9.5.0"
       }
     },
     "node_modules/@nestia/e2e": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@nestia/e2e/-/e2e-7.0.3.tgz",
-      "integrity": "sha512-QPRmj9kdIAHvimegxHLXCC0JSyt+l7Up9xacCFPG5N4y13Xoxt+teMm76FLJuLRtPb111ODS2O7d1D0RABaVxQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nestia/e2e/-/e2e-7.1.0.tgz",
+      "integrity": "sha512-vNonr5l0N+ugfDDnyDgBXKuluJgmdOXcDFVY1iNu/ATDJRYraR85yvN5DVhJy+3vcO+kKEHqF7/jyYQQDWx/Jg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@nestia/fetcher": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@nestia/fetcher/-/fetcher-7.0.3.tgz",
-      "integrity": "sha512-cId6hyq1A3vr4YtKzm32KWwcabpy5cYULrwEKczOFFnvXO1a4mn00dtXmUdTSMUxrNKbefvrZVKifKvxx2LqzQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@nestia/fetcher/-/fetcher-7.1.0.tgz",
+      "integrity": "sha512-gPcp7Tt6pcLd9yyDroGy54fI3xlcWRHBefwxygyQIAV9lRQsC7fD/hg24eYhNpUfFBbc2MP8V4dy39nAZ8RKsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@samchon/openapi": "^4.3.3",
-        "typia": "^9.3.1"
-      },
-      "peerDependencies": {
-        "@samchon/openapi": ">=4.3.3 <5.0.0",
-        "typia": ">=9.3.1 <10.0.0"
+        "@samchon/openapi": "^4.5.0"
       }
     },
     "node_modules/@samchon/openapi": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@samchon/openapi/-/openapi-4.4.1.tgz",
-      "integrity": "sha512-RMcHrR1Atw9XUhgMh1EAt81ZBnMXiOIEET7aGpW3c4PVUqJyCm8F5yFjWIp81yicGn5IgzkrOz68F4sSeAitew==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@samchon/openapi/-/openapi-4.5.0.tgz",
+      "integrity": "sha512-zowWJBjoKC7PUjHGIGUz6Ka3UFkvHagJ/LrdW8hGMp+4JlKmyuN9BPggK+VnH5bf8V68fPqSGVLZppcFQDBNPQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -842,13 +837,13 @@
       }
     },
     "node_modules/typia": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-9.4.0.tgz",
-      "integrity": "sha512-LfnK5xYvTJxBzAK40uU4TlE/1hRZAqGWWTivSYraGIDZAu4BJbPxNjtfzUIV71P30Le8ZpXMyYWbzHoBbApghQ==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-9.5.0.tgz",
+      "integrity": "sha512-HVQ5BR95NAmlEO+NGRqKz+EOEXktAqjKdelhms1rIj68mdDI1TzA7MUfNa4D6Ois95PcDdCgq9gwZiO+HXFC/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@samchon/openapi": "^4.4.1",
+        "@samchon/openapi": "^4.5.0",
         "@standard-schema/spec": "^1.0.0",
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",
@@ -860,7 +855,6 @@
         "typia": "lib/executable/typia.js"
       },
       "peerDependencies": {
-        "@samchon/openapi": ">=4.4.1 <5.0.0",
         "typescript": ">=4.8.0 <5.9.0"
       }
     },

--- a/internals/test-dependencies/package.json
+++ b/internals/test-dependencies/package.json
@@ -5,11 +5,11 @@
   "author": "Wrtn Technologies",
   "license": "MIT",
   "devDependencies": {
-    "@nestia/e2e": "^7.0.3",
-    "@nestia/fetcher": "^7.0.3",
-    "@samchon/openapi": "^4.4.1",
+    "@nestia/e2e": "^7.1.0",
+    "@nestia/fetcher": "^7.1.0",
+    "@samchon/openapi": "^4.5.0",
     "@types/node": "^22.15.3",
     "typescript": "~5.8.3",
-    "typia": "^9.4.0"
+    "typia": "^9.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,20 +15,20 @@ catalogs:
       version: 5.2.0
   samchon:
     '@nestia/core':
-      specifier: ^7.0.3
-      version: 7.0.3
+      specifier: ^7.1.0
+      version: 7.1.0
     '@nestia/e2e':
-      specifier: ^7.0.3
-      version: 7.0.3
+      specifier: ^7.1.0
+      version: 7.1.0
     '@nestia/fetcher':
-      specifier: ^7.0.3
-      version: 7.0.3
+      specifier: ^7.1.0
+      version: 7.1.0
     '@nestia/migrate':
-      specifier: ^7.0.3
-      version: 7.0.3
+      specifier: ^7.1.0
+      version: 7.1.0
     '@samchon/openapi':
-      specifier: ^4.4.1
-      version: 4.4.1
+      specifier: ^4.5.0
+      version: 4.5.0
     embed-prisma:
       specifier: ^1.1.0
       version: 1.1.0
@@ -45,8 +45,8 @@ catalogs:
       specifier: ^3.0.0
       version: 3.0.0
     typia:
-      specifier: ^9.4.0
-      version: 9.4.0
+      specifier: ^9.5.0
+      version: 9.5.0
   typescript:
     ts-node:
       specifier: ^10.9.2
@@ -85,7 +85,7 @@ importers:
     dependencies:
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       tstl:
         specifier: catalog:samchon
         version: 3.0.0
@@ -116,13 +116,13 @@ importers:
         version: link:../../packages/rpc
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.0.3(@nestia/fetcher@7.0.3(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
+        version: 7.1.0(@nestia/fetcher@7.1.0)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.5.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.5.0(typescript@5.8.3))
       '@nestia/e2e':
         specifier: catalog:samchon
-        version: 7.0.3
+        version: 7.1.0
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.0.3
+        version: 7.1.0
       '@nestjs/common':
         specifier: ^11.1.3
         version: 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -131,7 +131,7 @@ importers:
         version: 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       openai:
         specifier: catalog:libs
         version: 5.2.0(zod@3.25.57)
@@ -140,7 +140,7 @@ importers:
         version: 1.1.0
       typia:
         specifier: catalog:samchon
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
     devDependencies:
       '@types/node':
         specifier: ^22.15.17
@@ -156,7 +156,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.30.2(@samchon/openapi@4.4.1)(openai@5.2.0(zod@3.25.57))(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))
+        version: 0.30.2(@samchon/openapi@4.5.0)(openai@5.2.0(zod@3.25.57))(typia@9.5.0(typescript@5.8.3))
       '@autobe/interface':
         specifier: workspace:^
         version: link:../interface
@@ -171,7 +171,7 @@ importers:
         version: 6.1.0(rollup@4.41.0)
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       '@types/node':
         specifier: ^22.15.18
         version: 22.15.19
@@ -189,7 +189,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -235,13 +235,13 @@ importers:
         version: link:../utils
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.0.3(@nestia/fetcher@7.0.3(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
+        version: 7.1.0(@nestia/fetcher@7.1.0)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.5.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.5.0(typescript@5.8.3))
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.0.3
+        version: 7.1.0
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.2
         version: 5.2.2(prettier@3.5.3)
@@ -268,7 +268,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
     devDependencies:
       '@autobe/filesystem':
         specifier: workspace:^
@@ -296,10 +296,10 @@ importers:
     dependencies:
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       typia:
         specifier: catalog:samchon
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -324,7 +324,7 @@ importers:
         version: link:../rpc
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       openai:
         specifier: catalog:libs
         version: 5.2.0(zod@3.25.57)
@@ -336,7 +336,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -367,7 +367,7 @@ importers:
         version: 7.1.0(@emotion/react@11.14.0(@types/react@19.1.5)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.5)(react@19.1.0))(@types/react@19.1.5)(react@19.1.0))(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       '@stackblitz/sdk':
         specifier: ^1.11.0
         version: 1.11.0
@@ -446,10 +446,10 @@ importers:
         version: link:../interface
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       typia:
         specifier: catalog:samchon
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -468,13 +468,13 @@ importers:
         version: link:../interface
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       tstl:
         specifier: catalog:samchon
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -505,19 +505,19 @@ importers:
         version: link:../packages/utils
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.0.3(@nestia/fetcher@7.0.3(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)
+        version: 7.1.0(@nestia/fetcher@7.1.0)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.5.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.5.0(typescript@5.8.3))
       '@nestia/e2e':
         specifier: catalog:samchon
-        version: 7.0.3
+        version: 7.1.0
       '@nestia/fetcher':
         specifier: catalog:samchon
-        version: 7.0.3(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))
+        version: 7.1.0
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.0.3
+        version: 7.1.0
       '@samchon/openapi':
         specifier: catalog:samchon
-        version: 4.4.1
+        version: 4.5.0
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -532,7 +532,7 @@ importers:
         version: 3.0.0
       typia:
         specifier: catalog:samchon
-        version: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+        version: 9.5.0(typescript@5.8.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -1323,26 +1323,25 @@ packages:
     resolution: {integrity: sha512-jMxvwzkKzd3cXo2EB9GM2ic0eYo2rP/BS6gJt6HnWbsDO1O8GSD4k7o2Cpr2YERtMpGF/MGcDfsfj2EbQPtrXw==}
     engines: {node: '>= 10'}
 
-  '@nestia/core@7.0.3':
-    resolution: {integrity: sha512-AvQPsLjWQkdpdBkpa/+3OMio0ABYxVgxULzxwsQ4a3B4Dd4np9XKqPoEfKsMVaK46JYyq3laLYPr+u7ZU4Di9w==}
+  '@nestia/core@7.1.0':
+    resolution: {integrity: sha512-vWT0gDuxgGDd9okAlc5SdSEfFuZih55ompZZc7WgIfWdTBDEaxk8gPW76pu2egZFGYQ70Dg8d3WpwMRmSF1A0A==}
     peerDependencies:
-      '@nestia/fetcher': '>=7.0.3'
+      '@nestia/fetcher': '>=7.1.0'
       '@nestjs/common': '>=7.0.1'
       '@nestjs/core': '>=7.0.1'
+      '@samchon/openapi': '>=4.5.0 <5.0.0'
       reflect-metadata: '>=0.1.12'
       rxjs: '>=6.0.3'
+      typia: '>=9.5.0 <10.0.0'
 
-  '@nestia/e2e@7.0.3':
-    resolution: {integrity: sha512-QPRmj9kdIAHvimegxHLXCC0JSyt+l7Up9xacCFPG5N4y13Xoxt+teMm76FLJuLRtPb111ODS2O7d1D0RABaVxQ==}
+  '@nestia/e2e@7.1.0':
+    resolution: {integrity: sha512-vNonr5l0N+ugfDDnyDgBXKuluJgmdOXcDFVY1iNu/ATDJRYraR85yvN5DVhJy+3vcO+kKEHqF7/jyYQQDWx/Jg==}
 
-  '@nestia/fetcher@7.0.3':
-    resolution: {integrity: sha512-cId6hyq1A3vr4YtKzm32KWwcabpy5cYULrwEKczOFFnvXO1a4mn00dtXmUdTSMUxrNKbefvrZVKifKvxx2LqzQ==}
-    peerDependencies:
-      '@samchon/openapi': '>=4.3.3 <5.0.0'
-      typia: '>=9.3.1 <10.0.0'
+  '@nestia/fetcher@7.1.0':
+    resolution: {integrity: sha512-gPcp7Tt6pcLd9yyDroGy54fI3xlcWRHBefwxygyQIAV9lRQsC7fD/hg24eYhNpUfFBbc2MP8V4dy39nAZ8RKsg==}
 
-  '@nestia/migrate@7.0.3':
-    resolution: {integrity: sha512-rU60DlLvxO/ZjBILoY5I3vqdJmcOZIdqOgtVBNUp/y027Rx9x5mEjxqHqCjPfJESsn1XrXagwl9ltMiNbr+AuA==}
+  '@nestia/migrate@7.1.0':
+    resolution: {integrity: sha512-osb9TXhguXQA1y1DBKyzPgrDvNtyVwFcC3bFSVoU0HUfk+2gcAKaQOEWEDrMOJaAMkdntX+xK4wYtp/XVdQ3xw==}
     hasBin: true
 
   '@nestjs/common@11.1.3':
@@ -1733,8 +1732,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@samchon/openapi@4.4.1':
-    resolution: {integrity: sha512-RMcHrR1Atw9XUhgMh1EAt81ZBnMXiOIEET7aGpW3c4PVUqJyCm8F5yFjWIp81yicGn5IgzkrOz68F4sSeAitew==}
+  '@samchon/openapi@4.5.0':
+    resolution: {integrity: sha512-zowWJBjoKC7PUjHGIGUz6Ka3UFkvHagJ/LrdW8hGMp+4JlKmyuN9BPggK+VnH5bf8V68fPqSGVLZppcFQDBNPQ==}
 
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
@@ -4622,11 +4621,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typia@9.4.0:
-    resolution: {integrity: sha512-LfnK5xYvTJxBzAK40uU4TlE/1hRZAqGWWTivSYraGIDZAu4BJbPxNjtfzUIV71P30Le8ZpXMyYWbzHoBbApghQ==}
+  typia@9.5.0:
+    resolution: {integrity: sha512-HVQ5BR95NAmlEO+NGRqKz+EOEXktAqjKdelhms1rIj68mdDI1TzA7MUfNa4D6Ois95PcDdCgq9gwZiO+HXFC/g==}
     hasBin: true
     peerDependencies:
-      '@samchon/openapi': '>=4.4.1 <5.0.0'
       typescript: '>=4.8.0 <5.9.0'
 
   uc.micro@2.1.0:
@@ -4922,12 +4920,12 @@ packages:
 
 snapshots:
 
-  '@agentica/core@0.30.2(@samchon/openapi@4.4.1)(openai@5.2.0(zod@3.25.57))(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))':
+  '@agentica/core@0.30.2(@samchon/openapi@4.5.0)(openai@5.2.0(zod@3.25.57))(typia@9.5.0(typescript@5.8.3))':
     dependencies:
-      '@samchon/openapi': 4.4.1
+      '@samchon/openapi': 4.5.0
       openai: 5.2.0(zod@3.25.57)
       tstl: 3.0.0
-      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      typia: 9.5.0(typescript@5.8.3)
       uuid: 11.1.0
 
   '@ampproject/remapping@2.3.0':
@@ -5607,12 +5605,12 @@ snapshots:
       '@napi-rs/simple-git-win32-arm64-msvc': 0.1.19
       '@napi-rs/simple-git-win32-x64-msvc': 0.1.19
 
-  '@nestia/core@7.0.3(@nestia/fetcher@7.0.3(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)))(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typescript@5.8.3)':
+  '@nestia/core@7.1.0(@nestia/fetcher@7.1.0)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.5.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.5.0(typescript@5.8.3))':
     dependencies:
-      '@nestia/fetcher': 7.0.3(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))
+      '@nestia/fetcher': 7.1.0
       '@nestjs/common': 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@samchon/openapi': 4.4.1
+      '@samchon/openapi': 4.5.0
       detect-ts-node: 1.0.5
       get-function-location: 2.0.0
       glob: 7.2.3
@@ -5621,30 +5619,28 @@ snapshots:
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tgrid: 1.1.0
-      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      typia: 9.5.0(typescript@5.8.3)
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
-      - typescript
       - utf-8-validate
 
-  '@nestia/e2e@7.0.3': {}
+  '@nestia/e2e@7.1.0': {}
 
-  '@nestia/fetcher@7.0.3(@samchon/openapi@4.4.1)(typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3))':
+  '@nestia/fetcher@7.1.0':
     dependencies:
-      '@samchon/openapi': 4.4.1
-      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      '@samchon/openapi': 4.5.0
 
-  '@nestia/migrate@7.0.3':
+  '@nestia/migrate@7.1.0':
     dependencies:
-      '@samchon/openapi': 4.4.1
+      '@samchon/openapi': 4.5.0
       commander: 10.0.0
       inquirer: 8.2.5
       prettier: 3.5.3
       prettier-plugin-jsdoc: 1.3.2(prettier@3.5.3)
       tstl: 3.0.0
       typescript: 5.8.3
-      typia: 9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3)
+      typia: 9.5.0(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6002,7 +5998,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.41.0':
     optional: true
 
-  '@samchon/openapi@4.4.1': {}
+  '@samchon/openapi@4.5.0': {}
 
   '@shikijs/core@2.5.0':
     dependencies:
@@ -9728,9 +9724,9 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typia@9.4.0(@samchon/openapi@4.4.1)(typescript@5.8.3):
+  typia@9.5.0(typescript@5.8.3):
     dependencies:
-      '@samchon/openapi': 4.4.1
+      '@samchon/openapi': 4.5.0
       '@standard-schema/spec': 1.0.0
       commander: 10.0.0
       comment-json: 4.2.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,20 +10,20 @@ catalogs:
     "@agentica/core": ^0.30.2
     "@agentica/rpc": ^0.30.2
   samchon:
-    "@nestia/benchmark": ^7.0.3
-    "@nestia/core": ^7.0.3
-    "@nestia/e2e": ^7.0.3
-    "@nestia/editor": ^7.0.3
-    "@nestia/fetcher": ^7.0.3
-    "@nestia/migrate": ^7.0.3
-    "@nestia/sdk": ^7.0.3
-    "@samchon/openapi": ^4.4.1
+    "@nestia/benchmark": ^7.1.0
+    "@nestia/core": ^7.1.0
+    "@nestia/e2e": ^7.1.0
+    "@nestia/editor": ^7.1.0
+    "@nestia/fetcher": ^7.1.0
+    "@nestia/migrate": ^7.1.0
+    "@nestia/sdk": ^7.1.0
+    "@samchon/openapi": ^4.5.0
     embed-prisma: ^1.1.0
     embed-typescript: ^1.0.1
     prisma-markdown: ^3.0.0
     tgrid: ^1.1.0
     tstl: ^3.0.0
-    typia: ^9.4.0
+    typia: ^9.5.0
   typescript:
     ts-node: ^10.9.2
     ts-patch: ^3.3.0


### PR DESCRIPTION
Previously, the first paragraph of each property's JSDoc comment was designated as the title, but in AI function calling, this overlapped with the introduction of the description, unnecessarily increasing token usage and causing the opening to be overly emphasized.

```typescript
export interface Something {
  /**
   * Previously, the top paragraph went to the title.
   *
   * And since the entire comment became the description, the beginning of the sentence was overly emphasized.
   */
  before: string;

  /**
   * The changed approach is that the entire comment only goes into the description,
   *
   * @title and the title is constructed only when explicitly specified with JSDocTag.
   */
  after: string;
}
```

Changed the rule so that titles are only generated when explicitly specified using `@title` JSDocTag, while the entire comment content goes into the description field.

This improves efficiency in AST function calling by reducing redundant content between title and description properties.