### PR TITLE
feat(agent): add total and completed count for analyze progress status

### DIFF
--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyze.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyze.ts
@@ -70,6 +70,11 @@ export const orchestrateAnalyze =
       return history;
     }
 
+    const retryCount = 3 as const;
+    const progress = {
+      total: tableOfContents.length * retryCount,
+      completed: 0,
+    };
     const pointers = await Promise.all(
       tableOfContents.map(async ({ filename }) => {
         const pointer: AutoBeAnalyzePointer = { value: { files: {} } };
@@ -79,7 +84,8 @@ export const orchestrateAnalyze =
           tableOfContents,
           filename,
           roles,
-          3,
+          progress,
+          retryCount,
         );
         return pointer;
       }),

--- a/packages/interface/src/events/AutoBeAnalyzeWriteEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeWriteEvent.ts
@@ -47,4 +47,10 @@ export interface AutoBeAnalyzeWriteEvent
    * process throughout the project lifecycle.
    */
   step: number;
+
+  /** Total number of documents to generate. */
+  total: number;
+
+  /** Number of documents generated so far. */
+  completed: number;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,17 +15,17 @@ catalogs:
       version: 5.2.0
   samchon:
     '@nestia/core':
-      specifier: ^7.1.1
-      version: 7.1.1
+      specifier: ^7.2.1
+      version: 7.2.1
     '@nestia/e2e':
-      specifier: ^7.1.1
-      version: 7.1.1
+      specifier: ^7.2.1
+      version: 7.2.1
     '@nestia/fetcher':
-      specifier: ^7.1.1
-      version: 7.1.1
+      specifier: ^7.2.1
+      version: 7.2.1
     '@nestia/migrate':
-      specifier: ^7.1.1
-      version: 7.1.1
+      specifier: ^7.2.1
+      version: 7.2.1
     '@samchon/openapi':
       specifier: ^4.6.0
       version: 4.6.0
@@ -97,13 +97,13 @@ importers:
         version: link:../../packages/rpc
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.1.1(@nestia/fetcher@7.1.1)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.6.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.6.0(typescript@5.8.3))
+        version: 7.2.1(@nestia/fetcher@7.2.1)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.6.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.6.0(typescript@5.8.3))
       '@nestia/e2e':
         specifier: catalog:samchon
-        version: 7.1.1
+        version: 7.2.1
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.1.1
+        version: 7.2.1
       '@nestjs/common':
         specifier: ^11.1.3
         version: 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -210,10 +210,10 @@ importers:
         version: link:../utils
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.1.1(@nestia/fetcher@7.1.1)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.6.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.6.0(typescript@5.8.3))
+        version: 7.2.1(@nestia/fetcher@7.2.1)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.6.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.6.0(typescript@5.8.3))
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.1.1
+        version: 7.2.1
       '@samchon/openapi':
         specifier: catalog:samchon
         version: 4.6.0
@@ -496,16 +496,16 @@ importers:
         version: link:../packages/utils
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.1.1(@nestia/fetcher@7.1.1)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.6.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.6.0(typescript@5.8.3))
+        version: 7.2.1(@nestia/fetcher@7.2.1)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.6.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.6.0(typescript@5.8.3))
       '@nestia/e2e':
         specifier: catalog:samchon
-        version: 7.1.1
+        version: 7.2.1
       '@nestia/fetcher':
         specifier: catalog:samchon
-        version: 7.1.1
+        version: 7.2.1
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.1.1
+        version: 7.2.1
       '@samchon/openapi':
         specifier: catalog:samchon
         version: 4.6.0
@@ -1317,10 +1317,10 @@ packages:
     resolution: {integrity: sha512-jMxvwzkKzd3cXo2EB9GM2ic0eYo2rP/BS6gJt6HnWbsDO1O8GSD4k7o2Cpr2YERtMpGF/MGcDfsfj2EbQPtrXw==}
     engines: {node: '>= 10'}
 
-  '@nestia/core@7.1.1':
-    resolution: {integrity: sha512-R4xfSqm2v6BfzoUlbjrJ/kLNprPa0G2Wvk396/2sCcbaCzNV4CRfhRLrygylo+XnQZs96ZzcKG15PtKBUVmEEQ==}
+  '@nestia/core@7.2.1':
+    resolution: {integrity: sha512-jJKvr+K9nmX5qMdTIcE/yPIb6h5o9EmwSFkYFAWyV2Itd+l3lhtCI09F8Mx1yaMITqe4e8GdsfZSq30/LSzAHA==}
     peerDependencies:
-      '@nestia/fetcher': '>=7.1.1'
+      '@nestia/fetcher': '>=7.2.1'
       '@nestjs/common': '>=7.0.1'
       '@nestjs/core': '>=7.0.1'
       '@samchon/openapi': '>=4.5.0 <5.0.0'
@@ -1328,14 +1328,14 @@ packages:
       rxjs: '>=6.0.3'
       typia: '>=9.5.0 <10.0.0'
 
