### PR TITLE
feat(interface) remove compiled javascript files

### DIFF
--- a/packages/compiler/src/AutoBeTypeScriptCompiler.ts
+++ b/packages/compiler/src/AutoBeTypeScriptCompiler.ts
@@ -4,7 +4,7 @@ import {
   IAutoBeTypeScriptCompiler,
 } from "@autobe/interface";
 import nestiaCoreTransform from "@nestia/core/lib/transform";
-import { EmbedTypeScript } from "embed-typescript";
+import { EmbedTypeScript, IEmbedTypeScriptResult } from "embed-typescript";
 import ts from "typescript";
 import typiaTransform from "typia/lib/transform";
 
@@ -77,10 +77,15 @@ export class AutoBeTypeScriptCompiler implements IAutoBeTypeScriptCompiler {
         ],
       }),
     });
-    return compiler.compile({
+    const result: IEmbedTypeScriptResult = await compiler.compile({
       ...props.files,
       ...(props.prisma ?? {}),
     });
+    return result.type === "success"
+      ? { type: "success" }
+      : result.type === "failure"
+        ? { type: "failure", diagnostics: result.diagnostics }
+        : { type: "exception", error: result.error };
   }
 
   public async getExternal(location: string): Promise<string | undefined> {

--- a/packages/compiler/src/test/AutoBeTestCompiler.ts
+++ b/packages/compiler/src/test/AutoBeTestCompiler.ts
@@ -7,7 +7,7 @@ import {
   IAutoBeTypeScriptCompileResult,
 } from "@autobe/interface";
 import { AutoBeEndpointComparator, validateTestFunction } from "@autobe/utils";
-import { EmbedTypeScript } from "embed-typescript";
+import { EmbedTypeScript, IEmbedTypeScriptResult } from "embed-typescript";
 import { HashMap, Pair } from "tstl";
 import ts from "typescript";
 import { IValidation } from "typia";
@@ -53,7 +53,12 @@ export class AutoBeTestCompiler implements IAutoBeTestCompiler {
         ],
       }),
     });
