### PR TITLE
fix(agent): final compilation of test agent

### DIFF
--- a/internals/dependencies/nestjs/package-lock.json
+++ b/internals/dependencies/nestjs/package-lock.json
@@ -22,6 +22,7 @@
         "@nestjs/swagger": "^11.1.5",
         "@prisma/client": "^6.6.0",
         "@samchon/openapi": "^4.5.0",
+        "@types/cli-progress": "^3.11.6",
         "@types/express": "^5.0.1",
         "@types/inquirer": "^9.0.7",
         "@types/jsonwebtoken": "^9.0.9",
@@ -1349,6 +1350,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cli-progress": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.6.tgz",
+      "integrity": "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },

--- a/internals/dependencies/nestjs/package.json
+++ b/internals/dependencies/nestjs/package.json
@@ -18,6 +18,7 @@
     "@nestjs/swagger": "^11.1.5",
     "@prisma/client": "^6.6.0",
     "@samchon/openapi": "^4.5.0",
+    "@types/cli-progress": "^3.11.6",
     "@types/express": "^5.0.1",
     "@types/inquirer": "^9.0.7",
     "@types/jsonwebtoken": "^9.0.9",

--- a/packages/agent/src/orchestrate/test/orchestrateTest.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTest.ts
@@ -70,7 +70,7 @@ export const orchestrateTest =
     const compiler: IAutoBeCompiler = await ctx.compiler();
     const result: AutoBeTestFile[] = success.map((c) => c.file);
     const compiled: IAutoBeTypeScriptCompileResult =
-      await compiler.test.compile({
+      await compiler.typescript.compile({
         files: Object.fromEntries([
           ...Object.entries(
             await ctx.files({

--- a/test/src/features/test/internal/validate_agent_test_main.ts
+++ b/test/src/features/test/internal/validate_agent_test_main.ts
@@ -55,7 +55,14 @@ export const validate_agent_test_main = async (
       ...(await agent.getFiles()),
       "logs/compiled.json": JSON.stringify(result.compiled, null, 2),
       "logs/events.json": JSON.stringify(events, null, 2),
-      "logs/result.json": typia.json.stringify(result),
+      "logs/result.json": JSON.stringify(
+        {
+          ...result,
+          files: undefined,
+        },
+        null,
+        2,
+      ),
       "logs/histories.json": typia.json.stringify(histories),
       "pnpm-workspace.yaml": "",
     },


### PR DESCRIPTION
This pull request includes updates to improve the test orchestration and logging mechanisms in the agent's codebase. The most important changes involve switching to a different compile method for TypeScript tests and modifying the structure of the logged result JSON to exclude files.

### Test orchestration updates:
* [`packages/agent/src/orchestrate/test/orchestrateTest.ts`](diffhunk://#diff-da0f884d69cbd6a2950be9203925295ce405e2ab85d5e7ef37b3d7fbeb63eb3cL73-R73): Changed the method used for TypeScript test compilation from `compiler.test.compile` to `compiler.typescript.compile` for better alignment with the naming convention and functionality.

### Logging improvements:
* [`test/src/features/test/internal/validate_agent_test_main.ts`](diffhunk://#diff-33d48b68dc459507466717f8cdc6de963d14b5c488f1b1730ea0eaaf60cf641fL58-R65): Updated the structure of the `logs/result.json` file to exclude the `files` property from the logged result, ensuring cleaner and more focused logs.