### PR TITLE
fix(playground): exact audio base64 format

### DIFF
--- a/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatBodyMovie.tsx
+++ b/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatBodyMovie.tsx
@@ -92,10 +92,9 @@ export const AutoBePlaygroundChatBodyMovie = (
           else if (isAudio)
             return {
               type: "audio",
-              data: await fileToBase64(file),
+              data: (await fileToBase64(file)).split(",")[1],
               format: file.type.includes("wav") ? "wav" : "mp3",
             };
-
           return {
             type: "file",
             file: props.uploadFile
@@ -509,10 +508,8 @@ const fileToBase64 = (file: File): Promise<string> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => {
-      const dataUrl = reader.result as string;
-      // Remove the data URL prefix to get pure base64
-      const base64 = dataUrl.split(",")[1];
-      resolve(base64);
+      const data: string = reader.result as string;
+      resolve(data);
     };
     reader.onerror = reject;
     reader.readAsDataURL(file);


### PR DESCRIPTION
This pull request updates how audio file uploads are handled in the `AutoBePlaygroundChatBodyMovie` component, specifically changing where base64 data extraction occurs. The main change is to have the base64 extraction logic in the component itself rather than in the `fileToBase64` utility function, which now returns the full Data URL.

**Audio file upload handling:**

* In `AutoBePlaygroundChatBodyMovie.tsx`, the code now extracts the base64-encoded data from the Data URL after calling `fileToBase64`, instead of having `fileToBase64` return just the base64 string. This makes the data handling more explicit at the usage site.

**Utility function adjustment:**

* The `fileToBase64` function now returns the full Data URL string rather than stripping out the prefix and returning only the base64 portion.