-    return compiler.compile(props.files);
+    const result: IEmbedTypeScriptResult = await compiler.compile(props.files);
+    return result.type === "success"
+      ? { type: "success" }
+      : result.type === "failure"
+        ? { type: "failure", diagnostics: result.diagnostics }
+        : { type: "exception", error: result.error };
   }
 
   public async validate(

--- a/packages/interface/src/compiler/IAutoBeTypeScriptCompileResult.ts
+++ b/packages/interface/src/compiler/IAutoBeTypeScriptCompileResult.ts
@@ -33,16 +33,16 @@ export namespace IAutoBeTypeScriptCompileResult {
     /** Discriminator indicating successful compilation. */
     type: "success";
 
-    /**
-     * Generated JavaScript files as key-value pairs.
-     *
-     * Contains the compiled JavaScript output with each key representing the
-     * output file path and each value containing the generated JavaScript code.
-     * The compiled code is ready for execution in Node.js environments and
-     * maintains all functionality specified in the original TypeScript source
-     * while ensuring optimal runtime performance.
-     */
-    javascript: Record<string, string>;
+    // /**
+    //  * Generated JavaScript files as key-value pairs.
+    //  *
+    //  * Contains the compiled JavaScript output with each key representing the
+    //  * output file path and each value containing the generated JavaScript code.
+    //  * The compiled code is ready for execution in Node.js environments and
+    //  * maintains all functionality specified in the original TypeScript source
+    //  * while ensuring optimal runtime performance.
+    //  */
+    // javascript: Record<string, string>;
   }
 
   /**
@@ -70,15 +70,15 @@ export namespace IAutoBeTypeScriptCompileResult {
      */
     diagnostics: IDiagnostic[];
 
-    /**
-     * Partial JavaScript output despite compilation failures.
-     *
-     * Contains any JavaScript code that was successfully generated before
-     * compilation failures occurred. This partial output can provide context
-     * for understanding which parts of the code compiled correctly and which
-     * areas require correction during the AI feedback and refinement process.
-     */
-    javascript: Record<string, string>;
+    // /**
+    //  * Partial JavaScript output despite compilation failures.
+    //  *
+    //  * Contains any JavaScript code that was successfully generated before
+    //  * compilation failures occurred. This partial output can provide context
+    //  * for understanding which parts of the code compiled correctly and which
+    //  * areas require correction during the AI feedback and refinement process.
+    //  */
+    // javascript: Record<string, string>;
   }
 
   /**

--- a/test/src/features/compiler/test_compiler_realize_files.ts
+++ b/test/src/features/compiler/test_compiler_realize_files.ts
@@ -23,7 +23,6 @@ export const test_compiler_realize_files = async (): Promise<void> => {
         files: {},
         compiled: {
           type: "success",
-          javascript: {},
         },
         id: v4(),
         created_at: new Date().toISOString(),

--- a/test/src/features/test/internal/validate_agent_test_correct.ts
+++ b/test/src/features/test/internal/validate_agent_test_correct.ts
@@ -69,14 +69,7 @@ export const validate_agent_test_correct = async (
       ]),
       "test/tsconfig.json":
         AutoBeCompilerInterfaceTemplate["test/tsconfig.json"],
-      "logs/corrects.json": JSON.stringify(
-        result.map((r) => ({
-          ...r,
-          javascript: undefined,
-        })),
-        null,
-        2,
-      ),
+      "logs/corrects.json": JSON.stringify(result, null, 2),
       "logs/failures.json": JSON.stringify(
         result
           .map((c) => c.result)

--- a/test/src/features/test/internal/validate_agent_test_write.ts
+++ b/test/src/features/test/internal/validate_agent_test_write.ts
@@ -71,14 +71,7 @@ export const validate_agent_test_write = async (
       "test/tsconfig.json":
         AutoBeCompilerInterfaceTemplate["test/tsconfig.json"],
       "logs/results.json": typia.json.stringify(writes),
-      "logs/compiled.json": JSON.stringify(
-        {
-          ...result,
-          javascript: undefined,
-        },
-        null,
-        2,
-      ),
+      "logs/compiled.json": JSON.stringify(result, null, 2),
     },
   });
   if (process.argv.includes("--archive"))


### PR DESCRIPTION
This pull request refactors the TypeScript compilation process by modifying the handling of compilation results to simplify the output and improve error handling. The most notable changes include updating the `compile` method to return structured results, deprecating the inclusion of JavaScript output in the compilation result, and updating related test cases to reflect these changes.

### Compiler Enhancements:
* Updated the `compile` method in `AutoBeTypeScriptCompiler` and `AutoBeTestCompiler` to return structured results, differentiating between success, failure, and exception cases. This improves error handling and clarity. (`packages/compiler/src/AutoBeTypeScriptCompiler.ts`, `packages/compiler/src/test/AutoBeTestCompiler.ts`) [[1]](diffhunk://#diff-cad54d4ee71a3f3f3d525f73ad52fb3d133c03bb52d73b2812dfd8aaf4bfd481L80-R88) [[2]](diffhunk://#diff-16b138c3bdd7c8682409a0a1f5c985d48e18e8aa6deb58e074fb603acdd14f4cL56-R61)

### Interface Changes:
* Deprecated the `javascript` field in `IAutoBeTypeScriptCompileResult` for both successful and failed compilations, marking it as commented-out code. This simplifies the interface and focuses on diagnostics and error reporting. (`packages/interface/src/compiler/IAutoBeTypeScriptCompileResult.ts`) [[1]](diffhunk://#diff-1dd37c466aec520b840a1a5453192c6a5a34d211217e47e24a4b3f1e4c45cd8aL36-R45) [[2]](diffhunk://#diff-1dd37c466aec520b840a1a5453192c6a5a34d211217e47e24a4b3f1e4c45cd8aL73-R81)

### Test Updates:
* Removed references to the `javascript` field from test cases, including `test_compiler_realize_files`, `validate_agent_test_correct`, and `validate_agent_test_write`, to align with the updated interface. (`test/src/features/compiler/test_compiler_realize_files.ts`, `test/src/features/test/internal/validate_agent_test_correct.ts`, `test/src/features/test/internal/validate_agent_test_write.ts`) [[1]](diffhunk://#diff-2aba0a566a7340239b79cbf6cae2e7e1e56bd1ed9df94491fda22b1dcf963a30L26) [[2]](diffhunk://#diff-7eb6ef182d12726f14de60aed06999214a5d00ef949473e9407c2bb1c053d072L72-R72) [[3]](diffhunk://#diff-40236b228b208091d0e036be5ceb0d365c4307acb8ca4c72eb6c11be47bf8ab2L74-R74)