-  '@nestia/e2e@7.1.1':
-    resolution: {integrity: sha512-w4vBrLe7WLtGERtW8nL8NIXAhi2t9Z/n7vcItcpCAsCT1VVDxdMak6MZA8tSL61Jw6aGzjSArpSy3PRs6HPRWQ==}
+  '@nestia/e2e@7.2.1':
+    resolution: {integrity: sha512-daXic40btgRja9m9NFusEp5FQIEWg3W71oMKEP5XFXwSdlrsRVpsj8ytzyI8A0DeCayPA68UJdiGl9+IERplRw==}
 
-  '@nestia/fetcher@7.1.1':
-    resolution: {integrity: sha512-0ukXiupR7qCxBRP+zfZV2gV1T+p9Xlppb884MNylC0dsfKIAXQChRGgwNsYrOLAufH//3i6NW7mbdjEvsQkgIw==}
+  '@nestia/fetcher@7.2.1':
+    resolution: {integrity: sha512-we5GEI16SmMiZyq6/k5wSYveDSDMjP+4rF6TTFAgn0tR6uB9BZFapqdidlse1bxtSvd8fsP1SGEVbMe3hkyqew==}
 
-  '@nestia/migrate@7.1.1':
-    resolution: {integrity: sha512-3QPSrMM+7zivMKSwfqptBnDHByOdG4r8P/gyRlHjDfCKHsBl9UXCcE4QClBEkOxRK+A7icIUzGFEyolla9e1gg==}
+  '@nestia/migrate@7.2.1':
+    resolution: {integrity: sha512-gdUsY2MWuaDo8tHWOaaKmDcKL28eLzuu5fCqRDj03hmeTQAbjSUDbCiq105WprnjUi/SQEVNvv+kq7FkLQV8lw==}
     hasBin: true
 
   '@nestjs/common@11.1.3':
@@ -5611,9 +5611,9 @@ snapshots:
       '@napi-rs/simple-git-win32-arm64-msvc': 0.1.19
       '@napi-rs/simple-git-win32-x64-msvc': 0.1.19
 
-  '@nestia/core@7.1.1(@nestia/fetcher@7.1.1)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.6.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.6.0(typescript@5.8.3))':
+  '@nestia/core@7.2.1(@nestia/fetcher@7.2.1)(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@samchon/openapi@4.6.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.6.0(typescript@5.8.3))':
     dependencies:
-      '@nestia/fetcher': 7.1.1
+      '@nestia/fetcher': 7.2.1
       '@nestjs/common': 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@samchon/openapi': 4.6.0
@@ -5631,13 +5631,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@nestia/e2e@7.1.1': {}
+  '@nestia/e2e@7.2.1': {}
 
-  '@nestia/fetcher@7.1.1':
+  '@nestia/fetcher@7.2.1':
     dependencies:
       '@samchon/openapi': 4.6.0
 
-  '@nestia/migrate@7.1.1':
+  '@nestia/migrate@7.2.1':
     dependencies:
       '@samchon/openapi': 4.6.0
       commander: 10.0.0


### PR DESCRIPTION
This pull request introduces progress tracking for document analysis and updates dependencies in the project. The most significant changes include adding a progress object to track the status of document generation, modifying related functions to utilize this progress object, and upgrading the `@nestia` dependencies in the `pnpm-lock.yaml` file.

### Progress tracking for document analysis:
* Added a `progress` object to track the total and completed number of documents being analyzed. This includes updates to the `orchestrateAnalyze` function in `orchestrateAnalyze.ts` and the `writeDocumentUntilReviewPassed` function in `writeDocumentUntilReviewPassed.ts` to pass and update the `progress` object. [[1]](diffhunk://#diff-b9d5e2b6585091c8e6fdb8862e5794072327782b6dc63890e052a4c11166768bR73-R77) [[2]](diffhunk://#diff-b9d5e2b6585091c8e6fdb8862e5794072327782b6dc63890e052a4c11166768bL82-R88) [[3]](diffhunk://#diff-da9a00369a5e0e1def3a648523c1d6292c3361b1d2b98454bf5cf21422ff9214R19) [[4]](diffhunk://#diff-da9a00369a5e0e1def3a648523c1d6292c3361b1d2b98454bf5cf21422ff9214R42-R56)
* Extended the `AutoBeAnalyzeWriteEvent` interface to include `total` and `completed` fields for progress tracking.

### Dependency updates:
* Upgraded `@nestia/core`, `@nestia/e2e`, `@nestia/fetcher`, and `@nestia/migrate` from version `7.1.1` to `7.2.1` in the `pnpm-lock.yaml` file. This affects multiple sections, including `catalogs`, `importers`, `packages`, and `snapshots`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18-R28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL100-R106) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL213-R216) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL499-R508) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1320-R1338) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5614-R5616) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5634-R5640)