### PR TITLE
fix(agent): miss-used AI function calling application

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
@@ -159,55 +159,60 @@ function createApplication<Model extends ILlmSchema.Model>(props: {
   const application: ILlmApplication<Model> = collection[
     props.model
   ] as unknown as ILlmApplication<Model>;
-  application.functions[0] = {
-    ...application.functions[0],
-    validate: (next: unknown) => {
-      const result: IValidation<IAutoBeInterfaceOperationApplication.IProps> =
-        typia.validate<IAutoBeInterfaceOperationApplication.IProps>(next);
-      if (result.success === false) return result;
+  const validate = (next: unknown) => {
+    const result: IValidation<IAutoBeInterfaceOperationApplication.IProps> =
+      typia.validate<IAutoBeInterfaceOperationApplication.IProps>(next);
+    if (result.success === false) return result;
 
-      const operations: IAutoBeInterfaceOperationApplication.IOperation[] =
-        result.data.operations;
-      const errors: IValidation.IError[] = [];
-      operations.forEach((op, i) => {
-        if (op.method === "get" && op.requestBody !== null)
+    const operations: IAutoBeInterfaceOperationApplication.IOperation[] =
+      result.data.operations;
+    const errors: IValidation.IError[] = [];
+    operations.forEach((op, i) => {
+      if (op.method === "get" && op.requestBody !== null)
+        errors.push({
+          path: `$input.operations[${i}].requestBody`,
+          expected:
+            "GET method should not have request body. Change method, or re-design the operation.",
+          value: op.requestBody,
+        });
+      if (props.roles.length === 0) op.authorizationRoles = [];
+      else if (op.authorizationRoles.length !== 0 && props.roles.length !== 0)
+        op.authorizationRoles.forEach((role, j) => {
+          if (props.roles.includes(role) === true) return;
           errors.push({
-            path: `$input.operations[${i}].requestBody`,
-            expected:
-              "GET method should not have request body. Change method, or re-design the operation.",
-            value: op.requestBody,
+            path: `$input.operations[${i}].authorizationRoles[${j}]`,
+            expected: `null | ${props.roles.map((str) => JSON.stringify(str)).join(" | ")}`,
+            description: [
+              `Role "${role}" is not defined in the roles list.`,
+              "",
+              "Please select one of them below, or do not define (`null`):  ",
+              "",
+              ...props.roles.map((role) => `- ${role}`),
+            ].join("\n"),
+            value: role,
           });
-        if (props.roles.length === 0) op.authorizationRoles = [];
-        else if (op.authorizationRoles.length !== 0 && props.roles.length !== 0)
-          op.authorizationRoles.forEach((role, j) => {
-            if (props.roles.includes(role) === true) return;
-            errors.push({
-              path: `$input.operations[${i}].authorizationRoles[${j}]`,
-              expected: `null | ${props.roles.map((str) => JSON.stringify(str)).join(" | ")}`,
-              description: [
-                `Role "${role}" is not defined in the roles list.`,
-                "",
-                "Please select one of them below, or do not define (`null`):  ",
-                "",
-                ...props.roles.map((role) => `- ${role}`),
-              ].join("\n"),
-              value: role,
-            });
-          });
-      });
-      if (errors.length !== 0)
-        return {
-          success: false,
-          errors,
-          data: next,
-        };
-      return result;
-    },
+        });
+    });
+    if (errors.length !== 0)
+      return {
+        success: false,
+        errors,
+        data: next,
+      };
+    return result;
   };
   return {
     protocol: "class",
     name: "interface",
-    application,
+    application: {
+      ...application,
+      functions: [
+        {
+          ...application.functions[0],
+          validate,
+        },
+      ],
+    },
     execute: {
       makeOperations: (next) => {
         props.build(next.operations);

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
@@ -119,74 +119,78 @@ function createApplication<Model extends ILlmSchema.Model>(
   const application: ILlmApplication<Model> = collection[
     ctx.model
   ] as unknown as ILlmApplication<Model>;
-  // application.functions[0] = {
-  //   ...application.functions[0],
-  //   validate: (
-  //     input: unknown,
-  //   ): IValidation<IAutoBePrismaSchemaApplication.IProps> => {
-  //     const result: IValidation<IAutoBePrismaSchemaApplication.IProps> =
-  //       typia.validate<IAutoBePrismaSchemaApplication.IProps>(input);
-  //     if (result.success === false) return result;
+  // const validate = (
+  //   input: unknown,
+  // ): IValidation<IAutoBePrismaSchemaApplication.IProps> => {
+  //   const result: IValidation<IAutoBePrismaSchemaApplication.IProps> =
+  //     typia.validate<IAutoBePrismaSchemaApplication.IProps>(input);
+  //   if (result.success === false) return result;
 
-  //     const everyModels: AutoBePrisma.IModel[] = result.data.models;
-  //     result.data.models = result.data.models.filter((m) =>
-  //       props.otherComponents.every(
-  //         (oc) => oc.tables.includes(m.name) === false,
-  //       ),
-  //     );
-  //     const expected: string[] = props.targetComponent.tables;
-  //     const actual: string[] = result.data.models.map((m) => m.name);
-  //     const missed: string[] = expected.filter(
-  //       (x) => actual.includes(x) === false,
-  //     );
-  //     if (missed.length === 0) return result;
+  //   const everyModels: AutoBePrisma.IModel[] = result.data.models;
+  //   result.data.models = result.data.models.filter((m) =>
+  //     props.otherComponents.every((oc) => oc.tables.includes(m.name) === false),
+  //   );
+  //   const expected: string[] = props.targetComponent.tables;
+  //   const actual: string[] = result.data.models.map((m) => m.name);
+  //   const missed: string[] = expected.filter(
+  //     (x) => actual.includes(x) === false,
+  //   );
+  //   if (missed.length === 0) return result;
 
-  //     ctx.dispatch({
-  //       type: "prismaInsufficient",
-  //       created_at: new Date().toISOString(),
-  //       component: props.targetComponent,
-  //       actual: everyModels,
-  //       missed,
-  //       tablesToCreate: result.data.tablesToCreate,
-  //       validationReview: result.data.validationReview,
-  //       confirmedTables: result.data.confirmedTables,
-  //     });
-  //     return {
-  //       success: false,
-  //       data: result.data,
-  //       errors: [
-  //         {
-  //           path: "$input.file.models",
-  //           value: result.data.models,
-  //           expected: `Array<AutoBePrisma.IModel>`,
-  //           description: [
-  //             "You missed some tables from the current domain's component.",
-  //             "",
-  //             "Look at the following details to fix the schemas. Never forget to",
-  //             "compose the `missed` tables at the next function calling.",
-  //             "",
-  //             "- filename: current domain's filename",
-  //             "- namespace: current domain's namespace",
-  //             "- expected: expected tables in the current domain",
-  //             "- actual: actual tables you made",
-  //             "- missed: tables you have missed, and you have to compose again",
-  //             "",
-  //             JSON.stringify({
-  //               filename: props.targetComponent.filename,
-  //               namespace: props.targetComponent.namespace,
-  //               expected,
-  //               actual,
-  //               missed,
-  //             }),
-  //           ].join("\n"),
-  //         },
-  //       ],
-  //     };
-  //   },
+  //   ctx.dispatch({
+  //     type: "prismaInsufficient",
+  //     created_at: new Date().toISOString(),
+  //     component: props.targetComponent,
+  //     actual: everyModels,
+  //     missed,
+  //     tablesToCreate: result.data.tablesToCreate,
+  //     validationReview: result.data.validationReview,
+  //     confirmedTables: result.data.confirmedTables,
+  //   });
+  //   return {
+  //     success: false,
+  //     data: result.data,
+  //     errors: [
+  //       {
+  //         path: "$input.file.models",
+  //         value: result.data.models,
+  //         expected: `Array<AutoBePrisma.IModel>`,
+  //         description: [
+  //           "You missed some tables from the current domain's component.",
+  //           "",
+  //           "Look at the following details to fix the schemas. Never forget to",
+  //           "compose the `missed` tables at the next function calling.",
+  //           "",
+  //           "- filename: current domain's filename",
+  //           "- namespace: current domain's namespace",
+  //           "- expected: expected tables in the current domain",
+  //           "- actual: actual tables you made",
+  //           "- missed: tables you have missed, and you have to compose again",
+  //           "",
+  //           JSON.stringify({
+  //             filename: props.targetComponent.filename,
+  //             namespace: props.targetComponent.namespace,
+  //             expected,
+  //             actual,
+  //             missed,
+  //           }),
+  //         ].join("\n"),
+  //       },
+  //     ],
+  //   };
   // };
   return {
     protocol: "class",
     name: "Prisma Generator",
+    // application: {
+    //   ...application,
+    //   functions: [
+    //     {
+    //       ...application.functions[0],
+    //       validate,
+    //     },
+    //   ],
+    // },
     application,
     execute: {
       makePrismaSchemaFile: (next) => {

--- a/packages/agent/src/orchestrate/test/experimental/orchestrateTestWrite.ast
+++ b/packages/agent/src/orchestrate/test/experimental/orchestrateTestWrite.ast
@@ -228,33 +228,38 @@ function createApplication<Model extends ILlmSchema.Model>(props: {
   const application: ILlmApplication<Model> = collection[
     props.model
   ] as unknown as ILlmApplication<Model>;
-  application.functions[0] = {
-    ...application.functions[0],
-    validate: (input: unknown): IValidation<unknown> => {
-      const result: IValidation<ICreateTestCodeProps> =
-        typia.validate<ICreateTestCodeProps>(input);
-      if (result.success === false) return result;
+  const validate = (input: unknown): IValidation<unknown> => {
+    const result: IValidation<ICreateTestCodeProps> =
+      typia.validate<ICreateTestCodeProps>(input);
+    if (result.success === false) return result;
 
-      const context: IAutoBeTextValidateContext = {
-        function: result.data.function,
-        document: props.document,
-        endpoints,
-        errors: [],
-      };
-      validateTestFunction(context);
-      return context.errors.length === 0
-        ? result
-        : {
-            success: false,
-            data: result.data,
-            errors: context.errors,
-          };
-    },
+    const context: IAutoBeTextValidateContext = {
+      function: result.data.function,
+      document: props.document,
+      endpoints,
+      errors: [],
+    };
+    validateTestFunction(context);
+    return context.errors.length === 0
+      ? result
+      : {
+          success: false,
+          data: result.data,
+          errors: context.errors,
+        };
   };
   return {
     protocol: "class",
     name: "Create Test Code",
-    application,
+    application: {
+      ...application,
+      functions: [
+        {
+          ...application.functions[0],
+          validate,
+        },
+      ],
+    },
     execute: {
       createTestCode: (next) => {
         props.build(next);

--- a/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
@@ -231,68 +231,71 @@ function createApplication<Model extends ILlmSchema.Model>(props: {
   const application: ILlmApplication<Model> = collection[
     props.model
   ] as unknown as ILlmApplication<Model>;
+  const validate = (next: unknown): IValidation => {
+    const result: IValidation<IAutoBeTestScenarioApplication.IProps> =
+      typia.validate<IAutoBeTestScenarioApplication.IProps>(next);
+    if (result.success === false) return result;
 
-  application.functions[0] = {
-    ...application.functions[0],
-    validate: (next: unknown): IValidation => {
-      const result: IValidation<IAutoBeTestScenarioApplication.IProps> =
-        typia.validate<IAutoBeTestScenarioApplication.IProps>(next);
-      if (result.success === false) return result;
+    // merge to unique scenario groups
+    const scenarioGroups: IAutoBeTestScenarioApplication.IScenarioGroup[] = [];
+    result.data.scenarioGroups.forEach((sg) => {
+      const created = scenarioGroups.find(
+        (el) =>
+          el.endpoint.method === sg.endpoint.method &&
+          el.endpoint.path === sg.endpoint.path,
+      );
+      if (created) {
+        created.scenarios.push(...sg.scenarios);
+      } else {
+        scenarioGroups.push(sg);
+      }
+    });
 
-      // merge to unique scenario groups
-      const scenarioGroups: IAutoBeTestScenarioApplication.IScenarioGroup[] =
-        [];
-      result.data.scenarioGroups.forEach((sg) => {
-        const created = scenarioGroups.find(
-          (el) =>
-            el.endpoint.method === sg.endpoint.method &&
-            el.endpoint.path === sg.endpoint.path,
-        );
-        if (created) {
-          created.scenarios.push(...sg.scenarios);
-        } else {
-          scenarioGroups.push(sg);
-        }
-      });
-
-      // validate endpoints
-      const errors: IValidation.IError[] = [];
-      scenarioGroups.forEach((group, i) => {
-        if (props.dict.has(group.endpoint) === false)
-          errors.push({
-            value: group.endpoint,
-            path: `$input.scenarioGroups[${i}].endpoint`,
-            expected: "AutoBeOpenApi.IEndpoint",
-            description: props.endpointNotFound,
-          });
-        group.scenarios.forEach((s, j) => {
-          s.dependencies.forEach((dep, k) => {
-            if (props.dict.has(dep.endpoint) === false)
-              errors.push({
-                value: dep.endpoint,
-                path: `$input.scenarioGroups[${i}].scenarios[${j}].dependencies[${k}].endpoint`,
-                expected: "AutoBeOpenApi.IEndpoint",
-                description: props.endpointNotFound,
-              });
-          });
+    // validate endpoints
+    const errors: IValidation.IError[] = [];
+    scenarioGroups.forEach((group, i) => {
+      if (props.dict.has(group.endpoint) === false)
+        errors.push({
+          value: group.endpoint,
+          path: `$input.scenarioGroups[${i}].endpoint`,
+          expected: "AutoBeOpenApi.IEndpoint",
+          description: props.endpointNotFound,
+        });
+      group.scenarios.forEach((s, j) => {
+        s.dependencies.forEach((dep, k) => {
+          if (props.dict.has(dep.endpoint) === false)
+            errors.push({
+              value: dep.endpoint,
+              path: `$input.scenarioGroups[${i}].scenarios[${j}].dependencies[${k}].endpoint`,
+              expected: "AutoBeOpenApi.IEndpoint",
+              description: props.endpointNotFound,
+            });
         });
       });
-      return errors.length === 0
-        ? {
-            success: true,
-            data: scenarioGroups,
-          }
-        : {
-            success: false,
-            data: scenarioGroups,
-            errors,
-          };
-    },
+    });
+    return errors.length === 0
+      ? {
+          success: true,
+          data: scenarioGroups,
+        }
+      : {
+          success: false,
+          data: scenarioGroups,
+          errors,
+        };
   };
   return {
     protocol: "class",
     name: "Make test plans",
-    application,
+    application: {
+      ...application,
+      functions: [
+        {
+          ...application.functions[0],
+          validate,
+        },
+      ],
+    },
     execute: {
       makeScenario: (next) => {
         props.build(next);


### PR DESCRIPTION
This pull request refactors how the `validate` method is assigned to the first element of the `functions` array in several `createApplication` implementations. Instead of directly assigning the `validate` method, the code now replaces the entire function object at index 0 with a new object that spreads the original properties and adds or overrides the `validate` method. This approach ensures that the `validate` method is incorporated in a more robust and extensible way.

### Refactoring of `validate` method assignment

**Interface Operations**

- Refactored `createApplication` in `orchestrateInterfaceOperations.ts` to replace `application.functions[0]` with a new object that includes a `validate` method, instead of directly assigning the method. [[1]](diffhunk://#diff-707e88ad2b5a1dc0ef2103e899e40ebf21bbcff5fe9f65ef9fd70bbb7434189bL162-R164) [[2]](diffhunk://#diff-707e88ad2b5a1dc0ef2103e899e40ebf21bbcff5fe9f65ef9fd70bbb7434189bR205)

**Test Scenario**

- Updated `createApplication` in `orchestrateTestScenario.ts` to use the same object replacement pattern for `application.functions[0]`, ensuring the `validate` method is added while preserving existing properties. [[1]](diffhunk://#diff-4c52729a4e10e87bb801cf5adbae7129bc5521c9cbc322a07b5b8e587a338398L235-R244) [[2]](diffhunk://#diff-4c52729a4e10e87bb801cf5adbae7129bc5521c9cbc322a07b5b8e587a338398R290)

**Test Write (Experimental)**

- Applied the object replacement pattern for `application.functions[0]` in `orchestrateTestWrite.ast`, improving consistency in how the `validate` method is added. [[1]](diffhunk://#diff-85c50ed5698836d2f22001019c3e3d8a1cd8cb2711df9343fb31fcf19e0f6addL231-R233) [[2]](diffhunk://#diff-85c50ed5698836d2f22001019c3e3d8a1cd8cb2711df9343fb31fcf19e0f6addR252-L253)

### Consistency in commented-out Prisma code

**Prisma Schemas**

- Updated commented-out code in `orchestratePrismaSchemas.ts` to match the new pattern for adding `validate` to `application.functions[0]`, ensuring future consistency if this code is re-enabled. [[1]](diffhunk://#diff-ddac200dc1a870982d23ce59f35255469b6bf31dbfb2587f20c903c9a0c5569aL122-R135) [[2]](diffhunk://#diff-ddac200dc1a870982d23ce59f35255469b6bf31dbfb2587f20c903c9a0c5569aR185)