### PR TITLE
fix(filesystem): for npm publishing

### DIFF
--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -18,5 +18,17 @@
     "@types/node": "^22.15.19",
     "rimraf": "^6.0.1",
     "typescript": "catalog:typescript"
+  },
+  "files": [
+    "lib",
+    "src",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "lib/index.js",
+    "typings": "lib/index.d.ts"
   }
 }

--- a/packages/filesystem/tsconfig.json
+++ b/packages/filesystem/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../internals/config/tsconfig.json",
   "compilerOptions": {
-    "noEmit": true,
+    "outDir": "lib",
   },
   "include": ["src"],
 }


### PR DESCRIPTION
This pull request introduces changes to prepare the `filesystem` package for publication. The updates include specifying the files to be included in the package, configuring publishing options, and modifying TypeScript settings to generate output files.

### Publication preparation:

* [`packages/filesystem/package.json`](diffhunk://#diff-8b4d86e418f80903f5df96d1057f4a5584307947d24b0dc96d4836c762278b76R21-R32): Added a `files` array to specify which files to include in the package, and a `publishConfig` object to set the package's publishing options, such as public access and entry points for JavaScript and TypeScript.

### TypeScript configuration:

* [`packages/filesystem/tsconfig.json`](diffhunk://#diff-f15e1d8604bd7474d6ba12fd733aa3dde9f137495232767fba5a905d585650feL4-R4): Changed the `compilerOptions.noEmit` setting to `outDir: "lib"` to enable TypeScript to generate compiled output in the `lib` directory.