### PR TITLE
fix(vscode-extension): rollup install

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -32,6 +32,7 @@
     "@vscode/test-cli": "^0.0.11",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.6.0",
+    "rollup": "^4.40.1",
     "typescript": "catalog:typescript"
   },
   "contributes": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,6 +506,9 @@ importers:
       '@vscode/vsce':
         specifier: ^3.6.0
         version: 3.6.0
+      rollup:
+        specifier: ^4.40.1
+        version: 4.46.2
       typescript:
         specifier: catalog:typescript
         version: 5.9.2


### PR DESCRIPTION
This pull request adds Rollup as a new development dependency to the VSCode extension package. This change prepares the project for bundling or build optimizations using Rollup.

Dependency management:

* Added `rollup` as a new dev dependency in `package.json` for the VSCode extension (`packages/vscode-extension/package.json`).
* Updated `pnpm-lock.yaml` to include `rollup` with its resolved version and specifier.