### PR TITLE
feat(agent): divide and conquer of prisma corrector

### DIFF
--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
@@ -10,6 +10,7 @@ import typia from "typia";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
+import { divideArray } from "../../utils/divideArray";
 import { enforceToolCall } from "../../utils/enforceToolCall";
 import { forceRetry } from "../../utils/forceRetry";
 import { transformPrismaCorrectHistories } from "./histories/transformPrismaCorrectHistories";
@@ -28,10 +29,10 @@ export function orchestratePrismaCorrect<Model extends ILlmSchema.Model>(
       return true;
     });
   application.files = application.files.filter((f) => f.models.length !== 0);
-  return step(ctx, application, life);
+  return iterate(ctx, application, life);
 }
 
-async function step<Model extends ILlmSchema.Model>(
+async function iterate<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   application: AutoBePrisma.IApplication,
   life: number,
@@ -58,8 +59,9 @@ async function step<Model extends ILlmSchema.Model>(
     step: ctx.state().analyze?.step ?? 0,
     created_at: new Date().toISOString(),
   });
-  const next: IAutoBePrismaCorrectApplication.IProps = await forceRetry(() =>
-    process(ctx, result),
+  const next: IAutoBePrismaCorrectApplication.IProps = await process(
+    ctx,
+    result,
   );
   const correction: AutoBePrisma.IApplication = {
     files: application.files.map((file) => ({
@@ -79,7 +81,7 @@ async function step<Model extends ILlmSchema.Model>(
     step: ctx.state().analyze?.step ?? 0,
     created_at: new Date().toISOString(),
   });
-  return step(
+  return iterate(
     ctx,
     {
       files: correction.files,
@@ -89,6 +91,43 @@ async function step<Model extends ILlmSchema.Model>(
 }
 
 async function process<Model extends ILlmSchema.Model>(
+  ctx: AutoBeContext<Model>,
+  failure: IAutoBePrismaValidation.IFailure,
+  capacity: number = 8,
+): Promise<IAutoBePrismaCorrectApplication.IProps> {
+  if (failure.errors.length <= capacity)
+    return forceRetry(() => execute(ctx, failure));
+  const divided: IAutoBePrismaValidation.IError[][] = divideArray({
+    array: failure.errors,
+    capacity,
+  });
+
+  const plannings: string[] = [];
+  const models: Record<string, AutoBePrisma.IModel> = {};
+  for (const errors of divided) {
+    const next: IAutoBePrismaCorrectApplication.IProps = await forceRetry(() =>
+      execute(ctx, {
+        success: false,
+        data: {
+          ...failure.data,
+          files: failure.data.files.map((file) => ({
+            ...file,
+            models: file.models.map((m) => models[m.name] ?? m),
+          })),
+        },
+        errors,
+      }),
+    );
+    plannings.push(next.planning);
+    for (const m of next.models) models[m.name] = m;
+  }
+  return {
+    planning: plannings.join("\n\n"),
+    models: Object.values(models),
+  };
+}
+
+async function execute<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   failure: IAutoBePrismaValidation.IFailure,
 ): Promise<IAutoBePrismaCorrectApplication.IProps> {


### PR DESCRIPTION
This pull request refactors the `orchestratePrismaCorrect` workflow to improve how it handles large numbers of validation errors by batching them and processing each batch separately. The main changes involve introducing a new batching mechanism and renaming functions for clarity.

**Refactoring and Error Batching:**

* Replaces the recursive `step` function with a new `iterate` function and updates all related calls for improved readability and clarity. (`orchestratePrismaCorrect.ts`) [[1]](diffhunk://#diff-ef86dd4305e40242004412ee7909671fd0ffa7985080fe9b62574ab1f1b0fdafL31-R35) [[2]](diffhunk://#diff-ef86dd4305e40242004412ee7909671fd0ffa7985080fe9b62574ab1f1b0fdafL82-R84)
* Introduces batching of validation errors using the new `divideArray` utility. If the number of errors exceeds a set capacity (default 8), errors are divided into batches and processed sequentially, with results merged at the end. (`orchestratePrismaCorrect.ts`) [[1]](diffhunk://#diff-ef86dd4305e40242004412ee7909671fd0ffa7985080fe9b62574ab1f1b0fdafR96-R132) [[2]](diffhunk://#diff-ef86dd4305e40242004412ee7909671fd0ffa7985080fe9b62574ab1f1b0fdafR13)
* Extracts the core execution logic into a new `execute` function, simplifying the main process and improving maintainability. (`orchestratePrismaCorrect.ts`)

**Reliability Improvements:**

* Removes unnecessary use of `forceRetry` in the main process loop, now only applying retries to the execution of each batch. (`orchestratePrismaCorrect.ts`)

These changes make the error correction process more robust and scalable, especially when handling large numbers of validation errors.