### PR TITLE
fix(agent): resolve dependencies

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -39,7 +39,6 @@
   },
   "devDependencies": {
     "@autobe/compiler": "workspace:^",
-    "@autobe/filesystem": "workspace:^",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.2",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -38,7 +38,6 @@
     "typia": "catalog:samchon"
   },
   "devDependencies": {
-    "@autobe/filesystem": "workspace:^",
     "@types/node": "^22.15.3",
     "rimraf": "^6.0.1",
     "sync-request": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,33 +14,9 @@ catalogs:
       specifier: ^5.2.0
       version: 5.2.0
   samchon:
-    '@nestia/core':
-      specifier: ^7.3.0
-      version: 7.3.0
-    '@nestia/e2e':
-      specifier: ^7.3.0
-      version: 7.3.0
-    '@nestia/fetcher':
-      specifier: ^7.3.0
-      version: 7.3.0
-    '@nestia/migrate':
-      specifier: ^7.3.0
-      version: 7.3.0
     '@samchon/openapi':
       specifier: ^4.6.0
       version: 4.6.0
-    embed-prisma:
-      specifier: ^1.1.0
-      version: 1.1.0
-    embed-typescript:
-      specifier: ^1.0.1
-      version: 1.0.1
-    prisma-markdown:
-      specifier: ^3.0.0
-      version: 3.0.1
-    tgrid:
-      specifier: ^1.2.0
-      version: 1.2.0
     tstl:
       specifier: ^3.0.0
       version: 3.0.0
@@ -169,9 +145,6 @@ importers:
       '@autobe/compiler':
         specifier: workspace:^
         version: link:../compiler
-      '@autobe/filesystem':
-        specifier: workspace:^
-        version: link:../filesystem
       '@rollup/plugin-json':
         specifier: ^6.1.0
         version: 6.1.0(rollup@4.41.0)


### PR DESCRIPTION
This pull request removes the dependency on `@autobe/filesystem` across multiple packages and updates the `pnpm-lock.yaml` file to reflect these changes. The most important changes are as follows:

### Dependency Removal

* Removed `@autobe/filesystem` from the `devDependencies` in `packages/agent/package.json`.
* Removed `@autobe/filesystem` from the `devDependencies` in `packages/compiler/package.json`.

### Lockfile Updates

* Removed references to `@autobe/filesystem` under the `importers` section in `pnpm-lock.yaml`.
* Cleaned up unrelated dependencies under the `catalogs:samchon` section in `pnpm-lock.yaml`, including dependencies like `@nestia/core`, `embed-prisma`, and others.