### PR TITLE
feat(agent): optimize `AutoBePrismaSchemasEvent` related

### DIFF
--- a/packages/agent/prompts/PRISMA_SCHEMA.md
+++ b/packages/agent/prompts/PRISMA_SCHEMA.md
@@ -153,7 +153,7 @@ const otherTables: string[] = [
   modifications: [
     {
       name: "shopping_goods_options",
-      // Re-define only the neccessary model based on review feedback
+      // Re-define only the necessary model based on review feedback
     }
   ]
 }

--- a/packages/agent/prompts/PRISMA_SCHEMA.md
+++ b/packages/agent/prompts/PRISMA_SCHEMA.md
@@ -15,13 +15,13 @@ Your Domain: targetComponent.namespace = "..."
 1. **plan**: Analyze and plan database design for targetComponent.tables
 2. **draft**: Generate initial AST models based on the strategic plan
 3. **review**: Review the draft models for quality and completeness
-4. **final**: Produce refined production-ready AST models based on review feedback
+4. **modifications**: Produce modified AST models based on review feedback (only models that need changes)
 
 **SUCCESS CRITERIA:**
 ✅ Every table from `targetComponent.tables` exists in your output
 ✅ Total model count = `targetComponent.tables.length` (plus junction tables if needed)
 ✅ All model names match `targetComponent.tables` entries exactly
-✅ Complete IAutoBePrismaSchemaApplication.IProps structure with 4 fields (plan, draft, review, final)
+✅ Complete IAutoBePrismaSchemaApplication.IProps structure with 4 fields (plan, draft, review, modifications)
 ✅ AST models include proper field classification and type normalization
 
 ---
@@ -150,18 +150,10 @@ const otherTables: string[] = [
   
   review: "Draft validation complete: All required tables (shopping_goods, shopping_goods_options) are correctly implemented. Foreign key relationships properly configured. AST structure validated. Normalization verified - no calculated fields in regular tables. Index strategy optimized. All descriptions are in English and follow the required format.",
   
-  final: [
-    {
-      name: "shopping_goods",
-      // Refined model based on review feedback
-      // Complete model with comprehensive descriptions following Summary\n\nBody format
-      // Includes proper relationships, normalization compliance, and business context
-    },
+  modifications: [
     {
       name: "shopping_goods_options",
-      // Refined model with improvements from review
-      // Complete model with unique constraint on (goods_id, name)
-      // All review points addressed
+      // Re-define only the neccessary model based on review feedback
     }
   ]
 }

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
@@ -36,16 +36,23 @@ export async function orchestratePrismaSchemas<Model extends ILlmSchema.Model>(
             otherComponents.map((c) => c.tables).flat(),
           ),
       );
+      const models: AutoBePrisma.IModel[] = result.draft.map((draftModel) => {
+        const modified: AutoBePrisma.IModel | undefined =
+          result.modifications.find((m) => m.name === draftModel.name);
+        return modified ?? draftModel;
+      });
+
       const event: AutoBePrismaSchemasEvent = {
         type: "prismaSchemas",
         created_at: start.toISOString(),
         plan: result.plan,
         draft: result.draft,
         review: result.review,
+        modifications: result.modifications,
         file: {
           filename: comp.filename,
           namespace: comp.namespace,
-          models: result.final,
+          models: models,
         },
         completed: (completed += comp.tables.length),
         total,

--- a/packages/agent/src/orchestrate/prisma/structures/IAutoBePrismaSchemaApplication.ts
+++ b/packages/agent/src/orchestrate/prisma/structures/IAutoBePrismaSchemaApplication.ts
@@ -100,16 +100,22 @@ export namespace IAutoBePrismaSchemaApplication {
     review: string;
 
     /**
-     * Step 4: Production-ready Prisma schema models.
+     * Step 4: Model modifications based on review feedback.
      *
-     * AI generates the final Prisma schema models by applying the review feedback
-     * to the draft models. This must be a refined Abstract Syntax Tree (AST)
-     * representation using the AutoBePrisma.IModel interface that addresses all
-     * review points and produces error-free, production-ready schemas.
+     * AI generates only the modified Prisma schema models based on the review
+     * feedback. This contains ONLY the models that need changes, not the entire
+     * schema. The modifications will be applied to the draft models to produce
+     * the final production-ready schemas.
      *
-     * **Quality Requirements:**
+     * **Modification Structure:**
      *
-     * - **Complete Coverage**: All targetComponent.tables implemented with exact names
+     * - **Partial Updates**: Include only models that require changes
+     * - **Complete Model**: Each modified model must be complete (not partial fields)
+     * - **Model Identity**: Use exact model names from draft for matching
+     * - **Applied Changes**: Incorporate all review feedback for each model
+     *
+     * **Quality Requirements for Modified Models:**
+     *
      * - **Zero Errors**: Valid AST structure, no validation warnings
      * - **Proper Relationships**: All foreign keys reference existing tables correctly
      * - **Optimized Indexes**: Strategic indexes without redundant foreign key indexes
@@ -120,25 +126,18 @@ export namespace IAutoBePrismaSchemaApplication {
      *   (created_at, updated_at, deleted_at)
      * - **Type Safety**: Consistent use of UUID for all keys, appropriate field types
      *
-     * **Normalization Compliance:**
+     * **Application Process:**
      *
-     * - 1NF: Atomic values, no repeating groups
-     * - 2NF: No partial dependencies on composite keys
-     * - 3NF: No transitive dependencies
-     * - **Prohibited Fields**: No pre-calculated totals, cached values, or
-     *   aggregates in regular tables
+     * The final schema is constructed by:
+     * 1. Starting with the draft models
+     * 2. Replacing models that exist in modifications
+     * 3. Keeping unmodified models from draft as-is
      *
-     * **Relationship Patterns in AST:**
+     * Workflow: Review feedback → Identify changes → Generate modified models only
      *
-     * - 1:1: Foreign field with unique: true
-     * - 1:N: Foreign field with unique: false
-     * - M:N: Separate junction table model with composite indexes
-     *
-     * Workflow: Review feedback → Model refinement → Production-ready models
-     *
-     * This structured representation serves as the ultimate deliverable for
-     * programmatic schema generation and manipulation.
+     * This approach minimizes context usage while ensuring all necessary
+     * corrections are applied to produce production-ready schemas.
      */
-    final: AutoBePrisma.IModel[];
+    modifications: AutoBePrisma.IModel[];
   }
 }

