### PR TITLE
fix(website): `AutoBeRoadmapDiagram.tsx` to read exact diagram

### DIFF
--- a/website/src/components/AutoBeRoadmapDiagram.tsx
+++ b/website/src/components/AutoBeRoadmapDiagram.tsx
@@ -8,6 +8,7 @@ export const AutoBeRoadmapDiagram = async () => {
   const content: string = [
     "```mermaid",
     (await getLocalSourceFile("README.md"))
+      .split("## Roadmap Schedule")[1]
       .split("```mermaid")[1]
       .split("```")[0]
       .trim(),


### PR DESCRIPTION
This pull request updates the `AutoBeRoadmapDiagram` component to refine how the roadmap schedule is extracted from the `README.md` file. The change ensures that the relevant section is specifically targeted for processing.

* [`website/src/components/AutoBeRoadmapDiagram.tsx`](diffhunk://#diff-e2449ebd0f2fba6fdec7cf861af75877457563b6578863ae43f0f8c8b33b2fbfR11): Adjusted the parsing logic to split the content by "## Roadmap Schedule" before further processing, ensuring the roadmap schedule is accurately extracted.