### PR TITLE
refactor(agent): add comments and util function `arrayToRecord`

### DIFF
--- a/packages/agent/src/orchestrate/realize/structures/IAutoBeRealizeCompile.ts
+++ b/packages/agent/src/orchestrate/realize/structures/IAutoBeRealizeCompile.ts
@@ -4,42 +4,60 @@ import {
 } from "@autobe/interface";
 import { tags } from "typia";
 
-import { IAutoBeRealizeCoderApplication } from "./IAutoBeRealizeCoderApplication";
 import { FAILED } from "./IAutoBeRealizeFailedSymbol";
 
 export namespace IAutoBeRealizeCompile {
-  export interface Success {
-    type: "success";
+  type IBase<T extends "success" | "failed"> = {
+    type: T;
+  };
+
+  interface IOperation {
+    /**
+     * Operation: An object containing the function specification including the
+     * endpoint
+     */
     op: AutoBeOpenApi.IOperation;
-    result: Pick<
-      IAutoBeRealizeCoderApplication.RealizeCoderOutput,
-      "filename" | "implementationCode"
-    > & {
-      /** Function name */
-      name: string;
-    };
   }
 
-  export interface Fail {
-    type: "failed";
-    op: AutoBeOpenApi.IOperation;
+  interface SuccessResult {
+    /** The name of the file where the implementation will be written */
+    filename: string;
+    /** The generated implementation code for the function */
+    implementationCode: string;
+    /** Function name */
+    name: string;
+  }
+
+  export interface Success extends IBase<"success">, IOperation {
+    result: SuccessResult;
+  }
+
+  export interface Fail extends IBase<"failed">, IOperation {
     result: FAILED;
   }
 
-  export type FileContentMap = Record<
-    string,
-    {
-      result: "failed" | "success";
-      content: string;
-      role?: (string & tags.MinLength<1>) | null;
-      endpoint?: AutoBeOpenApi.IEndpoint;
-      location?: string;
-      name?: string;
-    }
-  >;
+  export interface FileContentMapEntry {
+    result: "failed" | "success";
+    content: string;
+    role?: (string & tags.MinLength<1>) | null;
+    endpoint?: AutoBeOpenApi.IEndpoint;
+    location?: string;
+    name?: string;
+  }
+
+  export type FileContentMap = Record<string, FileContentMapEntry>;
 
   export interface CompileDiagnostics {
+    /**
+     * Array containing all errors including previous attempts. Includes errors
+     * that have already been resolved. Used to preserve error context and
+     * identify recurring error patterns.
+     */
     total: IAutoBeTypeScriptCompileResult.IDiagnostic[];
+    /**
+     * Array containing errors from the most recent code compilation. These are
+     * the errors that need to be resolved in the current iteration.
+     */
     current: IAutoBeTypeScriptCompileResult.IDiagnostic[];
   }
 }

--- a/packages/agent/src/utils/arrayToRecord.ts
+++ b/packages/agent/src/utils/arrayToRecord.ts
@@ -1,0 +1,49 @@
+/**
+ * Converts an array of key-value pairs (entries) into a Record.
+ *
+ * @param entries - Array of [key, value] tuples
+ * @returns Record object from the entries
+ */
+export function arrayToRecord<V>(
+  entries: Array<[string, V]>,
+): Record<string, V>;
+
+/**
+ * Converts an array of objects into a Record using specified key and value
+ * properties.
+ *
+ * @param items - Array of items to convert
+ * @param keyProp - Property name to use as the key
+ * @param valueProp - Property name to use as the value
+ * @returns Record object with the extracted key-value pairs
+ */
+export function arrayToRecord<T, K extends keyof T, V extends keyof T>(
+  items: T[],
+  keyProp: K,
+  valueProp: V,
+): Record<string, T[V]>;
+
+export function arrayToRecord<T, K extends keyof T, V extends keyof T>(
+  items: T[] | Array<[string, any]>,
+  keyProp?: K,
+  valueProp?: V,
+): Record<string, any> {
+  // Handle entries format [string, value][]
+  if (items.length > 0 && Array.isArray(items[0]) && items[0].length === 2) {
+    return (items as Array<[string, any]>).reduce(
+      (acc, [key, value]) => Object.assign(acc, { [key]: value }),
+      {},
+    );
+  }
+
+  // Handle object array format with key and value properties
+  if (keyProp !== undefined && valueProp !== undefined) {
+    return (items as T[])
+      .map((item) => ({
+        [String(item[keyProp])]: item[valueProp],
+      }))
+      .reduce((acc, cur) => Object.assign(acc, cur), {});
+  }
+
+  throw new Error("Invalid arguments for arrayToRecord");
+}

--- a/test/src/features/realize/internal/validate_agent_realize_coder.ts
+++ b/test/src/features/realize/internal/validate_agent_realize_coder.ts
@@ -1,6 +1,7 @@
 import { orchestrateRealizeAuthorization } from "@autobe/agent/src/orchestrate/realize/orchestrateRealizeAuthorization";
 import { InternalFileSystem } from "@autobe/agent/src/orchestrate/realize/utils/InternalFileSystem";
 import { writeCodeUntilCompilePassed } from "@autobe/agent/src/orchestrate/realize/writeCodeUntilCompilePassed";
+import { arrayToRecord } from "@autobe/agent/src/utils/arrayToRecord";
 import { FileSystemIterator } from "@autobe/filesystem";
 import { AutoBeEvent, AutoBeRealizeFunction } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
@@ -53,11 +54,7 @@ export const validate_agent_realize_coder = async (
 
   const result: AutoBeRealizeFunction[] = await go();
 
-  const codes = result.reduce<Record<string, string>>((acc, cur) => {
-    return Object.assign(acc, {
-      [cur.location]: cur.content,
-    });
-  }, {});
+  const codes = arrayToRecord(result, "location", "content");
 
   const histories = agent.getHistories();
   const prisma = agent.getContext().state().prisma?.compiled;


### PR DESCRIPTION
  Created a new utility function that handles two common patterns for converting arrays to
  Records:

  1. Object array conversion: Extracts key-value pairs from objects using specified properties
  arrayToRecord(items, "id", "value") // { [item.id]: item.value }
  2. Entry array conversion: Directly converts [key, value][] arrays (e.g., from Object.entries)
  arrayToRecord(Object.entries(obj)) // Reconstructs the object

  Refactored existing code

  - Replaced manual map + reduce patterns with arrayToRecord calls
  - Simplified authorization payload processing
  - Cleaned up file entries filtering and conversion

  Benefits

  - DRY principle: Eliminated duplicate array-to-Record conversion logic
  - Type safety: Maintained full TypeScript type inference with generics
  - Flexibility: Single function handles multiple use cases through overloading
  - Readability: More declarative code that clearly expresses intent