### PR TITLE
feat(agent): add total token usage tracking to AutoBeTokenUsage class

### DIFF
--- a/packages/agent/src/context/AutoBeTokenUsage.ts
+++ b/packages/agent/src/context/AutoBeTokenUsage.ts
@@ -4,6 +4,7 @@ import { IAutoBeTokenUsageJson } from "@autobe/interface";
 import { IAutoBeApplication } from "./IAutoBeApplication";
 
 export class AutoBeTokenUsage {
+  public readonly total: AgenticaTokenUsage;
   public readonly facade: AgenticaTokenUsage;
   public readonly analyze: AgenticaTokenUsage;
   public readonly prisma: AgenticaTokenUsage;
@@ -13,6 +14,7 @@ export class AutoBeTokenUsage {
 
   public constructor(props?: IAutoBeTokenUsageJson) {
     if (props === undefined) {
+      this.total = new AgenticaTokenUsage();
       this.facade = new AgenticaTokenUsage();
       this.analyze = new AgenticaTokenUsage();
       this.prisma = new AgenticaTokenUsage();
@@ -22,6 +24,7 @@ export class AutoBeTokenUsage {
       return;
     }
 
+    this.total = new AgenticaTokenUsage(props.total);
     this.facade = new AgenticaTokenUsage(props.facade);
     this.analyze = new AgenticaTokenUsage(props.analyze);
     this.prisma = new AgenticaTokenUsage(props.prisma);
@@ -34,7 +37,7 @@ export class AutoBeTokenUsage {
     usage: AgenticaTokenUsage,
     additionalStages: (keyof IAutoBeApplication)[] = [],
   ) {
-    this.facade.increment(usage);
+    this.total.increment(usage);
     additionalStages.forEach((stage) => {
       this[stage].increment(usage);
     });
@@ -49,6 +52,7 @@ export class AutoBeTokenUsage {
 
   public static plus(usageA: AutoBeTokenUsage, usageB: AutoBeTokenUsage) {
     return new AutoBeTokenUsage({
+      total: AgenticaTokenUsage.plus(usageA.total, usageB.total),
       facade: AgenticaTokenUsage.plus(usageA.facade, usageB.facade),
       analyze: AgenticaTokenUsage.plus(usageA.analyze, usageB.analyze),
       prisma: AgenticaTokenUsage.plus(usageA.prisma, usageB.prisma),
@@ -60,6 +64,7 @@ export class AutoBeTokenUsage {
 
   public toJSON(): IAutoBeTokenUsageJson {
     return {
+      total: this.total.toJSON(),
       facade: this.facade.toJSON(),
       analyze: this.analyze.toJSON(),
       prisma: this.prisma.toJSON(),
@@ -70,8 +75,16 @@ export class AutoBeTokenUsage {
   }
 
   /** @internal */
-  private static keys(): ("facade" | keyof IAutoBeApplication)[] {
-    return ["facade", "analyze", "prisma", "interface", "test", "realize"];
+  private static keys(): ("total" | "facade" | keyof IAutoBeApplication)[] {
+    return [
+      "total",
+      "facade",
+      "analyze",
+      "prisma",
+      "interface",
+      "test",
+      "realize",
+    ];
   }
 }
 

--- a/packages/interface/src/json/IAutoBeTokenUsageJson.ts
+++ b/packages/interface/src/json/IAutoBeTokenUsageJson.ts
@@ -26,6 +26,9 @@ export interface IAutoBeTokenUsageJson {
    * development pipeline. This aggregate view enables overall cost assessment
    * and resource utilization analysis for complete project automation.
    */
+  total: IAutoBeInternalTokenUsageJson;
+
+  /** Token usage for the facade agent */
   facade: IAutoBeInternalTokenUsageJson;
 
   /** Token usage for the analysis phase */

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -134,9 +134,10 @@ async function main(): Promise<void> {
 
   console.log("Token Usage");
   console.table({
-    Total: tokenUsage.facade.aggregate.total.toLocaleString("en-US"),
-    Input: tokenUsage.facade.aggregate.input.total.toLocaleString("en-US"),
-    Output: tokenUsage.facade.aggregate.output.total.toLocaleString("en-US"),
+    Total: tokenUsage.total.aggregate.total.toLocaleString("en-US"),
+    Input: tokenUsage.total.aggregate.input.total.toLocaleString("en-US"),
+    Output: tokenUsage.total.aggregate.output.total.toLocaleString("en-US"),
+    Facade: tokenUsage.facade.aggregate.total.toLocaleString("en-US"),
     Analyze: tokenUsage.analyze.aggregate.total.toLocaleString("en-US"),
     Prisma: tokenUsage.prisma.aggregate.total.toLocaleString("en-US"),
     Interface: tokenUsage.interface.aggregate.total.toLocaleString("en-US"),


### PR DESCRIPTION
This pull request introduces the concept of a `total` token usage aggregate to the `AutoBeTokenUsage` class, enabling a more comprehensive view of overall token utilization across different stages. The changes involve updates to the class implementation, its JSON interface, and related test code.

### Enhancements to `AutoBeTokenUsage`:

* Added a new `total` property to the `AutoBeTokenUsage` class, initialized in both the default and parameterized constructors. This property aggregates token usage across all stages. (`[[1]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971R7)`, `[[2]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971R17)`, `[[3]](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971R27)`)
* Updated the `increment` method to include the `total` property, ensuring that token usage is aggregated correctly when incrementing usage. (`[packages/agent/src/context/AutoBeTokenUsage.tsL37-R40](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971L37-R40)`)
* Modified the `plus` method to combine the `total` usage from two `AutoBeTokenUsage` instances. (`[packages/agent/src/context/AutoBeTokenUsage.tsR55](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971R55)`)
* Updated the `toJSON` method to include the `total` property in the serialized output. (`[packages/agent/src/context/AutoBeTokenUsage.tsR67](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971R67)`)
* Adjusted the internal `keys` method to include `total` as part of the static keys array. (`[packages/agent/src/context/AutoBeTokenUsage.tsL73-R87](diffhunk://#diff-8b1f41eb75b70e1c035e2a3f31e2e4e0677713cbcbbba0d203e3b416b453f971L73-R87)`)

### Updates to JSON Interface:

* Added a `total` field to the `IAutoBeTokenUsageJson` interface to support serialization and deserialization of the new aggregate property. (`[packages/interface/src/json/IAutoBeTokenUsageJson.tsR29-R31](diffhunk://#diff-8ee61647339068eaeb151201202a8466609805257a9b959a01ffdb2a848ac8a9R29-R31)`)

### Changes to Test Code:

* Updated the test output in `test/src/index.ts` to include the `total` aggregate alongside other stages, ensuring the new property is reflected in the token usage summary. (`[test/src/index.tsL137-R140](diffhunk://#diff-ecfaaff51b5918af495fc6567267f0209e361d75365794b43290a19884354d09L137-R140)`)