### PR TITLE
feat(website): change to new youtube video

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ An AI-powered no-code agent that builds backend applications, enhanced by compil
 
 ## Playground
 
-https://github.com/user-attachments/assets/00a3649a-ca0a-417b-a2eb-43387d45b4aa
+https://github.com/user-attachments/assets/49856941-7c41-4312-9877-6a34bd8b73b6
 
 [https://stackblitz.com/github/wrtnlabs/autobe-playground-stackblitz](https://stackblitz.com/github/wrtnlabs/autobe-playground-stackblitz?file=md!README.md)
 

--- a/website/src/template/AutoBePlaygroundSection.mdx
+++ b/website/src/template/AutoBePlaygroundSection.mdx
@@ -1,6 +1,6 @@
 <br/>
 <iframe
-  src="https://www.youtube.com/embed/SIgP-1OcAwg"
+  src="https://www.youtube.com/embed/1kG-etfXVqI"
   title="AutoBE Demonstration (Bullet-in Board System)"
   width="100%"
   style={{ aspectRatio: "16/9" }}


### PR DESCRIPTION
This pull request includes updates to external links and embedded media references in the project documentation and website.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R48): Updated the playground asset URL to point to a new resource.

### Website Updates:
* [`website/src/template/AutoBePlaygroundSection.mdx`](diffhunk://#diff-f71dc825064691ee145ab5fa572685f1ac0674de00fa3d8faef39dfb1c93dbf3L3-R3): Changed the embedded YouTube video URL to a new demonstration video.