### PR TITLE
fix(playground): supportAudio as optional

### DIFF
--- a/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx
+++ b/packages/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx
@@ -70,7 +70,7 @@ export function AutoBePlaygroundChatMovie(
         props.service.conversate(contents);
       }}
       setError={setError}
-      supportAudio={props.supportAudio}
+      supportAudio={!!props.supportAudio}
     />
   );
   const sideMovie = () => (
@@ -159,7 +159,7 @@ export namespace AutoBePlaygroundChatMovie {
     service: IAutoBeRpcService;
     listener: AutoBePlaygroundListener;
     eventGroups?: IAutoBePlaygroundEventGroup[];
-    supportAudio: boolean;
+    supportAudio?: boolean;
   }
 }
 


### PR DESCRIPTION
This pull request makes a small change to the handling of the `supportAudio` prop in the `AutoBePlaygroundChatMovie` component, ensuring it is treated as an optional boolean and always passed as a boolean value to child components.

- Props and type improvements:
  * Made the `supportAudio` prop in `AutoBePlaygroundChatMovie.Props` optional instead of required.

- Prop value normalization:
  * Ensured that `supportAudio` is always passed as a boolean (`!!props.supportAudio`) to the child component, preventing potential issues when the prop is undefined.