--- a/packages/interface/src/events/AutoBePrismaSchemasEvent.ts
+++ b/packages/interface/src/events/AutoBePrismaSchemasEvent.ts
@@ -68,7 +68,21 @@ export interface AutoBePrismaSchemasEvent
   review: string;
 
   /**
-   * Step 4: Generated Prisma schema file information for a specific business domain.
+   * Step 4: Model modifications based on review feedback.
+   *
+   * Contains only the Prisma schema models that need changes based on the
+   * review feedback. This partial list includes complete model definitions
+   * for tables that require modifications, not the entire schema. The final
+   * schema is constructed by applying these modifications to the draft models.
+   *
+   * Each model in this array represents a complete replacement for the
+   * corresponding model in the draft, incorporating all necessary corrections
+   * and improvements identified during the review process.
+   */
+  modifications: AutoBePrisma.IModel[];
+
+  /**
+   * Step 5: Generated Prisma schema file information for a specific business domain.
    *
    * This field contains the complete schema file data including the filename,
    * namespace, and the production-ready Prisma schema models. The AI agent has

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -61,6 +61,8 @@ export const validate_agent_prisma_main = async (
     console.log(
       "schemas",
       event.file.models.length,
+      event.draft.map((m) => m.name),
+      event.modifications.map((m) => m.name),
       event.file.models.map((m) => m.name),
     );
     schemas.push(event);


### PR DESCRIPTION
This pull request refactors the Prisma schema generation workflow to improve efficiency and clarity. The main change is replacing the previous "final" step—which required generating all models after review—with a new "modifications" step that only includes models needing changes. This reduces unnecessary work and context usage. The code and documentation are updated throughout to reflect this new approach.

**Workflow and API changes:**

* The fourth step in the workflow is now called `modifications` instead of `final`, and contains only the models that require changes based on review feedback, not the entire schema. All references in documentation and interfaces are updated accordingly. [[1]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL18-R24) [[2]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL103-L112) [[3]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL123-R141) [[4]](diffhunk://#diff-faf8f6562d8e72f212efabae2de2b4f31de99c2bca314b6800f34132bcd214cfL71-R85)

**Implementation updates:**

* In `orchestratePrismaSchemas`, the final schema is now constructed by applying the `modifications` (replacing only the changed models) to the `draft` models, ensuring that only necessary updates are made.
* Example data and comments in the schema prompt are updated to use the new `modifications` field, and to clarify that only changed models are included.

**Documentation improvements:**

* All relevant docstrings and success criteria are revised to explain the new process, including how the final schema is built from draft plus modifications, and the rationale for this change. [[1]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL103-L112) [[2]](diffhunk://#diff-1f8680c5055a3292e6c64efc02a7350b09fb764734d3cd118a6a9981f77a955cL123-R141) [[3]](diffhunk://#diff-faf8f6562d8e72f212efabae2de2b4f31de99c2bca314b6800f34132bcd214cfL71-R85) [[4]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bL18-R24)