### PR TITLE
feat(test): build test of test agent result

### DIFF
--- a/test/src/features/compiler/test_compiler_test_build.ts
+++ b/test/src/features/compiler/test_compiler_test_build.ts
@@ -1,0 +1,43 @@
+import { AutoBeAgent } from "@autobe/agent";
+import { AutoBeCompiler } from "@autobe/compiler";
+import {
+  AutoBeHistory,
+  AutoBeTestHistory,
+  IAutoBeTypeScriptCompileResult,
+} from "@autobe/interface";
+import { TestValidator } from "@nestia/e2e";
+import OpenAI from "openai";
+import typia from "typia";
+
+import { TestHistory } from "../../internal/TestHistory";
+
+export async function test_compiler_test_build(): Promise<void> {
+  const histories: AutoBeHistory[] = await TestHistory.getTest("bbs-backend");
+  const testHistory: AutoBeTestHistory = typia.assert<AutoBeTestHistory>(
+    histories.at(-1),
+  );
+  const agent: AutoBeAgent<"chatgpt"> = new AutoBeAgent({
+    model: "chatgpt",
+    vendor: {
+      api: new OpenAI({ apiKey: "" }),
+      model: "gpt-4.1",
+    },
+    compiler: (listener) => new AutoBeCompiler(listener),
+    histories: histories.slice(0, -1),
+  });
+
+  const files: Record<string, string> = {
+    ...(await agent.getFiles()),
+    ...Object.fromEntries(
+      testHistory.files.map((file) => [file.location, file.content]),
+    ),
+  };
+  const result: IAutoBeTypeScriptCompileResult = await (
+    await agent.getContext().compiler()
+  ).typescript.compile({
+    files: Object.fromEntries(
+      Object.entries(files).filter(([key]) => key.endsWith(".ts")),
+    ),
+  });
+  TestValidator.equals("result")(result.type)("success");
+}


### PR DESCRIPTION
This pull request adds a new test function, `test_compiler_test_build`, to the `test/src/features/compiler/test_compiler_test_build.ts` file. The function integrates with the AutoBe framework to compile TypeScript files and validate the compilation result.

### New functionality:

* **Added `test_compiler_test_build` function**:
  - Imports necessary modules from the AutoBe framework, OpenAI, and other libraries.
  - Retrieves test history using `TestHistory.getTest` and validates it with `typia.assert`.
  - Initializes an `AutoBeAgent` configured with a ChatGPT model and a custom compiler.
  - Merges files from the agent and test history, filtering for `.ts` files, and compiles them using the agent's TypeScript compiler.
  - Validates the compilation result to ensure it matches the expected outcome ("success").