### PR TITLE
feat(agent): mock agent's sleepMap updating

### DIFF
--- a/packages/agent/src/AutoBeMockAgent.ts
+++ b/packages/agent/src/AutoBeMockAgent.ts
@@ -138,7 +138,9 @@ export namespace AutoBeMockAgent {
   }
 }
 
-const sleepMap: Partial<Record<AutoBeEvent.Type, number>> = {
+const sleepMap: Record<AutoBeEvent.Type, number> = {
+  userMessage: 1_000,
+  assistantMessage: 1_000,
   // ANALYZE
   analyzeStart: 1_000,
   analyzeWrite: 500,
@@ -148,12 +150,14 @@ const sleepMap: Partial<Record<AutoBeEvent.Type, number>> = {
   prismaStart: 1_000,
   prismaComponents: 1_000,
   prismaSchemas: 500,
+  prismaInsufficient: 1_000,
+  prismaReview: 500,
   prismaValidate: 2_000,
   prismaCorrect: 500,
-  prismaInsufficient: 1_000,
   prismaComplete: 1_000,
   // INTERFACE
   interfaceStart: 1_000,
+  interfaceGroups: 1_000,
   interfaceEndpoints: 1_000,
   interfaceOperations: 400,
   interfaceSchemas: 400,
@@ -175,5 +179,10 @@ const sleepMap: Partial<Record<AutoBeEvent.Type, number>> = {
   realizeAuthorizationStart: 1_000,
   realizeAuthorizationWrite: 200,
   realizeAuthorizationValidate: 200,
+  realizeAuthorizationCorrect: 200,
   realizeAuthorizationComplete: 1_000,
+  realizeTestStart: 1_000,
+  realizeTestReset: 2_500,
+  realizeTestOperation: 400,
+  realizeTestComplete: 1_000,
 };

--- a/packages/playground-ui/src/movies/configure/AutoBePlaygroundConfigureMovie.tsx
+++ b/packages/playground-ui/src/movies/configure/AutoBePlaygroundConfigureMovie.tsx
@@ -67,7 +67,9 @@ export function AutoBePlaygroundConfigureMovie(
         header,
         listener,
         service: connector.getDriver(),
-        supportAudio,
+        uploadConfig: {
+          supportAudio,
+        },
       });
     } catch (error) {
       alert((error as Error)?.message);


### PR DESCRIPTION
This pull request updates the `sleepMap` in `AutoBeMockAgent.ts` to ensure all `AutoBeEvent.Type` values have explicit sleep durations, and adds new event types with their corresponding delays. The changes improve the consistency and completeness of event handling in the mock agent.

**Event delay mapping improvements:**

* Changed `sleepMap` from a `Partial<Record<...>>` to a full `Record<...>`, requiring all event types to have a defined delay.
* Added explicit delays for `userMessage` and `assistantMessage` event types.
* Added or reordered delays for several Prisma-related event types: `prismaInsufficient`, `prismaReview`, and ensured all are explicitly listed.
* Added new Interface event type delay: `interfaceGroups`.
* Added new Realize event type delays: `realizeAuthorizationCorrect`, `realizeTestStart`, `realizeTestReset`, `realizeTestOperation`, and `realizeTestComplete`.