### PR TITLE
fix(playground): `pnpm run playground`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "bumpp": "^10.1.1",
     "js-yaml": "^4.1.0",
     "prettier": "^3.5.3",
-    "prettier-plugin-jsdoc": "^1.3.2"
+    "prettier-plugin-jsdoc": "^1.3.2",
+    "rimraf": "^6.0.1"
   },
   "changelogithub": {
     "types": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       prettier-plugin-jsdoc:
         specifier: ^1.3.2
         version: 1.3.2(prettier@3.5.3)
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
 
   internals/website-examples:
     dependencies:


### PR DESCRIPTION
This pull request introduces a small addition to the project's dependencies by including the `rimraf` package. The change ensures compatibility with the project's existing setup and updates the lock file accordingly.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32-R33): Added `rimraf` version `^6.0.1` to the dependencies list.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR83-R85): Added `rimraf` version `6.0.1` under `importers`.