### PR TITLE
feat(prompts): add EARS requirements syntax guidelines to analyze prompts

### DIFF
--- a/packages/agent/prompts/ANALYZE.md
+++ b/packages/agent/prompts/ANALYZE.md
@@ -36,6 +36,21 @@ Documents and descriptions should be tailored to the language of the user.
 Please refer to the document below. The document below has a total of 1,500 characters and should be longer.
 Never insert a question in the document.
 
+Any part of your documentation that can be written in EARS(Easy Approach to Requirements Syntax) must be written in EARS(Easy Approach to Requirements Syntax).
+
+
+## EARS Format Requirements
+
+* **EARS (Easy Approach to Requirements Syntax)** is a structured approach to writing requirements clearly and concisely, reducing ambiguity in software and system engineering. Requirements that can be expressed in EARS must use one of the following templates:  
+  - **Ubiquitous**: "THE <system> SHALL <function>." (For always-applicable requirements, e.g., "The system shall record all user inputs.")  
+  - **Event-driven**: "WHEN <trigger>, THE <system> SHALL <function>." (For event-triggered actions, e.g., "When the user presses the 'Save' button, the system shall save the current document.")  
+  - **State-driven**: "WHILE <state>, THE <system> SHALL <function>." (For state-specific actions, e.g., "While the system is in 'Idle' mode, the system shall display the main menu.")  
+  - **Unwanted Behavior**: "IF <condition>, THEN THE <system> SHALL <function>." (For handling undesirable situations, e.g., "If the battery level is below 5%, then the system shall enter low-power mode.")  
+  - **Optional Features**: "WHERE <feature/condition>, THE <system> SHALL <function>." (For conditional features, e.g., "Where the premium mode is activated, the system shall provide advanced analytics.")  
+- **Instruct the analyze agent to use EARS for all applicable requirements, ensuring clarity, consistency, and testability.**  
+- If a requirement is ambiguous or not in EARS format when it could be, **command the analyze agent to rewrite it using the appropriate EARS template.**  
+- Ensure conditions, subjects, and actions in EARS-formatted requirements are specific and unambiguous.
+
 
 # abort
 If you have no further requests or questions, immediately call the 'abort' function instead of replying with text. Never respond with additional text.

--- a/packages/agent/prompts/ANALYZE_REVIEWER.md
+++ b/packages/agent/prompts/ANALYZE_REVIEWER.md
@@ -37,6 +37,7 @@
   **instruct the analyze agent to expand the content within the current page accordingly.**
 * If hyperlinks point to content not included in the current page,  
   **instruct the analyze agent to add a new section with the hyperlink’s title under the appropriate heading within the same page.**
+* The requirements statement must be written in the **EARS(Easy Approach to Requirements Syntax)**.
 
 ## If the Document is Sufficient
 


### PR DESCRIPTION
This pull request introduces changes to enforce the use of the EARS (Easy Approach to Requirements Syntax) format for writing requirements in documentation. The updates aim to improve clarity, reduce ambiguity, and ensure consistency in requirements statements.

### Enhancements to documentation requirements:

* [`packages/agent/prompts/ANALYZE.md`](diffhunk://#diff-4783a3252c3fb6d13b3786bbf3fc092427e627ba26c58c8ccd9984b9b609b1daR39-R53): Added a detailed explanation of the EARS format, including five structured templates (Ubiquitous, Event-driven, State-driven, Unwanted Behavior, Optional Features) and instructions for using EARS for all applicable requirements. Also included guidelines for rewriting ambiguous requirements into EARS format.
* [`packages/agent/prompts/ANALYZE_REVIEWER.md`](diffhunk://#diff-21993bfd5ba3398407d0cf5c8cb7147ebd90fc08a49424f9689055049f315200R40): Updated to mandate that all requirements statements must be written in the EARS format.