### PR TITLE
fix(agent): update tokenUsage assignment to use instance variable

### DIFF
--- a/packages/agent/src/AutoBeAgent.ts
+++ b/packages/agent/src/AutoBeAgent.ts
@@ -147,7 +147,7 @@ export class AutoBeAgent<Model extends ILlmSchema.Model>
           execute: () => transformFacadeStateMessage(this.state_),
         },
       },
-      tokenUsage: props.tokenUsage?.facade,
+      tokenUsage: this.usage_.facade,
       controllers: [
         createAutoBeController({
           model: props.model,


### PR DESCRIPTION
This pull request includes a small change to the `AutoBeAgent` class in `packages/agent/src/AutoBeAgent.ts`. The change updates the `tokenUsage` property to use `this.usage_.facade` instead of `props.tokenUsage?.facade`.