### PR TITLE
feat(prisma): draft and final, all of them are AST.

### DIFF
--- a/packages/agent/prompts/PRISMA_SCHEMA.md
+++ b/packages/agent/prompts/PRISMA_SCHEMA.md
@@ -11,19 +11,18 @@ Your File: targetComponent.filename = "..."
 Your Domain: targetComponent.namespace = "..."
 ```
 
-**YOUR 5-STEP PROCESS:**
+**YOUR 4-STEP PROCESS:**
 1. **thinking**: Analyze and plan database design for targetComponent.tables
-2. **draft**: Write initial Prisma schema code (PSL syntax)
-3. **review**: Review draft for syntax, normalization, and best practices
-4. **final**: Produce refined, production-ready PSL code
-5. **models**: Transform final code to AST with critical reinterpretation
+2. **draft**: Create initial Prisma schema models (AST format)
+3. **review**: Review draft models for structure, normalization, and best practices
+4. **final**: Produce refined, production-ready AST models
 
 **SUCCESS CRITERIA:**
 ✅ Every table from `targetComponent.tables` exists in your output
 ✅ Total model count = `targetComponent.tables.length` (plus junction tables if needed)
 ✅ All model names match `targetComponent.tables` entries exactly
-✅ Complete IAutoBePrismaSchemaApplication.IProps structure with all 5 fields
-✅ AST transformation includes proper field reclassification and type normalization
+✅ Complete IAutoBePrismaSchemaApplication.IProps structure with all 4 fields
+✅ AST models include proper field classification and type normalization
 
 ---
 
@@ -45,7 +44,7 @@ You are a world-class Prisma database schema expert specializing in snapshot-bas
 ### Core Principles
 
 - **Focus on assigned tables** - Create exactly what `targetComponent.tables` specifies
-- **Output structured function call** - Use IAutoBePrismaSchemaApplication.IProps with 5-step process
+- **Output structured function call** - Use IAutoBePrismaSchemaApplication.IProps with 4-step process
 - **Follow snapshot-based architecture** - Design for historical data preservation and audit trails  
 - **Prioritize data integrity** - Ensure referential integrity and proper constraints
 - **CRITICAL: Prevent all duplications** - Always review and verify no duplicate fields, relations, or models exist
@@ -72,40 +71,41 @@ DESIGN PLANNING:
 ✅ I will ensure strict 3NF normalization for regular tables
 ```
 
-### Step 2: Initial Prisma Schema Code (draft)
-Generate PSL code with:
-1. Model blocks for each table with exact names from targetComponent.tables
-2. Primary key field "id" with @id and @db.Uuid directives
-3. Business fields with appropriate types (no calculated fields)
-4. Foreign keys with @relation directives
-5. Indexes using @@index, @@unique (no single FK indexes)
-6. Triple-slash comments with business descriptions
+### Step 2: Initial Prisma Schema Models (draft)
+Generate AutoBePrisma.IModel[] array with:
+1. Model objects for each table with exact names from targetComponent.tables
+2. Primary field "id" with type "uuid"
+3. Business fields in plainFields array (no calculated fields)
+4. Foreign fields with IRelation configurations
+5. Index arrays (uniqueIndexes, plainIndexes, ginIndexes)
+6. Comprehensive descriptions with business context
 
-### Step 3: Schema Code Review (review)
-Systematic analysis of draft code:
-- Syntax validation and PSL compliance
+### Step 3: Schema Models Review (review)
+Systematic analysis of draft models:
+- AST structure validation and compliance
 - Normalization verification (1NF, 2NF, 3NF)
 - Prohibited fields check (no calculations in regular tables)
 - Index strategy validation
 - Description quality assessment
 - Relationship correctness
+- **Language validation**: Check if ALL descriptions are in English
+  - Identify any non-English descriptions in model or field descriptions
+  - Flag mixed-language descriptions that need correction
+  - Note which descriptions need translation in the final step
 
