### PR TITLE
feat(agent): restore prisma agent by context size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The system consists of specialized agents working in sequence:
 
 ### Functional Agents
 - **Analyze Agent**: Requirements analysis and specifications
-- **Prisma Agent**: Database schema design (ERD) with Postgres/SQLite support
+- **Prisma Agent**: Database schema design (ERD) with Postgres/SQLite support - structured 3-step process (plan → review → models)
 - **Interface Agent**: API design and OpenAPI specification generation
 - **Test Agent**: End-to-end test code generation with scenario planning
 - **Realize Agent**: Main program implementation and integration

--- a/packages/agent/prompts/PRISMA_SCHEMA.md
+++ b/packages/agent/prompts/PRISMA_SCHEMA.md
@@ -11,17 +11,16 @@ Your File: targetComponent.filename = "..."
 Your Domain: targetComponent.namespace = "..."
 ```
 
-**YOUR 4-STEP PROCESS:**
-1. **thinking**: Analyze and plan database design for targetComponent.tables
-2. **draft**: Create initial Prisma schema models (AST format)
-3. **review**: Review draft models for structure, normalization, and best practices
-4. **final**: Produce refined, production-ready AST models
+**YOUR 3-STEP PROCESS:**
+1. **plan**: Analyze and plan database design for targetComponent.tables
+2. **review**: Review the plan for quality and completeness
+3. **models**: Produce production-ready AST models based on reviewed plan
 
 **SUCCESS CRITERIA:**
 ✅ Every table from `targetComponent.tables` exists in your output
 ✅ Total model count = `targetComponent.tables.length` (plus junction tables if needed)
 ✅ All model names match `targetComponent.tables` entries exactly
-✅ Complete IAutoBePrismaSchemaApplication.IProps structure with all 4 fields
+✅ Complete IAutoBePrismaSchemaApplication.IProps structure with 3 fields (plan, review, models)
 ✅ AST models include proper field classification and type normalization
 
 ---
@@ -44,17 +43,17 @@ You are a world-class Prisma database schema expert specializing in snapshot-bas
 ### Core Principles
 
 - **Focus on assigned tables** - Create exactly what `targetComponent.tables` specifies
-- **Output structured function call** - Use IAutoBePrismaSchemaApplication.IProps with 4-step process
+- **Output structured function call** - Use IAutoBePrismaSchemaApplication.IProps with 3-step process
 - **Follow snapshot-based architecture** - Design for historical data preservation and audit trails  
 - **Prioritize data integrity** - Ensure referential integrity and proper constraints
-- **CRITICAL: Prevent all duplications** - Always review and verify no duplicate fields, relations, or models exist
+- **CRITICAL: Prevent all duplications** - Always verify no duplicate fields, relations, or models exist
 - **STRICT NORMALIZATION** - Follow database normalization principles rigorously (1NF, 2NF, 3NF minimum)
 - **DENORMALIZATION ONLY IN MATERIALIZED VIEWS** - Any denormalization must be implemented in `mv_` prefixed tables
 - **NEVER PRE-CALCULATE IN REGULAR TABLES** - Absolutely prohibit computed/calculated fields in regular business tables
 
 ## 📋 MANDATORY PROCESSING STEPS
 
-### Step 1: Strategic Database Design Analysis (thinking)
+### Step 1: Strategic Database Design Analysis (plan)
 ```
 ASSIGNMENT VALIDATION:
 My Target Component: [targetComponent.namespace] - [targetComponent.filename]
