### PR TITLE
fix(agent): Add Authorization Validation Feedback and modify the IOperation Type

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
@@ -88,6 +88,7 @@ async function process<Model extends ILlmSchema.Model>(
   const pointer: IPointer<AutoBeOpenApi.IOperation[] | null> = {
     value: null,
   };
+
   const agentica: MicroAgentica<Model> = new MicroAgentica({
     model: ctx.model,
     vendor: ctx.vendor,
@@ -104,6 +105,7 @@ async function process<Model extends ILlmSchema.Model>(
     controllers: [
       createApplication({
         model: ctx.model,
+        roles: ctx.state().analyze?.roles,
         build: (endpoints) => {
           pointer.value ??= [];
           pointer.value.push(...endpoints);
@@ -132,6 +134,7 @@ async function process<Model extends ILlmSchema.Model>(
 
 function createApplication<Model extends ILlmSchema.Model>(props: {
   model: Model;
+  roles: string[] | null;
   build: (operations: AutoBeOpenApi.IOperation[]) => void;
 }): IAgenticaController.IClass<Model> {
   assertSchemaModel(props.model);
@@ -153,6 +156,24 @@ function createApplication<Model extends ILlmSchema.Model>(props: {
             "GET method should not have request body. Change method, or re-design the operation.",
           value: op.requestBody,
         });
+      op.authorizationRoles?.forEach((role, j) => {
+        if (props.roles === null) {
+          op.authorizationRoles = null;
+        }
+        if (props.roles?.find((it) => it === role) === undefined)
+          errors.push({
+            path: `operations[${i}].authorizationRoles[${j}]`,
+            expected: `undefined | ${props.roles?.join(" | ")}`,
+            description: [
+              `Role "${role}" is not defined in the roles list.`,
+              "",
+              "Please select one of them below, or do not define (undefined):  ",
+              "",
+              ...(props.roles ?? []).map((role) => `- ${role}`),
+            ].join("\n"),
+            value: role,
+          });
+      });
     });
     if (errors.length !== 0)
       return {

--- a/packages/agent/src/orchestrate/interface/transformInterfaceHistories.ts
+++ b/packages/agent/src/orchestrate/interface/transformInterfaceHistories.ts
@@ -116,6 +116,26 @@ export const transformInterfaceHistories = (
         "```json",
         JSON.stringify(state.analyze.files),
         "```",
+        "",
+        state.analyze?.roles
+          ? [
+              "## Role Assignment",
+              "",
+              "Available roles: ",
+              "",
+              `${JSON.stringify(state.analyze.roles)}`,
+              "",
+              "For each API operation, assign `authorizationRoles` field:",
+              "* `authorizationRoles: null` - Public access, no authentication",
+              '* `authorizationRoles: ["roleName"]` - Restricted access, use exact names from available roles',
+              "* No duplicate roles in array",
+              "* Always set authorizationRoles field explicitly",
+            ].join("\n")
+          : [
+              "## Authorization",
+              "",
+              "No roles provided. Do not include any authorization-related fields in the API operations.",
+            ].join("\n"),
       ].join("\n"),
     },
     {

--- a/packages/interface/src/openapi/AutoBeOpenApi.ts
+++ b/packages/interface/src/openapi/AutoBeOpenApi.ts
@@ -1,3 +1,5 @@
+import { tags } from "typia";
+
 /**
  * AST type system for programmatic OpenAPI specification generation through AI
  * function calling.
@@ -393,12 +395,15 @@ export namespace AutoBeOpenApi {
     responseBody: AutoBeOpenApi.IResponseBody | null;
 
     /**
-     * Authorization
+     * List of roles that are allowed to access the API operation.
      *
-     * Defines which user role is subject to strategies such as membership
-     * registration, login, token issuance, refresh token, etc.
+     * If the API operation is not restricted to any role, this field must be
+     * `null`.
+     *
+     * If the API operation is restricted to some roles, this field must be an
+     * array of role names.
      */
-    authorization?: IAuthorization | null;
+    authorizationRoles: (string[] & tags.UniqueItems) | null;
   }
 
   /**
@@ -447,15 +452,25 @@ export namespace AutoBeOpenApi {
      * Therefore, if a user type cannot be clearly and uniquely distinguished in
      * the database, It **cannot** be used as a valid `role` here.
      */
-    role: string[];
+    role: string;
 
     /**
-     * Authentication method type
+     * Detailed description of the authorization role
      *
-     * Currently only `"bearer"` is supported, which uses a Bearer token in the
-     * HTTP Authorization header.
+     * Provides a comprehensive explanation of:
+     *
+     * - The purpose and scope of this authorization role
+     * - Which types of users are granted this role
+     * - What capabilities and permissions this role enables
+     * - Any constraints or limitations associated with the role
+     * - How this role relates to the underlying database schema
+     * - Examples of typical use cases for this role
+     *
+     * This description should be detailed enough for both API consumers to
+     * understand the role's purpose and for the system to properly enforce
+     * access controls.
      */
-    type: "Bearer";
+    description: string;
   }
 
   /**
@@ -725,12 +740,7 @@ export namespace AutoBeOpenApi {
     schemas: Record<string, IJsonSchemaDescriptive>;
 
     /** Whether includes `Authorization` header or not. */
-    authorization?: {
-      roles: {
-        title: string;
-        description: string;
-      }[];
-    };
+    authorization?: IAuthorization[];
   }
 
   /**


### PR DESCRIPTION
## Description
- Add the Validation Feedback about Authorization in Interface Agent.
- Modify the `AutoBeOpenApi.IOperation` and `AutoBeOpenApi.IAuthorization` type.

## Notification
- Not worked yet. because from Analysis agent, interface must be given the `roles` data.
  - Analysis agent not implemented the roles field yet.