### PR TITLE
feat(ui): remove margin and padding

### DIFF
--- a/packages/playground-ui/index.html
+++ b/packages/playground-ui/index.html
@@ -8,7 +8,7 @@
     <title>AutoBE Playground</title>
   </head>
 
-  <body>
+  <body style="margin: 0px; padding: 0px">
     <div id="root" style="width: 100%; height: 100%"></div>
     <script type="module" src="./src/main.tsx"></script>
   </body>

--- a/packages/playground-ui/replay.html
+++ b/packages/playground-ui/replay.html
@@ -8,7 +8,7 @@
     <title>AutoBE Playground</title>
   </head>
 
-  <body>
+  <body style="margin: 0px; padding: 0px">
     <div id="root" style="width: 100%; height: 100%"></div>
     <script type="module" src="./src/replay.tsx"></script>
   </body>

--- a/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx
+++ b/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx
@@ -48,7 +48,7 @@ export function AutoBePlaygroundChatMovie(
   const [tokenUsage, setTokenUsage] = useState<IAutoBeTokenUsageJson | null>(
     null,
   );
-  const [height, setHeight] = useState(122);
+  const [height, setHeight] = useState(130);
   const [enabled, setEnabled] = useState(true);
   const [openSide, setOpenSide] = useState(false);
 
@@ -178,7 +178,7 @@ export function AutoBePlaygroundChatMovie(
   );
   return (
     <>
-      <AppBar position="relative" component="div">
+      <AppBar position="relative" component="div" ref={upperDivRef}>
         <Toolbar>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             {props.title ?? "AutoBE Playground"}


### PR DESCRIPTION
This pull request introduces small changes to the `playground-ui` package to improve layout styling and functionality. The most important changes include adding inline styles to `body` tags for consistent margin and padding, adjusting the default height state in the chat movie component, and adding a `ref` to the `AppBar` component for future functionality.

### Layout improvements:

* [`packages/playground-ui/index.html`](diffhunk://#diff-1895190307b91deb5670bb9d6035d572749c6c49280716709dc62c416827c5eaL11-R11): Added `margin: 0px` and `padding: 0px` styles to the `body` tag to ensure consistent layout.
* [`packages/playground-ui/replay.html`](diffhunk://#diff-5123afd92309186cc0fa19e23c2d1034d3fdba5e7c6ddecef2ca5ef509af607aL11-R11): Added `margin: 0px` and `padding: 0px` styles to the `body` tag to ensure consistent layout.

### Component adjustments:

* [`packages/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx`](diffhunk://#diff-b27f9cd729f8d1a53a8258034ec7af32ca93380217ec7e434659b0ed8bf4077dL51-R51): Updated the default `height` state from `122` to `130` for better layout handling.
* [`packages/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx`](diffhunk://#diff-b27f9cd729f8d1a53a8258034ec7af32ca93380217ec7e434659b0ed8bf4077dL181-R181): Added a `ref` to the `AppBar` component to enable future functionality or interactions.