### PR TITLE
feat(compiler): prettier prisma description

### DIFF
--- a/test/src/TestFactory.ts
+++ b/test/src/TestFactory.ts
@@ -1,7 +1,7 @@
 import { AutoBeAgent } from "@autobe/agent";
-import { AutoBeCompiler } from "@autobe/compiler";
 import {
   AutoBeHistory,
+  IAutoBeCompiler,
   IAutoBeCompilerListener,
   IAutoBeTokenUsageJson,
 } from "@autobe/interface";
@@ -12,5 +12,5 @@ export interface TestFactory {
     histories: AutoBeHistory[],
     tokenUsage?: IAutoBeTokenUsageJson,
   ) => AutoBeAgent<ILlmSchema.Model>;
-  createCompiler: (listener?: IAutoBeCompilerListener) => AutoBeCompiler;
+  createCompiler: (listener?: IAutoBeCompilerListener) => IAutoBeCompiler;
 }

--- a/test/src/features/compiler/internal/prepare_compiler_test.ts
+++ b/test/src/features/compiler/internal/prepare_compiler_test.ts
@@ -1,11 +1,14 @@
-import { AutoBeCompiler } from "@autobe/compiler";
-import { AutoBeOpenApi, AutoBeTestScenario } from "@autobe/interface";
+import {
+  AutoBeOpenApi,
+  AutoBeTestScenario,
+  IAutoBeCompiler,
+} from "@autobe/interface";
 import { OpenApi } from "@samchon/openapi";
 
 import { TestFactory } from "../../../TestFactory";
 
 export const prepare_compiler_test = async (factory: TestFactory) => {
-  const compiler: AutoBeCompiler = factory.createCompiler();
+  const compiler: IAutoBeCompiler = factory.createCompiler();
   const document: AutoBeOpenApi.IDocument = await compiler.interface.invert(
     OpenApi.convert(
       await fetch(

--- a/test/src/features/compiler/test_compiler_facade_bbs.ts
+++ b/test/src/features/compiler/test_compiler_facade_bbs.ts
@@ -1,6 +1,6 @@
-import { AutoBeCompiler } from "@autobe/compiler";
 import { RepositoryFileSystem } from "@autobe/filesystem";
 import {
+  IAutoBeCompiler,
   IAutoBePrismaCompileResult,
   IAutoBeTypeScriptCompileResult,
 } from "@autobe/interface";
@@ -12,7 +12,7 @@ import { TestFactory } from "../../TestFactory";
 export const test_compiler_facade_bbs = async (
   factory: TestFactory,
 ): Promise<void> => {
-  const compiler: AutoBeCompiler = factory.createCompiler();
+  const compiler: IAutoBeCompiler = factory.createCompiler();
   const prisma: IAutoBePrismaCompileResult = await compiler.prisma.compile({
     files: await RepositoryFileSystem.prisma("samchon", "bbs-backend"),
   });

--- a/test/src/features/compiler/test_compiler_facade_shopping.ts
+++ b/test/src/features/compiler/test_compiler_facade_shopping.ts
@@ -1,6 +1,6 @@
-import { AutoBeCompiler } from "@autobe/compiler";
 import { RepositoryFileSystem } from "@autobe/filesystem";
 import {
+  IAutoBeCompiler,
   IAutoBePrismaCompileResult,
   IAutoBeTypeScriptCompileResult,
 } from "@autobe/interface";
@@ -12,7 +12,7 @@ import { TestFactory } from "../../TestFactory";
 export const test_compiler_facade_shopping = async (
   factory: TestFactory,
 ): Promise<void> => {
-  const compiler: AutoBeCompiler = factory.createCompiler();
+  const compiler: IAutoBeCompiler = factory.createCompiler();
   const prisma: IAutoBePrismaCompileResult = await compiler.prisma.compile({
     files: await RepositoryFileSystem.prisma("samchon", "shopping-backend"),
   });

--- a/test/src/features/compiler/test_compiler_interface_name.ts
+++ b/test/src/features/compiler/test_compiler_interface_name.ts
@@ -1,5 +1,4 @@
-import { AutoBeCompiler } from "@autobe/compiler";
-import { AutoBeOpenApi } from "@autobe/interface";
+import { AutoBeOpenApi, IAutoBeCompiler } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
 import typia from "typia";
 
@@ -8,7 +7,7 @@ import { TestFactory } from "../../TestFactory";
 export const test_compiler_interface_name = async (
   factory: TestFactory,
 ): Promise<void> => {
-  const compiler: AutoBeCompiler = factory.createCompiler();
+  const compiler: IAutoBeCompiler = factory.createCompiler();
   const result: Record<string, string> =
     await compiler.interface.write(DOCUMENT);
   const content: string =

--- a/test/src/features/compiler/test_compiler_interface_write.ts
+++ b/test/src/features/compiler/test_compiler_interface_write.ts
@@ -1,6 +1,5 @@
-import { AutoBeCompiler } from "@autobe/compiler";
 import { FileSystemIterator } from "@autobe/filesystem";
-import { AutoBeOpenApi } from "@autobe/interface";
+import { AutoBeOpenApi, IAutoBeCompiler } from "@autobe/interface";
 import { OpenApi } from "@samchon/openapi";
 import typia from "typia";
 
@@ -10,7 +9,7 @@ import { TestGlobal } from "../../TestGlobal";
 export const test_compiler_interface_write = async (
   factory: TestFactory,
 ): Promise<void> => {
-  const compiler: AutoBeCompiler = factory.createCompiler();
+  const compiler: IAutoBeCompiler = factory.createCompiler();
   const document: AutoBeOpenApi.IDocument = await compiler.interface.invert(
     OpenApi.convert(
       await fetch(

--- a/test/src/features/compiler/test_compiler_prisma_prettier.ts
+++ b/test/src/features/compiler/test_compiler_prisma_prettier.ts
@@ -1,0 +1,28 @@
+import { FileSystemIterator } from "@autobe/filesystem";
+import { AutoBePrisma, IAutoBeCompiler } from "@autobe/interface";
+import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
+
+import { TestFactory } from "../../TestFactory";
+import { TestGlobal } from "../../TestGlobal";
+import json from "./examples/prisma.application.json";
+
+export const test_compiler_prisma_prettier = async (
+  factory: TestFactory,
+): Promise<void> => {
+  const app: AutoBePrisma.IApplication =
+    typia.assert<AutoBePrisma.IApplication>(json);
+  const compiler: IAutoBeCompiler = factory.createCompiler();
+  const schemas: Record<string, string> = await compiler.prisma.write(app);
+  await FileSystemIterator.save({
+    root: `${TestGlobal.ROOT}/results/compiler/prisma/prettier`,
+    files: schemas,
+  });
+
+  for (const [key, value] of Object.entries(schemas))
+    TestValidator.predicate(key)(
+      value
+        .split("\n")
+        .every((line) => line.startsWith("///") === false || line.length <= 80),
+    );
+};


### PR DESCRIPTION
This pull request introduces improvements to the formatting of generated Prisma schema comments and refactors test code to use the `IAutoBeCompiler` interface instead of the concrete `AutoBeCompiler` class. The main changes include enhanced line wrapping for comments to ensure readability and consistency, and updates to tests for better abstraction and maintainability.

**Prisma schema comment formatting improvements:**

- Updated the `writeComment` function in `writePrismaApplication.ts` to support line wrapping with a configurable maximum length (defaulting to 80 characters), ensuring that comment lines do not exceed the specified length and are properly trimmed and formatted.
- Modified calls to `writeComment` in `writePrimary` and `writeField` to pass the new maximum line length parameter (78), aligning with the updated comment formatting logic. [[1]](diffhunk://#diff-a691124f4d4705ae7b12244424f04d3a47fb71d4caf3053144d1eb1d20d02eb8L125-R126) [[2]](diffhunk://#diff-a691124f4d4705ae7b12244424f04d3a47fb71d4caf3053144d1eb1d20d02eb8L142-R143)
- Updated the model writer to pass the new line length parameter and renamed the `indent` function to `addIndent` for clarity.

**Test code refactoring for compiler abstraction:**

- Replaced direct usage of `AutoBeCompiler` with the `IAutoBeCompiler` interface in all relevant test files, including `TestFactory.ts` and various feature tests. This change improves test flexibility and decouples tests from the concrete implementation. [[1]](diffhunk://#diff-92b59cb5bc17e4263e671d7cc87739afe278fff1c80d4a37b51de8ef7fab502eL2-R4) [[2]](diffhunk://#diff-92b59cb5bc17e4263e671d7cc87739afe278fff1c80d4a37b51de8ef7fab502eL15-R15) [[3]](diffhunk://#diff-212c853158cf31669b0dbae7081fbaaf1c98349d7e26fccaf16c55b0240ab0afL1-R11) [[4]](diffhunk://#diff-212c853158cf31669b0dbae7081fbaaf1c98349d7e26fccaf16c55b0240ab0afL1-R11) [[5]](diffhunk://#diff-3a56ab6c82f37e232b8d29cac317d2724cf7e2a3a7b33541a9545aa70827c6a4L1-R3) [[6]](diffhunk://#diff-3a56ab6c82f37e232b8d29cac317d2724cf7e2a3a7b33541a9545aa70827c6a4L15-R15) [[7]](diffhunk://#diff-bdb779feaa5a404167f32905ae048722289a2efe2e24ca4c08f8d536f77150a0L1-R3) [[8]](diffhunk://#diff-bdb779feaa5a404167f32905ae048722289a2efe2e24ca4c08f8d536f77150a0L15-R15) [[9]](diffhunk://#diff-5bd054cbec752e963ecba0b0bdf9d24acd616fb106f2a88bf25e652ed32b0e28L1-R1) [[10]](diffhunk://#diff-5bd054cbec752e963ecba0b0bdf9d24acd616fb106f2a88bf25e652ed32b0e28L11-R10) [[11]](diffhunk://#diff-ff325b7a8b5cf2cc85d8f846ba75a1246e4a410a04dd825e7f1f8c07a610dc59L1-R2) [[12]](diffhunk://#diff-ff325b7a8b5cf2cc85d8f846ba75a1246e4a410a04dd825e7f1f8c07a610dc59L13-R12)
- Added a new test `test_compiler_prisma_prettier.ts` to validate that all generated comment lines in Prisma schemas do not exceed 80 characters, ensuring the effectiveness of the new comment formatting logic.