### PR TITLE
feat(agent): new event `AutoBePrismaInsufficientEvent`

### DIFF
--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
@@ -106,6 +106,16 @@ async function process<Model extends ILlmSchema.Model>(
     file.models.every((m) => m.name !== x),
   );
   if (todo.length !== 0 && retryCount++ < 3) {
+    ctx.dispatch({
+      type: "prismaInsufficient",
+      completed: {
+        ...file,
+        models: [...(remained?.done ?? []), ...file.models],
+      },
+      expected: component.entireTables,
+      missed: todo,
+      created_at: new Date().toISOString(),
+    });
     const fulfill: IMakePrismaSchemaFileProps = await forceRetry(() =>
       process(
         ctx,

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
@@ -105,7 +105,7 @@ async function process<Model extends ILlmSchema.Model>(
   const todo: string[] = (remained?.todo ?? component.tables).filter((x) =>
     file.models.every((m) => m.name !== x),
   );
-  if (todo.length !== 0) {
+  if (todo.length !== 0 && retryCount++ < 3) {
     const fulfill: IMakePrismaSchemaFileProps = await forceRetry(() =>
       process(
         ctx,
@@ -119,7 +119,7 @@ async function process<Model extends ILlmSchema.Model>(
           todo,
           namespace: file.namespace,
         },
-        retryCount + 1,
+        retryCount,
       ),
     );
     pointer.value.file.models.push(...fulfill.file.models);

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
@@ -112,7 +112,7 @@ async function process<Model extends ILlmSchema.Model>(
         ...file,
         models: [...(remained?.done ?? []), ...file.models],
       },
-      expected: component.entireTables,
+      expected: component.tables,
       missed: todo,
       created_at: new Date().toISOString(),
     });

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
@@ -57,6 +57,7 @@ async function process<Model extends ILlmSchema.Model>(
     todo: string[];
     namespace: string;
   },
+  retryCount: number = 0,
 ): Promise<IMakePrismaSchemaFileProps> {
   const pointer: IPointer<IMakePrismaSchemaFileProps | null> = {
     value: null,
@@ -105,18 +106,21 @@ async function process<Model extends ILlmSchema.Model>(
     file.models.every((m) => m.name !== x),
   );
   if (todo.length !== 0) {
-    const fulfill: IMakePrismaSchemaFileProps = await process(
-      ctx,
-      {
-        filename: component.filename,
-        tables: component.tables,
-        entireTables: component.entireTables,
-      },
-      {
-        done: [...(remained?.done ?? []), ...file.models],
-        todo,
-        namespace: file.namespace,
-      },
+    const fulfill: IMakePrismaSchemaFileProps = await forceRetry(() =>
+      process(
+        ctx,
+        {
+          filename: component.filename,
+          tables: component.tables,
+          entireTables: component.entireTables,
+        },
+        {
+          done: [...(remained?.done ?? []), ...file.models],
+          todo,
+          namespace: file.namespace,
+        },
+        retryCount + 1,
+      ),
     );
     pointer.value.file.models.push(...fulfill.file.models);
   }

--- a/packages/interface/src/events/AutoBeEvent.ts
+++ b/packages/interface/src/events/AutoBeEvent.ts
@@ -12,6 +12,7 @@ import { AutoBeInterfaceStartEvent } from "./AutoBeInterfaceStartEvent";
 import { AutoBePrismaCompleteEvent } from "./AutoBePrismaCompleteEvent";
 import { AutoBePrismaComponentsEvent } from "./AutoBePrismaComponentsEvent";
 import { AutoBePrismaCorrectEvent } from "./AutoBePrismaCorrectEvent";
+import { AutoBePrismaInsufficientEvent } from "./AutoBePrismaInsufficientEvent";
 import { AutoBePrismaSchemasEvent } from "./AutoBePrismaSchemasEvent";
 import { AutoBePrismaStartEvent } from "./AutoBePrismaStartEvent";
 import { AutoBePrismaValidateEvent } from "./AutoBePrismaValidateEvent";
@@ -72,6 +73,7 @@ export type AutoBeEvent =
   | AutoBePrismaStartEvent
   | AutoBePrismaComponentsEvent
   | AutoBePrismaSchemasEvent
+  | AutoBePrismaInsufficientEvent
   | AutoBePrismaCompleteEvent
   | AutoBePrismaValidateEvent
   | AutoBePrismaCorrectEvent
@@ -138,6 +140,7 @@ export namespace AutoBeEvent {
     prismaStart: AutoBePrismaStartEvent;
     prismaComponents: AutoBePrismaComponentsEvent;
     prismaSchemas: AutoBePrismaSchemasEvent;
+    prismaInsufficient: AutoBePrismaInsufficientEvent;
     prismaComplete: AutoBePrismaCompleteEvent;
     prismaValidate: AutoBePrismaValidateEvent;
     prismaCorrect: AutoBePrismaCorrectEvent;

--- a/packages/interface/src/events/AutoBePrismaInsufficientEvent.ts
+++ b/packages/interface/src/events/AutoBePrismaInsufficientEvent.ts
@@ -1,0 +1,66 @@
+import { AutoBePrisma } from "../prisma";
+import { AutoBeEventBase } from "./AutoBeEventBase";
+
+/**
+ * Event fired when the Prisma agent creates fewer models than expected during
+ * the database schema creation process.
+ *
+ * This event occurs when the AI function calling process results in an
+ * incomplete set of models for a specific business domain or functional
+ * category. The event indicates that the schema generation did not meet the
+ * expected model count, which may require additional iterations or manual
+ * intervention to complete the database design.
+ *
+ * This insufficient model creation can happen due to various reasons such as
+ * incomplete AI responses, context limitations, or partial understanding of the
+ * business requirements. The event provides detailed information about the gap
+ * between expected and actual model creation to enable appropriate corrective
+ * actions.
+ *
+ * @author Samchon
+ */
+export interface AutoBePrismaInsufficientEvent
+  extends AutoBeEventBase<"prismaInsufficient"> {
+  /**
+   * The completed schema file containing the successfully generated models.
+   *
+   * Contains the {@link AutoBePrisma.IFile} structure representing a partial but
+   * valid schema file with the models that were actually created by the AI
+   * function calling process. The file includes the filename following the
+   * `schema-{number}-{domain}.prisma` convention, the business namespace, and
+   * all successfully created models with their fields, indexes, and
+   * relationships.
+   *
+   * This file represents what was successfully completed before the
+   * insufficient model generation was detected, providing a complete picture of
+   * the partial schema state and serving as the foundation for completing the
+   * missing models.
+   */
+  completed: AutoBePrisma.IFile;
+
+  /**
+   * Array of model names that should have been created for this domain.
+   *
+   * Contains the names of all models that were identified in the requirements
+   * analysis and component organization for this specific business domain. This
+   * represents the complete set of models that the AI function calling process
+   * was supposed to generate based on the business requirements.
+   *
+   * This list serves as the reference point for determining which models are
+   * missing and provides context for the scope of the database design task.
+   */
+  expected: string[];
+
+  /**
+   * Array of model names that were not created by the AI function calling.
+   *
+   * Contains the names of models that were identified in the requirements
+   * analysis but were not generated during the schema creation process. This
+   * information helps identify specific missing entities and enables targeted
+   * corrective actions to complete the schema design.
+   *
+   * The missing models represent the gap between what was planned and what was
+   * actually delivered by the AI function calling process.
+   */
+  missed: string[];
+}

--- a/packages/interface/src/events/index.ts
+++ b/packages/interface/src/events/index.ts
@@ -11,6 +11,7 @@ export * from "./AutoBeAnalyzeCompleteEvent";
 export * from "./AutoBePrismaStartEvent";
 export * from "./AutoBePrismaComponentsEvent";
 export * from "./AutoBePrismaSchemasEvent";
+export * from "./AutoBePrismaInsufficientEvent";
 export * from "./AutoBePrismaCompleteEvent";
 export * from "./AutoBePrismaValidateEvent";
 export * from "./AutoBePrismaCorrectEvent";

--- a/packages/interface/src/rpc/IAutoBeRpcListener.ts
+++ b/packages/interface/src/rpc/IAutoBeRpcListener.ts
@@ -13,6 +13,7 @@ import {
   AutoBePrismaCompleteEvent,
   AutoBePrismaComponentsEvent,
   AutoBePrismaCorrectEvent,
+  AutoBePrismaInsufficientEvent,
   AutoBePrismaSchemasEvent,
   AutoBePrismaStartEvent,
   AutoBePrismaValidateEvent,
@@ -143,6 +144,26 @@ export interface IAutoBeRpcListener {
    * areas have been fully designed.
    */
   prismaSchemas?(event: AutoBePrismaSchemasEvent): Promise<void>;
+
+  /**
+   * Optional handler for database schema insufficient model creation events.
+   *
+   * Called when the AI function calling process creates fewer models than
+   * expected for a specific business domain during database schema generation.
+   * This event indicates that the schema creation was incomplete and may
+   * require additional iterations or corrective actions to generate the missing
+   * models.
+   *
+   * Client applications can use this event to inform users about partial schema
+   * completion, display which models were successfully created versus which are
+   * still missing, and potentially trigger retry mechanisms or manual
+   * intervention workflows to complete the database design.
+   *
+   * The event provides detailed information about completed models and missing
+   * model names, enabling targeted recovery strategies to address the
+   * insufficient generation and ensure comprehensive database schema coverage.
+   */
+  prismaInsufficient?(event: AutoBePrismaInsufficientEvent): Promise<void>;
 
   /**
    * Optional handler for database schema validation events.
@@ -317,7 +338,7 @@ export interface IAutoBeRpcListener {
   realizeValidate?(event: AutoBeRealizeValidateEvent): Promise<void>;
 
   /**
-   * Mandatory handler for implementation completion events.
+   * Optional handler for implementation completion events.
    *
    * Called when the Realize phase completes successfully, providing the
    * complete working application implementation. Client applications must
@@ -326,12 +347,43 @@ export interface IAutoBeRpcListener {
    */
   realizeComplete?(event: AutoBeRealizeCompleteEvent): Promise<void>;
 
-  realizeTestStart?: (event: AutoBeRealizeTestStartEvent) => Promise<void>;
-  realizeTestReset?: (event: AutoBeRealizeTestResetEvent) => Promise<void>;
-  realizeTestOperation?: (
-    event: AutoBeRealizeTestOperationEvent,
-  ) => Promise<void>;
-  realizeTestComplete?: (
-    event: AutoBeRealizeTestCompleteEvent,
-  ) => Promise<void>;
+  /**
+   * Optional handler for implementation test start events.
+   *
+   * Called when the Realize agent begins running the test suite to validate the
+   * generated implementation, enabling client applications to show that
+   * comprehensive testing is beginning to ensure application quality and
+   * functionality.
+   */
+  realizeTestStart?(event: AutoBeRealizeTestStartEvent): Promise<void>;
+
+  /**
+   * Optional handler for implementation test reset events.
+   *
+   * Called when the test environment is reset between test runs, allowing
+   * client applications to show that clean testing conditions are being
+   * established to ensure reliable and isolated test execution.
+   */
+  realizeTestReset?(event: AutoBeRealizeTestResetEvent): Promise<void>;
+
+  /**
+   * Optional handler for implementation test operation events.
+   *
+   * Called during individual test operation execution, enabling client
+   * applications to provide detailed progress tracking and show which specific
+   * API endpoints and business logic components are being validated through the
+   * comprehensive test suite.
+   */
+  realizeTestOperation?(event: AutoBeRealizeTestOperationEvent): Promise<void>;
+
+  /**
+   * Optional handler for implementation test completion events.
+   *
+   * Called when the complete test suite execution finishes, providing test
+   * results and validation outcomes. Client applications can use this event to
+   * show final quality assurance results and confirm that the generated
+   * application meets all specified requirements and passes comprehensive
+   * validation.
+   */
+  realizeTestComplete?(event: AutoBeRealizeTestCompleteEvent): Promise<void>;
 }

--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundEventMovie.tsx
@@ -32,6 +32,7 @@ export function AutoBePlaygroundEventMovie(
     // PROGRESS EVENTS
     case "prismaComponents":
     case "prismaSchemas":
+    case "prismaInsufficient":
     case "interfaceEndpoints":
     case "interfaceOperations":
     case "interfaceComponents":

--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundProgressEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundProgressEventMovie.tsx
@@ -71,7 +71,7 @@ function getDescription(
     case "prismaSchemas":
       return `Generating Prisma Schemas: ${event.completed} of ${event.total}`;
     case "prismaInsufficient":
-      return `Prisma Insufficient (${event.file.namespace}): ${event.expected.length} of ${event.expected.length}`;
+      return `Prisma Insufficient (${event.completed.namespace}): ${event.expected.length} of ${event.expected.length}`;
     case "testScenario":
       return `Generating Test Plan Completed: ${event.scenarios.length}`;
     case "testWrite":

--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundProgressEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundProgressEventMovie.tsx
@@ -6,6 +6,7 @@ import {
   AutoBeInterfaceEndpointsEvent,
   AutoBeInterfaceOperationsEvent,
   AutoBePrismaComponentsEvent,
+  AutoBePrismaInsufficientEvent,
   AutoBePrismaSchemasEvent,
   AutoBeRealizeProgressEvent,
   AutoBeRealizeTestOperationEvent,
@@ -33,6 +34,7 @@ export namespace AutoBePlaygroundProgressEventMovie {
       | AutoBeAnalyzeWriteEvent
       | AutoBePrismaComponentsEvent
       | AutoBePrismaSchemasEvent
+      | AutoBePrismaInsufficientEvent
       | AutoBeInterfaceEndpointsEvent
       | AutoBeInterfaceOperationsEvent
       | AutoBeInterfaceComponentsEvent
@@ -68,6 +70,8 @@ function getDescription(
       return `Composing Prisma Tables: ${tables} of ${tables}`;
     case "prismaSchemas":
       return `Generating Prisma Schemas: ${event.completed} of ${event.total}`;
+    case "prismaInsufficient":
+      return `Prisma Insufficient (${event.file.namespace}): ${event.expected.length} of ${event.expected.length}`;
     case "testScenario":
       return `Generating Test Plan Completed: ${event.scenarios.length}`;
     case "testWrite":

--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundProgressEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundProgressEventMovie.tsx
@@ -71,7 +71,7 @@ function getDescription(
     case "prismaSchemas":
       return `Generating Prisma Schemas: ${event.completed} of ${event.total}`;
     case "prismaInsufficient":
-      return `Prisma Insufficient (${event.completed.namespace}): ${event.expected.length} of ${event.expected.length}`;
+      return `Prisma Insufficient (${event.completed.namespace}): ${event.missed.length} of ${event.expected.length}`;
     case "testScenario":
       return `Generating Test Plan Completed: ${event.scenarios.length}`;
     case "testWrite":

--- a/packages/playground-ui/src/structures/AutoBePlaygroundListener.ts
+++ b/packages/playground-ui/src/structures/AutoBePlaygroundListener.ts
@@ -38,6 +38,9 @@ export class AutoBePlaygroundListener {
       prismaSchemas: async (event) => {
         this.callback?.(event);
       },
+      prismaInsufficient: async (event) => {
+        this.callback?.(event);
+      },
       prismaComplete: async (event) => {
         this.callback?.(event);
       },

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -22,17 +22,33 @@ export const validate_agent_prisma_main = async (
   if (TestGlobal.env.CHATGPT_API_KEY === undefined) return false;
 
   const { agent } = await prepare_agent_prisma(factory, project);
-  const starts: AutoBePrismaStartEvent[] = [];
+  const time: Date = new Date();
+  const elapsed = () =>
+    (new Date().getTime() - time.getTime()).toLocaleString() + " ms";
+
+  let start: AutoBePrismaStartEvent | null = null;
   agent.on("prismaStart", (event) => {
-    console.log("started");
-    starts.push(event);
+    console.log("  - prisma started:", elapsed());
+    start = event;
+  });
+
+  const components: AutoBePrismaComponentsEvent[] = [];
+  const schemas: AutoBePrismaSchemasEvent[] = [];
+  agent.on("prismaComponents", (event) => {
+    console.log("  - prisma components:", elapsed());
+    components.push(event);
   });
   agent.on("prismaSchemas", (event) => {
-    console.log("progress", event.completed, "of", event.total);
+    console.log(
+      `  - prisma schemas (${event.completed} of ${event.total}):`,
+      elapsed(),
+    );
+    schemas.push(event);
   });
 
   const validates: AutoBePrismaValidateEvent[] = [];
   agent.on("prismaCorrect", async (event) => {
+    console.log("  - prisma corrected:", elapsed());
     await FileSystemIterator.save({
       root: `${TestGlobal.ROOT}/results/${project}/prisma-correct-${validates.length}`,
       files: Object.fromEntries([
@@ -43,6 +59,7 @@ export const validate_agent_prisma_main = async (
     });
   });
   agent.on("prismaValidate", async (event) => {
+    console.log("  - prisma validated:", elapsed());
     validates.push(event);
     await FileSystemIterator.save({
       root: `${TestGlobal.ROOT}/results/${project}/prisma-failure-${validates.length}`,
@@ -51,16 +68,6 @@ export const validate_agent_prisma_main = async (
         ...event.schemas,
       },
     });
-  });
-
-  const components: AutoBePrismaComponentsEvent[] = [];
-  agent.on("prismaComponents", (event) => {
-    components.push(event);
-  });
-
-  const schemas: AutoBePrismaSchemasEvent[] = [];
-  agent.on("prismaSchemas", (event) => {
-    schemas.push(event);
   });
 
   let history: AutoBePrismaHistory | AutoBeAssistantMessageHistory =
@@ -112,7 +119,7 @@ export const validate_agent_prisma_main = async (
       "logs/tokenUsage.json": JSON.stringify(agent.getTokenUsage(), null, 2),
       "logs/components.json": JSON.stringify(components, null, 2),
       "logs/schemas.json": JSON.stringify(schemas, null, 2),
-      "logs/starts.json": JSON.stringify(starts, null, 2),
+      "logs/start.json": JSON.stringify(start, null, 2),
     },
   });
   if (process.argv.includes("--archive"))

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -45,6 +45,12 @@ export const validate_agent_prisma_main = async (
     );
     schemas.push(event);
   });
+  agent.on("prismaInsufficient", (event) => {
+    console.log(
+      `  - prisma insufficient: (${event.completed.namespace}, ${JSON.stringify(event.missed)} of ${JSON.stringify(event.expected)})`,
+      elapsed(),
+    );
+  });
 
   const validates: AutoBePrismaValidateEvent[] = [];
   agent.on("prismaCorrect", async (event) => {

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -40,14 +40,14 @@ export const validate_agent_prisma_main = async (
   });
   agent.on("prismaSchemas", (event) => {
     console.log(
-      `  - prisma schemas (${event.completed} of ${event.total}):`,
+      `  - prisma schemas (${event.file.namespace}, ${event.completed} of ${event.total}):`,
       elapsed(),
     );
     schemas.push(event);
   });
   agent.on("prismaInsufficient", (event) => {
     console.log(
-      `  - prisma insufficient: (${event.completed.namespace}, ${JSON.stringify(event.missed)} of ${JSON.stringify(event.expected)})`,
+      `  - prisma insufficient: (${event.completed.namespace}, ${event.missed.length} of ${event.expected.length})`,
       elapsed(),
     );
   });


### PR DESCRIPTION
This pull request introduces a retry mechanism for processing Prisma schema files and enhances logging in the Prisma validation tests. The changes improve the system's resilience and provide more detailed feedback during test execution.

### Enhancements to Prisma schema processing:

* Added a `retryCount` parameter to the `process` function to limit retries to 3 attempts if processing fails. The retry logic uses a `forceRetry` wrapper to reattempt the operation. (`packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts`, [[1]](diffhunk://#diff-a845895ec2d362db67d593064547c951226e4932be1fa43b640b89e335aa944aR60) [[2]](diffhunk://#diff-a845895ec2d362db67d593064547c951226e4932be1fa43b640b89e335aa944aL107-R110) [[3]](diffhunk://#diff-a845895ec2d362db67d593064547c951226e4932be1fa43b640b89e335aa944aR122-R123)

### Improvements to Prisma validation logging:

* Replaced the `starts` array with a single `start` object to track the most recent Prisma start event. Updated the corresponding log file to `start.json`. (`test/src/features/prisma/internal/validate_agent_prisma_main.ts`, [test/src/features/prisma/internal/validate_agent_prisma_main.tsL115-R122](diffhunk://#diff-0fb56a3035156778e908fc3a0dcbeafaa78c5634810cdc7d43340935055b6facL115-R122))
* Added timestamps to log messages using an `elapsed` function to measure the time since the test started. The new logs provide detailed feedback for events like `prismaStart`, `prismaComponents`, `prismaSchemas`, and `prismaValidate`. (`test/src/features/prisma/internal/validate_agent_prisma_main.ts`, [[1]](diffhunk://#diff-0fb56a3035156778e908fc3a0dcbeafaa78c5634810cdc7d43340935055b6facL25-R51) [[2]](diffhunk://#diff-0fb56a3035156778e908fc3a0dcbeafaa78c5634810cdc7d43340935055b6facR62)
* Removed redundant arrays (`components`, `schemas`) for events already logged and replaced them with more streamlined logging logic. (`test/src/features/prisma/internal/validate_agent_prisma_main.ts`, [test/src/features/prisma/internal/validate_agent_prisma_main.tsL56-L65](diffhunk://#diff-0fb56a3035156778e908fc3a0dcbeafaa78c5634810cdc7d43340935055b6facL56-L65))