### PR TITLE
feat(*): fix license in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,7 @@ What improvements this brings
 - Check `/test/scripts/` for specific testing scenarios
 
 ### Repository Information
-- **License**: MIT
+- **License**: AGPL 3.0
 - **Maintainer**: Wrtn Technologies
 - **Repository**: https://github.com/wrtnlabs/autobe
 - **Documentation**: https://wrtnlabs.io/autobe/docs/


### PR DESCRIPTION
This pull request updates the licensing information in the `CLAUDE.md` file to reflect a change in the project's license.

* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L263-R263): Updated the license from MIT to AGPL 3.0 under the "Repository Information" section.