-### Step 4: Final Production Code (final)
-Refined PSL code incorporating all review feedback:
-- All syntax errors resolved
+### Step 4: Final Production Models (final)
+Refined AutoBePrisma.IModel[] array incorporating all review feedback:
+- All structure errors resolved
 - Complete targetComponent.tables coverage
 - Optimized index strategy
 - Comprehensive documentation
 - Full normalization compliance
-
-### Step 5: AST Transformation with Reinterpretation (models)
-Transform final code to AutoBePrisma.IModel[] array:
-- **CRITICAL**: Reinterpret PSL code to fit AST constraints
-- Separate fields into primary/foreign/plain categories
-- Extract @relation directives to IRelation structures
-- Parse @@index/@@unique to index arrays
-- Normalize types to AST enum values
+- Proper field classification and type normalization
 - Set material: true for mv_ prefixed tables
+- **All descriptions in English**: 
+  - Translate any non-English descriptions identified in review
+  - Maintain technical accuracy during translation
+  - Preserve the `Summary\n\nBody` format with proper paragraphs
 
 ## 🎯 CLEAR EXAMPLES
 
@@ -134,133 +134,33 @@ const otherComponents: AutoBePrisma.IComponent[] = [
 ### ✅ CORRECT OUTPUT
 ```typescript
 {
-  thinking: "Analyzing Sales domain requirements: need to create shopping_goods and shopping_goods_options tables. These will reference shopping_customers from Actors domain. Will implement snapshot pattern for goods history tracking and proper indexing for performance.",
+  thinking: "Analyzing Sales domain requirements: need to create shopping_goods and shopping_goods_options tables. These will reference shopping_sellers from Actors domain. Will implement proper normalization and indexing for performance.",
   
-  draft: `/// @namespace Sales
-model shopping_goods {
-  /// Primary Key.
-  id String @id @db.Uuid
-  
-  /// Seller who registered this goods.
-  shopping_seller_id String @db.Uuid
-  seller shopping_sellers @relation(fields: [shopping_seller_id], references: [id])
-  
-  /// Goods name.
-  name String
-  
-  /// Created timestamp.
-  created_at DateTime
-  
-  /// Product options.
-  options shopping_goods_options[]
-  
-  @@index([shopping_seller_id, created_at])
-}
-
-model shopping_goods_options {
-  /// Primary Key.
-  id String @id @db.Uuid
-  
-  /// Parent goods.
-  shopping_goods_id String @db.Uuid
-  goods shopping_goods @relation(fields: [shopping_goods_id], references: [id])
-  
-  /// Option name.
-  name String
-  
-  /// Option price.
-  price Float
-  
-  @@index([shopping_goods_id])
-}`,
-  
-  review: "Schema review: PSL syntax is correct. Models properly reference existing tables. Need to add unique constraint for option names within goods. Foreign key indexes are correctly excluded from manual indexes. Normalization is maintained - no calculated fields present.",
-  
-  final: `/// @namespace Sales
-model shopping_goods {
-  /// Primary Key.
-  id String @id @db.Uuid
-  
-  /// Seller who registered this goods - references existing shopping_sellers table.
-  shopping_seller_id String @db.Uuid
-  seller shopping_sellers @relation(fields: [shopping_seller_id], references: [id])
-  
-  /// Goods name for display.
-  name String
-  
-  /// Created timestamp for audit trail.
-  created_at DateTime
-  
-  /// Product options available for this goods.
-  options shopping_goods_options[]
-  
-  @@index([shopping_seller_id, created_at])
-}
-
-model shopping_goods_options {
-  /// Primary Key.
-  id String @id @db.Uuid
-  
-  /// Parent goods reference.
-  shopping_goods_id String @db.Uuid
-  goods shopping_goods @relation(fields: [shopping_goods_id], references: [id])
-  
-  /// Option name (e.g., size, color).
-  name String
-  
-  /// Additional price for this option.
-  price Float
-  
-  @@unique([shopping_goods_id, name])
-  @@index([shopping_goods_id])
-}`,
-  
-  models: [
+  draft: [
     {
       name: "shopping_goods",
-      description: "Product catalog main entity - implements requirement for seller goods management.",
-      material: false,
-      primaryField: { name: "id", type: "uuid", description: "Primary Key." },
-      foreignFields: [
-        {
-          name: "shopping_seller_id",
-          type: "uuid",
-          description: "Seller who registered this goods - references existing shopping_sellers table.",
-          relation: { name: "seller", targetModel: "shopping_sellers" },
-          unique: false,
-          nullable: false
-        }
-      ],
-      plainFields: [
-        { name: "name", type: "string", description: "Goods name for display.", nullable: false },
-        { name: "created_at", type: "datetime", description: "Created timestamp for audit trail.", nullable: false }
-      ],
-      uniqueIndexes: [],
-      plainIndexes: [{ fieldNames: ["shopping_seller_id", "created_at"] }],
-      ginIndexes: []
+      // Model structure with primary key, foreign keys to shopping_sellers, 
+      // and business fields (name, created_at)
     },
     {
       name: "shopping_goods_options",
-      description: "Product option variants - implements requirement for flexible product options.",
-      material: false,
-      primaryField: { name: "id", type: "uuid", description: "Primary Key." },
-      foreignFields: [
-        {
-          name: "shopping_goods_id",
-          type: "uuid",
-          description: "Parent goods reference.",
-          relation: { name: "goods", targetModel: "shopping_goods" },
-          unique: false,
-          nullable: false
-        }
-      ],
-      plainFields: [
-        { name: "name", type: "string", description: "Option name (e.g., size, color).", nullable: false },
-        { name: "price", type: "double", description: "Additional price for this option.", nullable: false }
-      ],
-      uniqueIndexes: [{ fieldNames: ["shopping_goods_id", "name"], unique: true }],
-      plainIndexes: [{ fieldNames: ["shopping_goods_id"] }],
-      ginIndexes: []
+      // Model structure with foreign key to shopping_goods,
+      // and option-specific fields (name, price)
+    }
+  ],
+  
+  review: "Schema models review: AST structure is correct. Models properly reference existing tables. Need to add unique constraint for option names within goods. Foreign key indexes are correctly excluded. Normalization is maintained. Language check: All descriptions are in English.",
+  
+  final: [
+    {
+      name: "shopping_goods",
+      // Refined model with comprehensive descriptions following Summary\n\nBody format
+      // Includes proper relationships, normalization compliance, and business context
+    },
+    {
+      name: "shopping_goods_options",
+      // Refined model with unique constraint on (goods_id, name)
+      // Complete descriptions explaining business purpose and constraints
     }
   ]
 }
@@ -271,27 +171,22 @@ model shopping_goods_options {
 - ✅ Created `shopping_goods_options` (from targetComponent.tables)  
 - ✅ Total: 2 models = targetComponent.tables.length
 - ✅ Can reference `shopping_sellers` via foreign key (ALREADY EXISTS in otherComponents)
-- ✅ Complete 5-step process with PSL code → AST transformation
-- ✅ Proper reinterpretation of @relation to IRelation structures
+- ✅ Complete 4-step process with direct AST model creation
+- ✅ Proper field classification and relationship structures
 
 ### ❌ COMMON MISTAKE
 ```typescript
 {
   thinking: "Need to create shopping system tables including customers and sellers...",
   
-  draft: `model shopping_customers {  // ❌ WRONG: This is from otherComponents!
-    id String @id
-    // ...
-  }
-  
-  model shopping_sellers {  // ❌ WRONG: This is from otherComponents!
-    id String @id
-    // ...
-  }`,
+  draft: [
+    { name: "shopping_customers" }, // ❌ WRONG: This is from otherComponents!
+    { name: "shopping_sellers" }    // ❌ WRONG: This is from otherComponents!
+  ],
   
   // ... rest of incorrect implementation
   
-  models: [
+  final: [
     { name: "shopping_customers" }, // ❌ ALREADY CREATED in otherComponents!
     { name: "shopping_sellers" }    // ❌ ALREADY CREATED in otherComponents!
   ]
@@ -413,6 +308,11 @@ interface IComponent {
 #### Description Writing Standards
 
 **LANGUAGE REQUIREMENT**: All descriptions MUST be written in English, regardless of the working language used for thinking/review steps.
+
+**IMPORTANT**: During the review step, you MUST check if all descriptions in the draft are written in English. If any descriptions are in another language, you MUST:
+1. Identify them in the review
+2. Translate them to English in the final step
+3. Maintain the `Summary\n\nBody` format during translation
 
 Each description MUST include:
 
@@ -573,10 +473,9 @@ Generate a single function call using the IAutoBePrismaSchemaApplication.IProps 
 // Function call format
 {
   thinking: string;                   // Step 1: Strategic database design analysis
-  draft: string;                      // Step 2: Initial Prisma schema code (PSL)
-  review: string;                     // Step 3: Schema code review and quality assessment
-  final: string;                      // Step 4: Final production-ready Prisma schema code
-  models: AutoBePrisma.IModel[];      // Step 5: AST representation (with reinterpretation)
+  draft: AutoBePrisma.IModel[];       // Step 2: Initial Prisma schema models (AST)
+  review: string;                     // Step 3: Schema models review and quality assessment
+  final: AutoBePrisma.IModel[];       // Step 4: Final production-ready Prisma schema models
 }
 ```
 
@@ -598,19 +497,27 @@ Generate a single function call using the IAutoBePrismaSchemaApplication.IProps 
 
 ### Task: Generate Structured Prisma Schema Definition
 
-Transform user requirements into a complete IAutoBePrismaSchemaApplication.IProps structure that implements the 5-step schema generation process:
+Transform user requirements into a complete IAutoBePrismaSchemaApplication.IProps structure that implements the 4-step schema generation process:
 
 1. **thinking**: Strategic database design analysis and planning
-2. **draft**: Initial Prisma schema code implementation (PSL syntax)
-3. **review**: Schema code review and quality assessment
-4. **final**: Final production-ready Prisma schema code
-5. **models**: AST representation with critical reinterpretation
+2. **draft**: Initial Prisma schema models in AST format (AutoBePrisma.IModel[])
+3. **review**: Schema models review and quality assessment
+4. **final**: Final production-ready Prisma schema models with refinements
 
-**CRITICAL: Step 5 Reinterpretation**
-- The final code MUST be reinterpreted to fit AST constraints
-- Field reclassification into primary/foreign/plain categories
-- Relationship extraction from @relation directives
-- Index decomposition from @@index/@@unique directives
-- Type normalization to AST enum values
+**Key AST Model Structure Concepts:**
+- **Primary Field**: Always named "id" with type "uuid"
+- **Foreign Fields**: Follow `{target_model}_id` naming with proper IRelation configurations
+- **Plain Fields**: Business data fields with appropriate types (string, int, double, datetime, boolean, uri)
+- **Indexes**: Separated into uniqueIndexes, plainIndexes, and ginIndexes arrays
+- **Descriptions**: Must follow `Summary\n\nBody` format with proper paragraphs
+- **Material Flag**: Set to true only for `mv_` prefixed materialized view tables
+
+**Description Writing Guidelines:**
+- Start with a concise one-line summary
+- Follow with detailed body paragraphs
+- Include requirements mapping, business purpose, technical context
+- Explain normalization compliance and relationships
+- Provide usage examples and constraints
+- All descriptions MUST be in English
 
 **🎯 REMEMBER: Your job is to create exactly the tables specified in `targetComponent.tables` with their exact names - nothing more, nothing less!**

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
@@ -41,7 +41,7 @@ export async function orchestratePrismaSchemas<Model extends ILlmSchema.Model>(
         file: {
           filename: comp.filename,
           namespace: comp.namespace,
-          models: result.models,
+          models: result.final,
         },
         completed: (completed += comp.tables.length),
         total,

--- a/packages/agent/src/orchestrate/prisma/structures/IAutoBePrismaSchemaApplication.ts
+++ b/packages/agent/src/orchestrate/prisma/structures/IAutoBePrismaSchemaApplication.ts
@@ -47,52 +47,57 @@ export namespace IAutoBePrismaSchemaApplication {
     thinking: string;
 
     /**
-     * Step 2: Initial Prisma schema code implementation.
+     * Step 2: Initial Prisma schema models implementation.
      *
-     * AI generates the first working version of the Prisma schema based on the
-     * strategic plan. This draft must be syntactically correct Prisma Schema
-     * Language (PSL) code that implements all planned tables, relationships,
-     * and constraints. The schema should follow Prisma conventions while
-     * incorporating enterprise patterns like snapshot tables and materialized
-     * views.
+     * AI generates the first working version of the Prisma schema models based on the
+     * strategic plan. This draft must be a structured Abstract Syntax Tree (AST)
+     * representation using the AutoBePrisma.IModel interface that implements all
+     * planned tables, relationships, and constraints. The models should follow
+     * Prisma conventions while incorporating enterprise patterns like snapshot
+     * tables and materialized views.
      *
      * **Implementation Requirements:**
      *
-     * - **Exact Table Names**: Use EXACT names from targetComponent.tables (NO
-     *   CHANGES)
-     * - **Valid PSL Syntax**: Proper model blocks, field definitions, and
-     *   directives
-     * - **Primary Keys**: Always UUID type with `@id` directive
-     * - **Foreign Keys**: UUID type following {target_model}_id naming pattern
-     * - **Data Types**: uuid, string, int, double, datetime, boolean, uri (no
-     *   pre-calculated fields)
-     * - **Relationships**: Proper `@relation` directives for 1:1, 1:N, M:N
-     *   patterns
-     * - **Descriptions**: Follow format with requirements mapping and business
-     *   purpose
-     * - **NO Prohibited Fields**: No totals, cached values, aggregates in regular
-     *   tables
+     * - **Model Array**: Each table from targetComponent.tables as IModel
+     * - **Exact Table Names**: Use EXACT names from targetComponent.tables (NO CHANGES)
+     * - **Primary Field**: Always UUID type with name "id"
+     * - **Foreign Fields**: Proper IRelation configurations for all relationships
+     * - **Plain Fields**: Business fields with correct types (no calculated fields)
+     * - **Data Types**: uuid, string, int, double, datetime, boolean, uri
+     * - **Relationships**: Proper relationship patterns for 1:1, 1:N, M:N
+     * - **Indexes**:
+     *   - UniqueIndexes: Business constraints and composite unique keys
+     *   - PlainIndexes: Query optimization (no single foreign key indexes)
+     *   - GinIndexes: Full-text search on string fields
+     * - **Material Flag**: true only for mv_ prefixed tables
+     * - **Descriptions**: Follow format with requirements mapping and business purpose
      *
-     * Workflow: Strategic plan → PSL implementation → Functional schema code
+     * **Relationship Patterns in AST:**
+     *
+     * - 1:1: Foreign field with unique: true
+     * - 1:N: Foreign field with unique: false
+     * - M:N: Separate junction table model with composite indexes
+     *
+     * Workflow: Strategic plan → AST implementation → Structured models
      */
-    draft: string;
+    draft: AutoBePrisma.IModel[];
 
     /**
-     * Step 3: Schema code review and quality assessment.
+     * Step 3: Schema models review and quality assessment.
      *
-     * AI performs a thorough review of the draft schema implementation,
+     * AI performs a thorough review of the draft schema models implementation,
      * examining multiple quality dimensions to ensure production readiness.
      * This review process identifies issues, suggests improvements, and
      * validates compliance with best practices.
      *
      * **Review Dimensions:**
      *
-     * **Syntax & Compilation:**
+     * **AST Structure Validation:**
      *
-     * - Prisma schema syntax errors and invalid directives
+     * - Model array completeness (all targetComponent.tables present)
      * - Model naming matches targetComponent.tables EXACTLY
      * - Field type appropriateness (uuid for keys, no calculated fields)
-     * - Relationship definition correctness (`@relation` syntax)
+     * - Relationship configurations correctness
      *
      * **Database Design Quality:**
      *
@@ -108,7 +113,7 @@ export namespace IAutoBePrismaSchemaApplication {
      *
      * **Index Strategy Validation:**
      *
-     * - NO single foreign key indexes (Prisma auto-creates these)
+     * - NO single foreign key indexes in PlainIndexes
      * - Composite indexes for query patterns
      * - Unique indexes for business constraints
      * - GIN indexes for full-text search fields
@@ -120,24 +125,31 @@ export namespace IAutoBePrismaSchemaApplication {
      * - Fields include: requirement aspect, business meaning, normalization
      *   rationale
      *
-     * Workflow: Draft schema → Systematic analysis → Specific improvements
+     * **Language Validation:**
+     *
+     * - ALL descriptions MUST be in English
+     * - Check if any model or field descriptions are written in non-English languages
+     * - Identify descriptions that need translation in the final step
+     * - Flag any mixed-language descriptions that combine English with other languages
+     *
+     * Workflow: Draft models → Systematic analysis → Specific improvements
      */
     review: string;
 
     /**
-     * Step 4: Final production-ready Prisma schema code.
+     * Step 4: Final production-ready Prisma schema models.
      *
-     * AI produces the final, polished version of the Prisma schema
-     * incorporating all review feedback. This code represents the completed
-     * schema implementation, ready for database migration and production
-     * deployment. All identified issues must be resolved, and the schema must
-     * meet enterprise-grade quality standards.
+     * AI produces the final, polished version of the Prisma schema models
+     * incorporating all review feedback. This structured AST representation
+     * represents the completed schema implementation, ready for database
+     * migration and production deployment. All identified issues must be
+     * resolved, and the schema must meet enterprise-grade quality standards.
      *
-     * **Final Schema Characteristics:**
+     * **Final Schema Model Characteristics:**
      *
      * - **Complete Coverage**: All targetComponent.tables implemented with exact
      *   names
-     * - **Zero Errors**: Valid PSL syntax, no compilation warnings
+     * - **Zero Errors**: Valid AST structure, no validation warnings
      * - **Proper Relationships**: All foreign keys reference existing tables
      *   correctly
      * - **Optimized Indexes**: Strategic indexes without redundant foreign key
@@ -145,43 +157,11 @@ export namespace IAutoBePrismaSchemaApplication {
      * - **Full Normalization**: Strict 3NF compliance, denormalization only in
      *   mv_ tables
      * - **Enterprise Documentation**: Complete descriptions with business context
+     * - **English-Only Descriptions**: All descriptions translated to English if needed
      * - **Audit Support**: Proper snapshot patterns and temporal fields
      *   (created_at, updated_at, deleted_at)
      * - **Type Safety**: Consistent use of UUID for all keys, appropriate field
      *   types
-     *
-     * Workflow: Review feedback → Schema refinement → Production-ready PSL code
-     */
-    final: string;
-
-    /**
-     * Step 5: Structured AST representation of the Prisma schema models.
-     *
-     * AI transforms the final Prisma schema code into a structured Abstract
-     * Syntax Tree (AST) representation using the AutoBePrisma.IModel interface.
-     * This involves critical reinterpretation and reclassification of the final
-     * code to conform to AST constraints.
-     *
-     * **CRITICAL: Reinterpretation & Post-Processing Required**
-     *
-     * The AI-generated final code may not directly map to valid AST structures
-     * due to:
-     *
-     * - Complex Prisma directives that need decomposition
-     * - Field attributes that require reclassification
-     * - Implicit relationships that need explicit AST representation
-     * - Schema-level constructs that must be distributed to models
-     *
-     * **Required Post-Processing Steps:**
-     *
-     * 1. **Field Reclassification**: Separate fields into primary, foreign, and
-     *    plain categories
-     * 2. **Relationship Extraction**: Convert `@relation` directives to IRelation
-     *    structures
-     * 3. **Index Decomposition**: Parse `@@index`, `@@unique` into appropriate
-     *    index arrays
-     * 4. **Type Normalization**: Map Prisma types to AST type enum values
-     * 5. **Constraint Resolution**: Convert schema constraints to AST properties
      *
      * **AST Structure Requirements:**
      *
@@ -191,7 +171,6 @@ export namespace IAutoBePrismaSchemaApplication {
      * - **Plain Fields**: Business fields with correct types (no calculated
      *   fields)
      * - **Indexes**:
-     *
      *   - UniqueIndexes: Business constraints and composite unique keys
      *   - PlainIndexes: Query optimization (no single foreign key indexes)
      *   - GinIndexes: Full-text search on string fields
@@ -203,12 +182,18 @@ export namespace IAutoBePrismaSchemaApplication {
      * - 1:N: Foreign field with unique: false
      * - M:N: Separate junction table model with composite indexes
      *
-     * Workflow: Final PSL code → Reinterpretation → AST transformation →
-     * Structured models
+     * **Language Translation Requirements:**
+     *
+     * - If review identified non-English descriptions in draft, translate them to English
+     * - Preserve the technical accuracy and business meaning during translation
+     * - Maintain the `Summary\n\nBody` format with proper paragraph breaks
+     * - Ensure all model descriptions, field descriptions, and other text are in English
+     *
+     * Workflow: Review feedback → Model refinement → Language translation → Production-ready structured models
      *
      * This structured representation serves as the ultimate deliverable for
      * programmatic schema generation and manipulation.
      */
-    models: AutoBePrisma.IModel[];
+    final: AutoBePrisma.IModel[];
   }
 }

--- a/packages/interface/src/events/AutoBePrismaSchemasEvent.ts
+++ b/packages/interface/src/events/AutoBePrismaSchemasEvent.ts
@@ -39,51 +39,52 @@ export interface AutoBePrismaSchemasEvent
   thinking: string;
 
   /**
-   * Initial Prisma schema code implementation.
+   * Initial Prisma schema models implementation.
    *
-   * Contains the first working version of the Prisma Schema Language (PSL) code
-   * for the target business domain. This draft implements all required tables
-   * with their fields, relationships, indexes, and constraints following Prisma
-   * conventions and enterprise database patterns.
+   * Contains the first working version of the Prisma schema models in structured
+   * AST format for the target business domain. This draft implements all required
+   * tables with their fields, relationships, indexes, and constraints following
+   * Prisma conventions and enterprise database patterns using the
+   * AutoBePrisma.IModel interface.
    *
    * The draft serves as the foundation for iterative refinement, demonstrating
    * the AI agent's understanding of the business requirements and its ability to
-   * translate them into syntactically correct database schema definitions that
-   * maintain data integrity and support efficient querying patterns.
+   * translate them into properly structured database schema models that maintain
+   * data integrity and support efficient querying patterns.
    */
-  draft: string;
+  draft: AutoBePrisma.IModel[];
 
   /**
-   * Schema code review and quality assessment.
+   * Schema models review and quality assessment.
    *
-   * Provides a comprehensive analysis of the draft schema implementation,
+   * Provides a comprehensive analysis of the draft schema models implementation,
    * identifying potential issues, areas for improvement, and validation of best
-   * practices compliance. The review examines syntax correctness, normalization
-   * adherence, relationship accuracy, index optimization, and documentation
-   * completeness.
+   * practices compliance. The review examines AST structure correctness,
+   * normalization adherence, relationship accuracy, index optimization, and
+   * documentation completeness.
    *
-   * This critical review phase ensures that the generated schema meets
-   * enterprise-grade quality standards, maintains data integrity, supports
-   * efficient query patterns, and aligns with both business requirements and
+   * This critical review phase ensures that the generated schema models meet
+   * enterprise-grade quality standards, maintain data integrity, support
+   * efficient query patterns, and align with both business requirements and
    * technical best practices before final implementation.
    */
   review: string;
 
   /**
-   * Final production-ready Prisma schema code.
+   * Final production-ready Prisma schema models.
    *
-   * Contains the refined and polished version of the Prisma schema that
-   * incorporates all review feedback and optimizations. This production-ready
-   * code has zero syntax errors, complete business entity coverage, optimized
-   * indexes, comprehensive documentation, and full compliance with database
-   * normalization principles.
+   * Contains the refined and polished version of the Prisma schema models that
+   * incorporate all review feedback and optimizations. This production-ready
+   * AST structure has zero validation errors, complete business entity coverage,
+   * optimized indexes, comprehensive documentation, and full compliance with
+   * database normalization principles.
    *
-   * The final schema represents the culmination of the iterative design process,
-   * ready for direct use in database migrations and production deployment. It
-   * ensures consistent data modeling, maintainable architecture, and optimal
-   * performance characteristics for the target business domain.
+   * The final schema models represent the culmination of the iterative design
+   * process, ready for direct use in database migrations and production
+   * deployment. They ensure consistent data modeling, maintainable architecture,
+   * and optimal performance characteristics for the target business domain.
    */
-  final: string;
+  final: AutoBePrisma.IModel[];
 
   /**
    * Generated Prisma schema file for a specific business domain.


### PR DESCRIPTION
This pull request refactors the Prisma schema generation process to use a 4-step workflow with AST (Abstract Syntax Tree) model representations instead of PSL (Prisma Schema Language) code strings. The changes affect both the agent prompt documentation and the TypeScript interface definitions, ensuring that all schema generation, review, and finalization steps operate on structured model objects. The process now emphasizes English-only descriptions, direct AST manipulation, and improved clarity in requirements.

**Refactor of Prisma Schema Generation Process:**

*Workflow and Structure Updates:*
- Changed the schema generation workflow from a 5-step process (including PSL code and a final AST transformation) to a streamlined 4-step process that works directly with AST model arrays throughout [[1]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL14-R25) [[2]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL48-R47) [[3]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL576-R478) [[4]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL601-R521).
- Updated all documentation, examples, and code references to reflect the new 4-step process and the use of `AutoBePrisma.IModel[]` for draft and final outputs [[1]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL75-R108) [[2]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL137-R163) [[3]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL274-R189).

*Interface and Type Definition Changes:*
- Modified `IAutoBePrismaSchemaApplication.IProps` so that `draft` and `final` are now arrays of `AutoBePrisma.IModel` (AST), not PSL strings.
- Updated step descriptions and requirements in the TypeScript interface to match the new process and clarify AST structure expectations [[1]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL50-R100) [[2]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL111-R116).

*Language and Description Requirements:*
- Enforced that all model and field descriptions must be in English, with explicit review and translation steps if any non-English text is found.
- Added guidelines for writing comprehensive, English-only descriptions in the correct format for all schema elements [[1]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL75-R108) [[2]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL601-R521).

*Example and Success Criteria Updates:*
- Updated all success criteria, correct/incorrect output examples, and core principles to align with the AST-first approach and new process [[1]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL137-R163) [[2]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL274-R189).

These changes make the schema generation process more robust, structured, and easier to validate programmatically, while ensuring clear communication and compliance with requirements.

**References:**  
[[1]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL14-R25) [[2]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL48-R47) [[3]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL75-R108) [[4]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL137-R163) [[5]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL274-R189) [[6]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bR312-R316) [[7]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL576-R478) [[8]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL601-R521) [[9]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL50-R100) [[10]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL111-R116)