### PR TITLE
chore: Add launch config for vscode

### DIFF
--- a/packages/vscode-extension/.vscode/launch.json
+++ b/packages/vscode-extension/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "${workspaceFolder}/../.."
+      ],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "autoAttachChildProcesses": true,
+      "preLaunchTask": "npm: watch"
+    }
+  ]
+}

--- a/packages/vscode-extension/.vscode/tasks.json
+++ b/packages/vscode-extension/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "group": "build",
+            "problemMatcher": "$tsc-watch",
+            "label": "npm: watch",
+            "isBackground": true,
+        }
+    ]
+}

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -23,12 +23,13 @@
     "vscode:apply-cursor": "pnpm vscode:pack -o autobe-vscode-extension.vsix && cursor --install-extension autobe-vscode-extension.vsix",
     "vscode:apply-code": "pnpm vscode:pack -o autobe-vscode-extension.vsix && code --install-extension autobe-vscode-extension.vsix",
     "test": "vscode-test",
-    "webview:build": "cd webview-ui && pnpm build && cd ..",
+    "webview:build": "cd ./webview-ui && pnpm build && cd ..",
     "build": "pnpm webview:build && pnpm rollup",
     "tsc": "tsc --noEmit",
     "rollup": "rollup -c",
     "webpack": "webpack",
-    "rspack": "rspack build"
+    "rspack": "rspack build",
+    "watch": "pnpm webview:build && pnpm rollup --watch"
   },
   "devDependencies": {
     "@autobe/agent": "workspace:^",


### PR DESCRIPTION
You can press F5 from `./packages/vscode-extension` to run the vscode extension in a development mode