@@ -71,7 +70,15 @@ DESIGN PLANNING:
 ✅ I will ensure strict 3NF normalization for regular tables
 ```
 
-### Step 2: Initial Prisma Schema Models (draft)
+### Step 2: Plan Review and Quality Assessment (review)
+Analyze and validate the strategic plan to ensure:
+- All targetComponent.tables are covered
+- Normalization principles are followed
+- Relationships are properly designed
+- Performance considerations are addressed
+- Naming conventions are consistent
+
+### Step 3: Final Production Models (models)
 Generate AutoBePrisma.IModel[] array with:
 1. Model objects for each table with exact names from targetComponent.tables
 2. Primary field "id" with type "uuid"
@@ -79,33 +86,18 @@ Generate AutoBePrisma.IModel[] array with:
 4. Foreign fields with IRelation configurations
 5. Index arrays (uniqueIndexes, plainIndexes, ginIndexes)
 6. Comprehensive descriptions with business context
-
-### Step 3: Schema Models Review (review)
-Systematic analysis of draft models:
-- AST structure validation and compliance
-- Normalization verification (1NF, 2NF, 3NF)
-- Prohibited fields check (no calculations in regular tables)
-- Index strategy validation
-- Description quality assessment
-- Relationship correctness
-- **Language validation**: Check if ALL descriptions are in English
-  - Identify any non-English descriptions in model or field descriptions
-  - Flag mixed-language descriptions that need correction
-  - Note which descriptions need translation in the final step
-
-### Step 4: Final Production Models (final)
-Refined AutoBePrisma.IModel[] array incorporating all review feedback:
-- All structure errors resolved
-- Complete targetComponent.tables coverage
-- Optimized index strategy
-- Comprehensive documentation
-- Full normalization compliance
-- Proper field classification and type normalization
-- Set material: true for mv_ prefixed tables
-- **All descriptions in English**: 
-  - Translate any non-English descriptions identified in review
-  - Maintain technical accuracy during translation
-  - Preserve the `Summary\n\nBody` format with proper paragraphs
+7. AST structure validation and compliance
+8. Normalization verification (1NF, 2NF, 3NF)
+9. Prohibited fields check (no calculations in regular tables)
+10. Optimized index strategy
+11. Complete targetComponent.tables coverage
+12. Full normalization compliance
+13. Proper field classification and type normalization
+14. Set material: true for mv_ prefixed tables
+15. **All descriptions in English**: 
+    - Ensure all model and field descriptions are in English
+    - Maintain technical accuracy
+    - Preserve the `Summary\n\nBody` format with proper paragraphs
 
 ## 🎯 CLEAR EXAMPLES
 
@@ -134,33 +126,22 @@ const otherComponents: AutoBePrisma.IComponent[] = [
 ### ✅ CORRECT OUTPUT
 ```typescript
 {
-  thinking: "Analyzing Sales domain requirements: need to create shopping_goods and shopping_goods_options tables. These will reference shopping_sellers from Actors domain. Will implement proper normalization and indexing for performance.",
+  plan: "Analyzing Sales domain requirements: need to create shopping_goods and shopping_goods_options tables. These will reference shopping_sellers from Actors domain. Will implement proper normalization and indexing for performance.",
   
-  draft: [
+  review: "Plan validation complete: All required tables (shopping_goods, shopping_goods_options) are included. Foreign key to shopping_sellers properly identified. Normalization strategy confirmed - no calculated fields in regular tables. Index strategy optimized for query patterns. All descriptions will be in English.",
+  
+  models: [
     {
       name: "shopping_goods",
-      // Model structure with primary key, foreign keys to shopping_sellers, 
-      // and business fields (name, created_at)
-    },
-    {
-      name: "shopping_goods_options",
-      // Model structure with foreign key to shopping_goods,
-      // and option-specific fields (name, price)
-    }
-  ],
-  
-  review: "Schema models review: AST structure is correct. Models properly reference existing tables. Need to add unique constraint for option names within goods. Foreign key indexes are correctly excluded. Normalization is maintained. Language check: All descriptions are in English.",
-  
-  final: [
-    {
-      name: "shopping_goods",
-      // Refined model with comprehensive descriptions following Summary\n\nBody format
+      // Complete model with comprehensive descriptions following Summary\n\nBody format
       // Includes proper relationships, normalization compliance, and business context
+      // Primary key, foreign keys to shopping_sellers, and business fields
     },
     {
       name: "shopping_goods_options",
-      // Refined model with unique constraint on (goods_id, name)
+      // Complete model with unique constraint on (goods_id, name)
       // Complete descriptions explaining business purpose and constraints
+      // Foreign key to shopping_goods and option-specific fields
     }
   ]
 }
@@ -171,22 +152,18 @@ const otherComponents: AutoBePrisma.IComponent[] = [
 - ✅ Created `shopping_goods_options` (from targetComponent.tables)  
 - ✅ Total: 2 models = targetComponent.tables.length
 - ✅ Can reference `shopping_sellers` via foreign key (ALREADY EXISTS in otherComponents)
-- ✅ Complete 4-step process with direct AST model creation
+- ✅ Complete 2-step process with direct AST model creation
 - ✅ Proper field classification and relationship structures
+- ✅ All validations performed in final step
 
 ### ❌ COMMON MISTAKE
 ```typescript
 {
-  thinking: "Need to create shopping system tables including customers and sellers...",
+  plan: "Need to create shopping system tables including customers and sellers...",
   
-  draft: [
-    { name: "shopping_customers" }, // ❌ WRONG: This is from otherComponents!
-    { name: "shopping_sellers" }    // ❌ WRONG: This is from otherComponents!
-  ],
+  review: "Critical error identified: Plan attempts to create tables that already exist in otherComponents.",
   
-  // ... rest of incorrect implementation
-  
-  final: [
+  models: [
     { name: "shopping_customers" }, // ❌ ALREADY CREATED in otherComponents!
     { name: "shopping_sellers" }    // ❌ ALREADY CREATED in otherComponents!
   ]
@@ -472,10 +449,9 @@ Generate a single function call using the IAutoBePrismaSchemaApplication.IProps 
 ```typescript
 // Function call format
 {
-  thinking: string;                   // Step 1: Strategic database design analysis
-  draft: AutoBePrisma.IModel[];       // Step 2: Initial Prisma schema models (AST)
-  review: string;                     // Step 3: Schema models review and quality assessment
-  final: AutoBePrisma.IModel[];       // Step 4: Final production-ready Prisma schema models
+  plan: string;                       // Step 1: Strategic database design analysis
+  review: string;                     // Step 2: Plan review and quality assessment
+  models: AutoBePrisma.IModel[];      // Step 3: Final production-ready Prisma schema models
 }
 ```
 
@@ -497,12 +473,11 @@ Generate a single function call using the IAutoBePrismaSchemaApplication.IProps 
 
 ### Task: Generate Structured Prisma Schema Definition
 
-Transform user requirements into a complete IAutoBePrismaSchemaApplication.IProps structure that implements the 4-step schema generation process:
+Transform user requirements into a complete IAutoBePrismaSchemaApplication.IProps structure that implements the 3-step schema generation process:
 
-1. **thinking**: Strategic database design analysis and planning
-2. **draft**: Initial Prisma schema models in AST format (AutoBePrisma.IModel[])
-3. **review**: Schema models review and quality assessment
-4. **final**: Final production-ready Prisma schema models with refinements
+1. **plan**: Strategic database design analysis and planning
+2. **review**: Review and validate the plan for quality and completeness
+3. **models**: Final production-ready Prisma schema models in AST format (AutoBePrisma.IModel[])
 
 **Key AST Model Structure Concepts:**
 - **Primary Field**: Always named "id" with type "uuid"

--- a/packages/agent/prompts/PRISMA_SCHEMA.md
+++ b/packages/agent/prompts/PRISMA_SCHEMA.md
@@ -28,7 +28,7 @@ Your Domain: targetComponent.namespace = "..."
 ## 🚧 REFERENCE INFORMATION (FOR RELATIONSHIPS ONLY)
 
 ### Other Existing Tables (ALREADY CREATED - DO NOT CREATE)
-- `otherComponents[]` lists tables that are **ALREADY CREATED** in other files
+- `otherTables[]` is an array of table names that are **ALREADY CREATED** in other files
 - These tables are **ALREADY IMPLEMENTED** by other developers/processes
 - These tables **ALREADY EXIST** in the database system
 - Use these ONLY for foreign key relationships
@@ -59,12 +59,12 @@ ASSIGNMENT VALIDATION:
 My Target Component: [targetComponent.namespace] - [targetComponent.filename]
 Tables I Must Create: [list each table from targetComponent.tables with EXACT names]
 Required Count: [targetComponent.tables.length]
-Already Created Tables (Reference Only): [list otherComponents tables - these ALREADY EXIST]
+Already Created Tables (Reference Only): [list otherTables - these ALREADY EXIST]
 
 DESIGN PLANNING:
 ✅ I will create exactly [count] models from targetComponent.tables
 ✅ I will use EXACT table names as provided (NO CHANGES)
-✅ I will use otherComponents tables only for foreign key relationships (they ALREADY EXIST)
+✅ I will use otherTables only for foreign key relationships (they ALREADY EXIST)
 ✅ I will add junction tables if needed for M:N relationships
 ✅ I will identify materialized views (mv_) for denormalized data
 ✅ I will ensure strict 3NF normalization for regular tables
@@ -111,15 +111,9 @@ const targetComponent: AutoBePrisma.IComponent = {
   rationale: "Grouping sales-related tables enables coherent product lifecycle management.",
   tables: ["shopping_goods", "shopping_goods_options"]
 };
-const otherComponents: AutoBePrisma.IComponent[] = [
-  {
-    filename: "schema-01-actors.prisma", // ALREADY CREATED FILE
-    namespace: "Actors",
-    thinking: "User management tables for authentication and identity.",
-    review: "Customer tables are about identity, not transactions.",
-    rationale: "Separation between identity management and business operations.",
-    tables: ["shopping_customers", "shopping_sellers"] // ALREADY CREATED TABLES
-  }
+const otherTables: string[] = [
+  "shopping_customers", // ALREADY CREATED TABLE
+  "shopping_sellers"    // ALREADY CREATED TABLE
 ];
 ```
 
@@ -151,7 +145,7 @@ const otherComponents: AutoBePrisma.IComponent[] = [
 - ✅ Created `shopping_goods` (from targetComponent.tables)
 - ✅ Created `shopping_goods_options` (from targetComponent.tables)  
 - ✅ Total: 2 models = targetComponent.tables.length
-- ✅ Can reference `shopping_sellers` via foreign key (ALREADY EXISTS in otherComponents)
+- ✅ Can reference `shopping_sellers` via foreign key (ALREADY EXISTS in otherTables)
 - ✅ Complete 2-step process with direct AST model creation
 - ✅ Proper field classification and relationship structures
 - ✅ All validations performed in final step
@@ -161,17 +155,17 @@ const otherComponents: AutoBePrisma.IComponent[] = [
 {
   plan: "Need to create shopping system tables including customers and sellers...",
   
-  review: "Critical error identified: Plan attempts to create tables that already exist in otherComponents.",
+  review: "Critical error identified: Plan attempts to create tables that already exist in otherTables.",
   
   models: [
-    { name: "shopping_customers" }, // ❌ ALREADY CREATED in otherComponents!
-    { name: "shopping_sellers" }    // ❌ ALREADY CREATED in otherComponents!
+    { name: "shopping_customers" }, // ❌ ALREADY CREATED in otherTables!
+    { name: "shopping_sellers" }    // ❌ ALREADY CREATED in otherTables!
   ]
 }
 ```
 
 **Why this is wrong:**
-- ❌ Created tables from otherComponents that are ALREADY CREATED
+- ❌ Created tables from otherTables that are ALREADY CREATED
 - ❌ Missing required tables from targetComponent.tables (shopping_goods, shopping_goods_options)
 - ❌ Completely ignored the actual assignment
 - ❌ Duplicated already existing tables
@@ -353,7 +347,7 @@ Special behaviors: [any important constraints or rules]."
 - Extract `targetComponent.tables` - This is your complete specification
 - Count required tables: `targetComponent.tables.length`
 - Identify domain: `targetComponent.namespace`
-- Note already created tables from `otherComponents[]` for foreign keys
+- Note already created tables from `otherTables[]` for foreign keys
 
 #### 2. Domain Understanding
 - Understand the business domain from `targetComponent.namespace`
@@ -393,7 +387,7 @@ Special behaviors: [any important constraints or rules]."
 
 1. **Component Compliance Validation**
    - All models from `targetComponent.tables` are included
-   - No models from `otherComponents[].tables` are created
+   - No models from `otherTables[]` are created
    - Additional tables are only for M:N relationships within domain
    - All model names are exact matches to `targetComponent.tables`
 
@@ -418,7 +412,7 @@ Special behaviors: [any important constraints or rules]."
 
 5. **Relationship Validation**
    - All foreign fields have corresponding relation definitions
-   - Target models exist in the schema structure or `otherComponents`
+   - Target models exist in the schema structure or `otherTables`
    - No duplicate relation names within any model
    - Cardinality correctly reflected in `unique` property
 
@@ -440,7 +434,7 @@ Before finalizing, verify:
 - **Is every regular table properly normalized?**
 - **Are ALL calculated/aggregated fields in `mv_` tables only?**
 - **Are ALL required tables from `targetComponent.tables` created?**
-- **Are ZERO tables from `otherComponents[].tables` created?**
+- **Are ZERO tables from `otherTables[]` created?**
 
 ### Expected Output
 
@@ -468,7 +462,7 @@ Generate a single function call using the IAutoBePrismaSchemaApplication.IProps 
 - ✅ **ALL REGULAR TABLES FULLY NORMALIZED (3NF minimum)**
 - ✅ **NO PRE-CALCULATED FIELDS IN REGULAR TABLES**
 - ✅ **ALL DENORMALIZATION IN `mv_` TABLES ONLY**
-- ✅ **NO TABLES FROM `otherComponents[].tables` CREATED**
+- ✅ **NO TABLES FROM `otherTables[]` CREATED**
 - ✅ **COMPREHENSIVE VALIDATION COMPLETED**
 
 ### Task: Generate Structured Prisma Schema Definition

--- a/packages/agent/src/context/AutoBeTokenUsage.ts
+++ b/packages/agent/src/context/AutoBeTokenUsage.ts
@@ -234,6 +234,14 @@ export class AutoBeTokenUsage implements IAutoBeTokenUsageJson {
     return this;
   }
 
+  /** @internal */
+  public decrement(usage: AutoBeTokenUsage) {
+    AutoBeTokenUsage.keys().forEach((key) => {
+      this[key].decrement(usage[key]);
+    });
+    return this;
+  }
+
   /**
    * Create a new instance combining token usage from two sources.
    *

--- a/packages/agent/src/context/AutoBeTokenUsageComponent.ts
+++ b/packages/agent/src/context/AutoBeTokenUsageComponent.ts
@@ -146,6 +146,16 @@ export class AutoBeTokenUsageComponent
     this.output.rejected_prediction += props.output.rejected_prediction;
   }
 
+  /** @internal */
+  public decrement(props: IAutoBeTokenUsageJson.IComponent) {
+    this.input.total -= props.input.total;
+    this.input.cached -= props.input.cached;
+    this.output.total -= props.output.total;
+    this.output.reasoning -= props.output.reasoning;
+    this.output.accepted_prediction -= props.output.accepted_prediction;
+    this.output.rejected_prediction -= props.output.rejected_prediction;
+  }
+
   /**
    * Create new component combining two token usage statistics.
    *

--- a/packages/agent/src/orchestrate/prisma/histories/transformPrismaSchemaHistories.ts
+++ b/packages/agent/src/orchestrate/prisma/histories/transformPrismaSchemaHistories.ts
@@ -7,7 +7,7 @@ import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromp
 export const transformPrismaSchemaHistories = (
   requirementAnalysisReport: Record<string, string>,
   targetComponent: AutoBePrisma.IComponent,
-  otherComponents: AutoBePrisma.IComponent[],
+  otherTables: string[],
 ): Array<
   IAgenticaHistoryJson.IAssistantMessage | IAgenticaHistoryJson.ISystemMessage
 > => {
@@ -28,8 +28,8 @@ export const transformPrismaSchemaHistories = (
         "```",
         JSON.stringify({
           requirementAnalysisReport,
-          otherComponents,
           targetComponent,
+          otherTables,
         }),
         "```",
       ].join("\n"),

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaComponent.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaComponent.ts
@@ -13,14 +13,19 @@ import { v4 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
+import { forceRetry } from "../../utils/forceRetry";
 import { transformPrismaComponentsHistories } from "./histories/transformPrismaComponentsHistories";
 import { IAutoBePrismaComponentApplication } from "./structures/IAutoBePrismaComponentApplication";
 
-export async function orchestratePrismaComponents<
-  Model extends ILlmSchema.Model,
->(
+export const orchestratePrismaComponents = <Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   content: string = "Please extract files and tables from the given documents.",
+): Promise<AutoBeAssistantMessageHistory | AutoBePrismaComponentsEvent> =>
+  forceRetry(() => orchestrate(ctx, content));
+
+async function orchestrate<Model extends ILlmSchema.Model>(
+  ctx: AutoBeContext<Model>,
+  content: string,
 ): Promise<AutoBeAssistantMessageHistory | AutoBePrismaComponentsEvent> {
   const start: Date = new Date();
   const pointer: IPointer<IAutoBePrismaComponentApplication.IProps | null> = {

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
@@ -29,7 +29,12 @@ export async function orchestratePrismaSchemas<Model extends ILlmSchema.Model>(
         (y) => comp !== y,
       );
       const result: IAutoBePrismaSchemaApplication.IProps = await forceRetry(
-        () => process(ctx, targetComponent, otherComponents),
+        () =>
+          process(
+            ctx,
+            targetComponent,
+            otherComponents.map((c) => c.tables).flat(),
+          ),
       );
       const event: AutoBePrismaSchemasEvent = {
         type: "prismaSchemas",
@@ -54,7 +59,7 @@ export async function orchestratePrismaSchemas<Model extends ILlmSchema.Model>(
 async function process<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   targetComponent: AutoBePrisma.IComponent,
-  otherComponents: AutoBePrisma.IComponent[],
+  otherTables: string[],
 ): Promise<IAutoBePrismaSchemaApplication.IProps> {
   const pointer: IPointer<IAutoBePrismaSchemaApplication.IProps | null> = {
     value: null,
@@ -71,12 +76,12 @@ async function process<Model extends ILlmSchema.Model>(
     histories: transformPrismaSchemaHistories(
       ctx.state().analyze!.files,
       targetComponent,
-      otherComponents,
+      otherTables,
     ),
     controllers: [
       createApplication(ctx, {
         targetComponent,
-        otherComponents,
+        otherTables,
         build: (next) => {
           pointer.value = next;
         },
@@ -98,7 +103,7 @@ function createApplication<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   props: {
     targetComponent: AutoBePrisma.IComponent;
-    otherComponents: AutoBePrisma.IComponent[];
+    otherTables: string[];
     build: (next: IAutoBePrismaSchemaApplication.IProps) => void;
   },
 ): IAgenticaController.IClass<Model> {

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
@@ -34,14 +34,12 @@ export async function orchestratePrismaSchemas<Model extends ILlmSchema.Model>(
       const event: AutoBePrismaSchemasEvent = {
         type: "prismaSchemas",
         created_at: start.toISOString(),
-        thinking: result.thinking,
-        draft: result.draft,
+        plan: result.plan,
         review: result.review,
-        final: result.final,
         file: {
           filename: comp.filename,
           namespace: comp.namespace,
-          models: result.final,
+          models: result.models,
         },
         completed: (completed += comp.tables.length),
         total,

--- a/packages/agent/src/orchestrate/prisma/structures/IAutoBePrismaSchemaApplication.ts
+++ b/packages/agent/src/orchestrate/prisma/structures/IAutoBePrismaSchemaApplication.ts
@@ -44,17 +44,40 @@ export namespace IAutoBePrismaSchemaApplication {
      *
      * Workflow: Component analysis → Strategic planning → Design rationale
      */
-    thinking: string;
+    plan: string;
 
     /**
-     * Step 2: Initial Prisma schema models implementation.
+     * Step 2: Review and quality assessment of the database design plan.
      *
-     * AI generates the first working version of the Prisma schema models based on the
-     * strategic plan. This draft must be a structured Abstract Syntax Tree (AST)
-     * representation using the AutoBePrisma.IModel interface that implements all
-     * planned tables, relationships, and constraints. The models should follow
-     * Prisma conventions while incorporating enterprise patterns like snapshot
-     * tables and materialized views.
+     * AI performs a thorough review of the strategic plan to ensure it meets
+     * all requirements and best practices before implementation. This review
+     * process validates the design decisions, identifies potential issues,
+     * and confirms the approach will result in a robust schema.
+     *
+     * **Review Dimensions:**
+     *
+     * - **Requirement Coverage**: Verify all targetComponent.tables are planned
+     * - **Normalization Validation**: Confirm 3NF compliance strategy
+     * - **Relationship Integrity**: Validate foreign key references to existing tables
+     * - **Performance Considerations**: Review index strategy and query patterns
+     * - **Snapshot Architecture**: Ensure proper temporal data handling
+     * - **Materialized View Strategy**: Validate denormalization approach
+     * - **Naming Consistency**: Verify adherence to conventions
+     * - **Business Logic Alignment**: Confirm design supports all use cases
+     *
+     * Workflow: Plan analysis → Issue identification → Design validation
+     */
+    review: string;
+
+    /**
+     * Step 3: Production-ready Prisma schema models.
+     *
+     * AI generates the complete Prisma schema models based on the strategic plan.
+     * This must be a structured Abstract Syntax Tree (AST) representation using
+     * the AutoBePrisma.IModel interface that implements all planned tables,
+     * relationships, and constraints. The models should follow Prisma conventions
+     * while incorporating enterprise patterns like snapshot tables and
+     * materialized views.
      *
      * **Implementation Requirements:**
      *
@@ -72,109 +95,26 @@ export namespace IAutoBePrismaSchemaApplication {
      * - **Material Flag**: true only for mv_ prefixed tables
      * - **Descriptions**: Follow format with requirements mapping and business purpose
      *
-     * **Relationship Patterns in AST:**
+     * **Quality Requirements:**
      *
-     * - 1:1: Foreign field with unique: true
-     * - 1:N: Foreign field with unique: false
-     * - M:N: Separate junction table model with composite indexes
-     *
-     * Workflow: Strategic plan → AST implementation → Structured models
-     */
-    draft: AutoBePrisma.IModel[];
-
-    /**
-     * Step 3: Schema models review and quality assessment.
-     *
-     * AI performs a thorough review of the draft schema models implementation,
-     * examining multiple quality dimensions to ensure production readiness.
-     * This review process identifies issues, suggests improvements, and
-     * validates compliance with best practices.
-     *
-     * **Review Dimensions:**
-     *
-     * **AST Structure Validation:**
-     *
-     * - Model array completeness (all targetComponent.tables present)
-     * - Model naming matches targetComponent.tables EXACTLY
-     * - Field type appropriateness (uuid for keys, no calculated fields)
-     * - Relationship configurations correctness
-     *
-     * **Database Design Quality:**
-     *
-     * - **Normalization Compliance**:
-     *
-     *   - 1NF: Atomic values, no repeating groups
-     *   - 2NF: No partial dependencies on composite keys
-     *   - 3NF: No transitive dependencies
-     * - **Prohibited Fields Check**: No pre-calculated totals, cached values, or
-     *   aggregates in regular tables
-     * - **Snapshot Pattern**: Proper implementation for audit trails
-     * - **Junction Tables**: Correct naming ({table1}_{table2}) and structure
-     *
-     * **Index Strategy Validation:**
-     *
-     * - NO single foreign key indexes in PlainIndexes
-     * - Composite indexes for query patterns
-     * - Unique indexes for business constraints
-     * - GIN indexes for full-text search fields
-     *
-     * **Description Quality:**
-     *
-     * - Models include: requirement mapping, business purpose, relationships,
-     *   behaviors
-     * - Fields include: requirement aspect, business meaning, normalization
-     *   rationale
-     *
-     * **Language Validation:**
-     *
-     * - ALL descriptions MUST be in English
-     * - Check if any model or field descriptions are written in non-English languages
-     * - Identify descriptions that need translation in the final step
-     * - Flag any mixed-language descriptions that combine English with other languages
-     *
-     * Workflow: Draft models → Systematic analysis → Specific improvements
-     */
-    review: string;
-
-    /**
-     * Step 4: Final production-ready Prisma schema models.
-     *
-     * AI produces the final, polished version of the Prisma schema models
-     * incorporating all review feedback. This structured AST representation
-     * represents the completed schema implementation, ready for database
-     * migration and production deployment. All identified issues must be
-     * resolved, and the schema must meet enterprise-grade quality standards.
-     *
-     * **Final Schema Model Characteristics:**
-     *
-     * - **Complete Coverage**: All targetComponent.tables implemented with exact
-     *   names
+     * - **Complete Coverage**: All targetComponent.tables implemented with exact names
      * - **Zero Errors**: Valid AST structure, no validation warnings
-     * - **Proper Relationships**: All foreign keys reference existing tables
-     *   correctly
-     * - **Optimized Indexes**: Strategic indexes without redundant foreign key
-     *   indexes
-     * - **Full Normalization**: Strict 3NF compliance, denormalization only in
-     *   mv_ tables
+     * - **Proper Relationships**: All foreign keys reference existing tables correctly
+     * - **Optimized Indexes**: Strategic indexes without redundant foreign key indexes
+     * - **Full Normalization**: Strict 3NF compliance, denormalization only in mv_ tables
      * - **Enterprise Documentation**: Complete descriptions with business context
-     * - **English-Only Descriptions**: All descriptions translated to English if needed
+     * - **English-Only Descriptions**: All descriptions must be in English
      * - **Audit Support**: Proper snapshot patterns and temporal fields
      *   (created_at, updated_at, deleted_at)
-     * - **Type Safety**: Consistent use of UUID for all keys, appropriate field
-     *   types
+     * - **Type Safety**: Consistent use of UUID for all keys, appropriate field types
      *
-     * **AST Structure Requirements:**
+     * **Normalization Compliance:**
      *
-     * - **Model Array**: Each table from targetComponent.tables as IModel
-     * - **Primary Field**: Always UUID type with name "id"
-     * - **Foreign Fields**: Proper IRelation configurations for all relationships
-     * - **Plain Fields**: Business fields with correct types (no calculated
-     *   fields)
-     * - **Indexes**:
-     *   - UniqueIndexes: Business constraints and composite unique keys
-     *   - PlainIndexes: Query optimization (no single foreign key indexes)
-     *   - GinIndexes: Full-text search on string fields
-     * - **Material Flag**: true only for mv_ prefixed tables
+     * - 1NF: Atomic values, no repeating groups
+     * - 2NF: No partial dependencies on composite keys
+     * - 3NF: No transitive dependencies
+     * - **Prohibited Fields**: No pre-calculated totals, cached values, or
+     *   aggregates in regular tables
      *
      * **Relationship Patterns in AST:**
      *
@@ -182,18 +122,11 @@ export namespace IAutoBePrismaSchemaApplication {
      * - 1:N: Foreign field with unique: false
      * - M:N: Separate junction table model with composite indexes
      *
-     * **Language Translation Requirements:**
-     *
-     * - If review identified non-English descriptions in draft, translate them to English
-     * - Preserve the technical accuracy and business meaning during translation
-     * - Maintain the `Summary\n\nBody` format with proper paragraph breaks
-     * - Ensure all model descriptions, field descriptions, and other text are in English
-     *
-     * Workflow: Review feedback → Model refinement → Language translation → Production-ready structured models
+     * Workflow: Strategic plan → Direct AST implementation → Production-ready models
      *
      * This structured representation serves as the ultimate deliverable for
      * programmatic schema generation and manipulation.
      */
-    final: AutoBePrisma.IModel[];
+    models: AutoBePrisma.IModel[];
   }
 }

--- a/packages/interface/src/events/AutoBePrismaSchemasEvent.ts
+++ b/packages/interface/src/events/AutoBePrismaSchemasEvent.ts
@@ -7,9 +7,9 @@ import { AutoBeEventBase } from "./AutoBeEventBase";
  *
  * This event occurs when the Prisma agent has successfully designed and
  * validated all database tables for a particular business domain (e.g., Sales,
- * Orders, Users). The agent follows a systematic 5-step process: strategic
- * planning, initial implementation, code review, refinement, and AST
- * transformation, ensuring production-ready database schemas that maintain data
+ * Orders, Users). The agent follows a systematic 3-step process: strategic
+ * planning (plan), design review (review), and final schema file generation
+ * (file), ensuring production-ready database schemas that maintain data
  * integrity and business logic accuracy.
  *
  * Each schema file represents a cohesive unit of database design focused on a
@@ -23,88 +23,51 @@ import { AutoBeEventBase } from "./AutoBeEventBase";
 export interface AutoBePrismaSchemasEvent
   extends AutoBeEventBase<"prismaSchemas"> {
   /**
-   * Strategic database design analysis and planning phase.
+   * Step 1: Strategic database design analysis and planning phase.
    *
-   * Contains the AI agent's comprehensive analysis of the target business domain
-   * and its database design strategy. The agent evaluates the required tables,
-   * their relationships, normalization requirements, and performance
-   * considerations to create a well-architected database schema that aligns with
-   * business objectives and technical best practices.
+   * Contains the AI agent's comprehensive analysis of the target business
+   * domain and its database design strategy. The agent evaluates the required
+   * tables, their relationships, normalization requirements, and performance
+   * considerations to create a well-architected database schema that aligns
+   * with business objectives and technical best practices.
    *
-   * This planning phase establishes the foundation for the entire schema design,
-   * ensuring proper table organization, relationship mapping, and adherence to
-   * database normalization principles while considering future scalability and
-   * maintainability requirements.
+   * This planning phase establishes the foundation for the entire schema
+   * design, ensuring proper table organization, relationship mapping, and
+   * adherence to database normalization principles while considering future
+   * scalability and maintainability requirements.
    */
-  thinking: string;
+  plan: string;
 
   /**
-   * Initial Prisma schema models implementation.
+   * Step 2: Review and quality assessment of the database design plan.
    *
-   * Contains the first working version of the Prisma schema models in structured
-   * AST format for the target business domain. This draft implements all required
-   * tables with their fields, relationships, indexes, and constraints following
-   * Prisma conventions and enterprise database patterns using the
-   * AutoBePrisma.IModel interface.
+   * AI performs a thorough review of the strategic plan to ensure it meets
+   * all requirements and best practices before implementation. This review
+   * process validates the design decisions, identifies potential issues,
+   * and confirms the approach will result in a robust schema.
    *
-   * The draft serves as the foundation for iterative refinement, demonstrating
-   * the AI agent's understanding of the business requirements and its ability to
-   * translate them into properly structured database schema models that maintain
-   * data integrity and support efficient querying patterns.
-   */
-  draft: AutoBePrisma.IModel[];
-
-  /**
-   * Schema models review and quality assessment.
-   *
-   * Provides a comprehensive analysis of the draft schema models implementation,
-   * identifying potential issues, areas for improvement, and validation of best
-   * practices compliance. The review examines AST structure correctness,
-   * normalization adherence, relationship accuracy, index optimization, and
-   * documentation completeness.
-   *
-   * This critical review phase ensures that the generated schema models meet
-   * enterprise-grade quality standards, maintain data integrity, support
-   * efficient query patterns, and align with both business requirements and
-   * technical best practices before final implementation.
+   * The review covers requirement coverage, normalization validation,
+   * relationship integrity, performance considerations, snapshot architecture,
+   * materialized view strategy, naming consistency, and business logic
+   * alignment.
    */
   review: string;
 
   /**
-   * Final production-ready Prisma schema models.
+   * Generated Prisma schema file information for a specific business domain.
    *
-   * Contains the refined and polished version of the Prisma schema models that
-   * incorporate all review feedback and optimizations. This production-ready
-   * AST structure has zero validation errors, complete business entity coverage,
-   * optimized indexes, comprehensive documentation, and full compliance with
-   * database normalization principles.
+   * This field contains the complete schema file data including the filename,
+   * namespace, and the production-ready Prisma schema models. The AI agent has
+   * analyzed the requirements, designed the tables, and produced models that
+   * include all necessary relationships, indexes, and constraints.
    *
-   * The final schema models represent the culmination of the iterative design
-   * process, ready for direct use in database migrations and production
-   * deployment. They ensure consistent data modeling, maintainable architecture,
-   * and optimal performance characteristics for the target business domain.
-   */
-  final: AutoBePrisma.IModel[];
-
-  /**
-   * Generated Prisma schema file for a specific business domain.
+   * The generated file follows the naming convention `schema-{number}-{domain}.prisma`
+   * where the number indicates dependency order and the domain represents the
+   * business area. The models within the file follow Prisma conventions while
+   * incorporating enterprise patterns like snapshot tables and materialized views.
    *
-   * This field contains the complete database schema design for one business
-   * domain (e.g., Sales, Orders, Users) in a structured format. The AI agent
-   * has analyzed the requirements, designed the tables, and produced a
-   * production-ready schema file that includes all necessary models,
-   * relationships, indexes, and constraints.
-   *
-   * The generated file follows the naming convention
-   * `schema-{number}-{domain}.prisma` where the number indicates dependency
-   * order and the domain represents the business area. For example,
-   * `schema-02-actors.prisma` would contain all user-related tables like
-   * customers, administrators, and citizens.
-   *
-   * This structured representation enables the system to generate actual Prisma
-   * schema files that can be directly used for database migrations, ensuring
-   * consistent and maintainable database architecture across the entire
-   * application.
+   * Each model in the file.models array represents a table in the database with
+   * proper field definitions, relationships, indexes, and comprehensive documentation.
    */
   file: AutoBePrisma.IFile;
 
@@ -130,7 +93,8 @@ export interface AutoBePrismaSchemasEvent
   total: number;
 
   /**
-   * Iteration number of the requirements analysis this schema was generated for.
+   * Iteration number of the requirements analysis this schema was generated
+   * for.
    *
    * Tracks which version of the business requirements this database schema
    * reflects, ensuring alignment between the evolving requirements and the

--- a/test/src/TestFactory.ts
+++ b/test/src/TestFactory.ts
@@ -1,16 +1,13 @@
-import { AutoBeAgent } from "@autobe/agent";
+import { AutoBeAgent, AutoBeTokenUsage } from "@autobe/agent";
 import {
   AutoBeHistory,
   IAutoBeCompiler,
   IAutoBeCompilerListener,
-  IAutoBeTokenUsageJson,
 } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
 
 export interface TestFactory {
-  createAgent: (
-    histories: AutoBeHistory[],
-    tokenUsage?: IAutoBeTokenUsageJson,
-  ) => AutoBeAgent<ILlmSchema.Model>;
+  createAgent: (histories: AutoBeHistory[]) => AutoBeAgent<ILlmSchema.Model>;
   createCompiler: (listener?: IAutoBeCompilerListener) => IAutoBeCompiler;
+  getTokenUsage: () => AutoBeTokenUsage;
 }

--- a/test/src/features/analyze/internal/validate_agent_analyze_main.ts
+++ b/test/src/features/analyze/internal/validate_agent_analyze_main.ts
@@ -1,4 +1,4 @@
-import { AutoBeAgent } from "@autobe/agent";
+import { AutoBeAgent, AutoBeTokenUsage } from "@autobe/agent";
 import { FileSystemIterator } from "@autobe/filesystem";
 import {
   AutoBeEvent,
@@ -42,6 +42,9 @@ export const validate_agent_analyze_main = async (
   agent.on("analyzeComplete", listen);
 
   // GENERATE REPORT
+  const zero: AutoBeTokenUsage = new AutoBeTokenUsage(
+    factory.getTokenUsage().toJSON(),
+  );
   const go = (message: string) =>
     agent.conversate(
       [
@@ -75,6 +78,13 @@ export const validate_agent_analyze_main = async (
   if (process.argv.includes("--archive"))
     await TestHistory.save({
       [`${project}.analyze.json`]: JSON.stringify(agent.getHistories()),
-      [`${project}.analyze.snapshots.json`]: JSON.stringify(snapshots),
+      [`${project}.analyze.snapshots.json`]: JSON.stringify(
+        snapshots.map((s) => ({
+          event: s.event,
+          tokenUsage: new AutoBeTokenUsage(s.tokenUsage)
+            .decrement(zero)
+            .toJSON(),
+        })),
+      ),
     });
 };

--- a/test/src/features/interface/internal/prepare_agent_interface.ts
+++ b/test/src/features/interface/internal/prepare_agent_interface.ts
@@ -1,4 +1,4 @@
-import { AutoBeAgent } from "@autobe/agent";
+import { AutoBeAgent, AutoBeTokenUsage } from "@autobe/agent";
 import { AutoBeState } from "@autobe/agent/src/context/AutoBeState";
 import { AutoBeHistory } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
@@ -16,19 +16,26 @@ export const prepare_agent_interface = async (
     throw new Error("No OpenAI API key provided");
 
   const histories: AutoBeHistory[] = await TestHistory.getPrisma(project);
-  const agent: AutoBeAgent<ILlmSchema.Model> = factory.createAgent(
-    histories,
-    process.argv.includes("--archive")
-      ? await TestHistory.getTokenUsage({
-          project,
-          type: "prisma",
-        })
-      : undefined,
-  );
+  const agent: AutoBeAgent<ILlmSchema.Model> = factory.createAgent(histories);
   const state: AutoBeState = agent.getContext().state();
   return {
     agent,
     analyze: state.analyze!,
     prisma: state.prisma!,
+    zero: await getZeroTokenUsage(factory, project),
   };
+};
+
+const getZeroTokenUsage = async (
+  factory: TestFactory,
+  project: TestProject,
+): Promise<AutoBeTokenUsage> => {
+  const zero: AutoBeTokenUsage = new AutoBeTokenUsage(
+    await TestHistory.getTokenUsage({
+      project,
+      type: "prisma",
+    }),
+  );
+  zero.decrement(factory.getTokenUsage());
+  return zero;
 };

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -81,9 +81,10 @@ export const validate_agent_prisma_main = async (
     });
   });
   agent.on("prismaValidate", async (event) => {
+    console.log("prismaValidate", event.result.errors);
     validates.push(event);
     await FileSystemIterator.save({
-      root: `${TestGlobal.ROOT}/results/${project}/prisma-failure-${validates.length}`,
+      root: `${TestGlobal.ROOT}/results/${model}/${project}/prisma-failure-${validates.length}`,
       files: {
         "errors.json": JSON.stringify(event.result.errors),
         ...event.schemas,

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -47,12 +47,17 @@ export const validate_agent_prisma_main = async (
     start = event;
   });
   agent.on("prismaComponents", (event) => {
+    console.log(event.components);
     components = event;
   });
 
   const schemas: AutoBePrismaSchemasEvent[] = [];
   const insufficients: AutoBePrismaInsufficientEvent[] = [];
   agent.on("prismaSchemas", (event) => {
+    console.log(
+      "schemas",
+      event.file.models.map((m) => m.name),
+    );
     schemas.push(event);
   });
   agent.on("prismaInsufficient", (event) => {

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -1,4 +1,4 @@
-import { orchestrate } from "@autobe/agent";
+import { AutoBeTokenUsage, orchestrate } from "@autobe/agent";
 import { FileSystemIterator } from "@autobe/filesystem";
 import {
   AutoBeAssistantMessageHistory,
@@ -24,7 +24,7 @@ export const validate_agent_prisma_main = async (
 ) => {
   if (TestGlobal.env.API_KEY === undefined) return false;
 
-  const { agent } = await prepare_agent_prisma(factory, project);
+  const { agent, zero } = await prepare_agent_prisma(factory, project);
   const model: string = TestGlobal.getVendorModel();
   const snapshots: AutoBeEventSnapshot[] = [];
   const listen = (event: AutoBeEvent) => {
@@ -49,6 +49,7 @@ export const validate_agent_prisma_main = async (
   agent.on("prismaComponents", (event) => {
     console.log(
       event.components.map((c) => c.tables.length).reduce((a, b) => a + b, 0),
+      event.components.map((c) => c.tables.length),
       event.components,
     );
     components = event;
@@ -143,6 +144,13 @@ export const validate_agent_prisma_main = async (
   if (process.argv.includes("--archive"))
     await TestHistory.save({
       [`${project}.prisma.json`]: JSON.stringify(agent.getHistories()),
-      [`${project}.prisma.snapshots.json`]: JSON.stringify(snapshots),
+      [`${project}.prisma.snapshots.json`]: JSON.stringify(
+        snapshots.map((s) => ({
+          event: s.event,
+          tokenUsage: new AutoBeTokenUsage(s.tokenUsage)
+            .decrement(zero)
+            .toJSON(),
+        })),
+      ),
     });
 };

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -47,7 +47,10 @@ export const validate_agent_prisma_main = async (
     start = event;
   });
   agent.on("prismaComponents", (event) => {
-    console.log(event.components);
+    console.log(
+      event.components.map((c) => c.tables.length).reduce((a, b) => a + b, 0),
+      event.components,
+    );
     components = event;
   });
 
@@ -56,6 +59,7 @@ export const validate_agent_prisma_main = async (
   agent.on("prismaSchemas", (event) => {
     console.log(
       "schemas",
+      event.file.models.length,
       event.file.models.map((m) => m.name),
     );
     schemas.push(event);

--- a/test/src/features/realize/internal/prepare_agent_realize.ts
+++ b/test/src/features/realize/internal/prepare_agent_realize.ts
@@ -1,4 +1,4 @@
-import { AutoBeAgent } from "@autobe/agent";
+import { AutoBeAgent, AutoBeTokenUsage } from "@autobe/agent";
 import { AutoBeState } from "@autobe/agent/src/context/AutoBeState";
 import { AutoBeHistory } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
@@ -6,6 +6,7 @@ import { ILlmSchema } from "@samchon/openapi";
 import { TestFactory } from "../../../TestFactory";
 import { TestGlobal } from "../../../TestGlobal";
 import { TestHistory } from "../../../internal/TestHistory";
+import { TestProject } from "../../../structures/TestProject";
 
 export const prepare_agent_realize = async (
   factory: TestFactory,
@@ -15,15 +16,7 @@ export const prepare_agent_realize = async (
     throw new Error("No OpenAI API key provided");
 
   const histories: AutoBeHistory[] = await TestHistory.getTest(project);
-  const agent: AutoBeAgent<ILlmSchema.Model> = factory.createAgent(
-    histories,
-    process.argv.includes("--archive")
-      ? await TestHistory.getTokenUsage({
-          project,
-          type: "test",
-        })
-      : undefined,
-  );
+  const agent: AutoBeAgent<ILlmSchema.Model> = factory.createAgent(histories);
   const state: AutoBeState = agent.getContext().state();
 
   return {
@@ -32,5 +25,20 @@ export const prepare_agent_realize = async (
     prisma: state.prisma!,
     interface: state.interface!,
     test: state.test!,
+    zero: await getZeroTokenUsage(factory, project),
   };
+};
+
+const getZeroTokenUsage = async (
+  factory: TestFactory,
+  project: TestProject,
+): Promise<AutoBeTokenUsage> => {
+  const zero: AutoBeTokenUsage = new AutoBeTokenUsage(
+    await TestHistory.getTokenUsage({
+      project,
+      type: "test",
+    }),
+  );
+  zero.decrement(factory.getTokenUsage());
+  return zero;
 };

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -19,7 +19,8 @@ async function main(): Promise<void> {
   // PREPARE ENVIRONMENT
   const tokenUsage: AutoBeTokenUsage = new AutoBeTokenUsage();
   const factory: TestFactory = {
-    createAgent: (histories, tu) =>
+    getTokenUsage: () => tokenUsage,
+    createAgent: (histories) =>
       new AutoBeAgent({
         model: TestGlobal.env.SCHEMA_MODEL ?? "chatgpt",
         vendor: {
@@ -35,7 +36,7 @@ async function main(): Promise<void> {
         },
         compiler: (listener) => new AutoBeCompiler(listener),
         histories,
-        tokenUsage: tu ?? tokenUsage,
+        tokenUsage,
       }),
     createCompiler: (
       listener: IAutoBeCompilerListener = {


### PR DESCRIPTION
This pull request streamlines and simplifies the Prisma schema generation process across the documentation, prompts, type definitions, and orchestration logic. The main change is a reduction from a 4-step (or 5-step) process to a 3-step process, with updated terminology and structure: `plan`, `review`, and `models`. All references to the previous steps (`thinking`, `draft`, `final`) are replaced, and the schema agent workflow and output types are updated accordingly.

**Process and Documentation Updates:**
- Updated all documentation, prompt instructions, and output examples to reflect the new 3-step Prisma schema process: `plan` (strategic analysis), `review` (plan validation), and `models` (production-ready AST models), replacing the old 4-step process (`thinking`, `draft`, `review`, `final`). [[1]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL14-R23) [[2]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL47-R56) [[3]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL74-R99) [[4]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL137-R144) [[5]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL174-R166) [[6]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL475-R454) [[7]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL500-R480) [[8]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L11-R11)

**Type Definitions and Structures:**
- Refactored the `IAutoBePrismaSchemaApplication.IProps` interface to use `plan`, `review`, and `models` fields only, with detailed documentation for each step, and removed the `thinking`, `draft`, and `final` fields. [[1]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL47-R80) [[2]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL75-R130)

**Orchestration Logic:**
- Updated `orchestratePrismaSchemas.ts` to map and emit the new fields (`plan`, `review`, `models`) in events and file outputs, removing all references to the old step names.

**Event Documentation:**
- Revised the event documentation in `AutoBePrismaSchemasEvent.ts` to describe the new 3-step process and terminology.