### PR TITLE
feat(playground): analyze review agent as progress typed

### DIFF
--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundCompleteEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundCompleteEventMovie.tsx
@@ -1,6 +1,5 @@
 import {
   AutoBeAnalyzeCompleteEvent,
-  AutoBeAnalyzeScenarioEvent,
   AutoBeInterfaceCompleteEvent,
   AutoBePrismaCompleteEvent,
   AutoBeRealizeCompleteEvent,
@@ -187,7 +186,6 @@ export namespace AutoBePlaygroundCompleteEventMovie {
     service: IAutoBeRpcService;
     event:
       | AutoBeAnalyzeCompleteEvent
-      | AutoBeAnalyzeScenarioEvent
       | AutoBePrismaCompleteEvent
       | AutoBeInterfaceCompleteEvent
       | AutoBeTestCompleteEvent
@@ -201,8 +199,6 @@ function getTitle(
   event: AutoBePlaygroundCompleteEventMovie.IProps["event"],
 ): string | null {
   switch (event.type) {
-    case "analyzeScenario":
-      return "Analyze Scenario";
     case "analyzeComplete":
       return "Analyze";
     case "prismaComplete":
@@ -274,8 +270,7 @@ const getMessage = (
 const getStage = (
   event: AutoBePlaygroundCompleteEventMovie.IProps["event"],
 ) => {
-  if (event.type === "analyzeScenario") return "analyze";
-  else if (event.type === "analyzeComplete") return "analyze";
+  if (event.type === "analyzeComplete") return "analyze";
   else if (event.type === "prismaComplete") return "prisma";
   else if (event.type === "interfaceComplete") return "interface";
   else if (event.type === "testComplete") return "test";

--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundEventMovie.tsx
@@ -27,6 +27,7 @@ export function AutoBePlaygroundEventMovie<Event extends AutoBeEvent>(
     case "realizeAuthorizationStart":
       return <AutoBePlaygroundStartEventMovie event={back} />;
     // SCENARIO EVENTS
+    case "analyzeScenario":
     case "prismaComponents":
     case "interfaceGroups":
     case "testScenario":
@@ -67,7 +68,6 @@ export function AutoBePlaygroundEventMovie<Event extends AutoBeEvent>(
       );
     // COMPLETE EVENTS
     case "analyzeComplete":
-    case "analyzeScenario":
     case "prismaComplete":
     case "interfaceComplete":
     case "testComplete":

--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundEventMovie.tsx
@@ -34,6 +34,7 @@ export function AutoBePlaygroundEventMovie<Event extends AutoBeEvent>(
       return <AutoBePlaygroundScenarioEventMovie event={back} />;
     // PROGRESS EVENTS
     case "analyzeWrite":
+    case "analyzeReview":
     case "interfaceEndpoints":
     case "prismaSchemas":
     case "prismaReview":
@@ -49,7 +50,6 @@ export function AutoBePlaygroundEventMovie<Event extends AutoBeEvent>(
         <AutoBePlaygroundProgressEventMovie event={back} last={props.last} />
       );
     // VALIDATE EVENTS
-    case "analyzeReview":
     case "prismaInsufficient":
     case "prismaValidate":
     case "interfaceComplement":

--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundProgressEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundProgressEventMovie.tsx
@@ -1,4 +1,5 @@
 import {
+  AutoBeAnalyzeReviewEvent,
   AutoBeAnalyzeWriteEvent,
   AutoBeInterfaceEndpointsEvent,
   AutoBeInterfaceOperationsEvent,
@@ -61,6 +62,7 @@ export namespace AutoBePlaygroundProgressEventMovie {
   export interface IProps {
     event:
       | AutoBeAnalyzeWriteEvent
+      | AutoBeAnalyzeReviewEvent
       | AutoBePrismaSchemasEvent
       | AutoBePrismaReviewEvent
       | AutoBeInterfaceEndpointsEvent
@@ -92,6 +94,11 @@ function getState(
         return {
           title: "Analyze Write",
           description: "Analyzing requirements, and writing a report paper",
+        };
+      case "analyzeReview":
+        return {
+          title: "Analyze Review",
+          description: "Reviewing the analysis results",
         };
       case "prismaSchemas":
         return {

--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundScenarioEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundScenarioEventMovie.tsx
@@ -1,4 +1,5 @@
 import {
+  AutoBeAnalyzeScenarioEvent,
   AutoBeInterfaceGroupsEvent,
   AutoBePrismaComponentsEvent,
   AutoBeRealizeTestResetEvent,
@@ -38,6 +39,7 @@ export function AutoBePlaygroundScenarioEventMovie(
 export namespace AutoBePlaygroundScenarioEventMovie {
   export interface IProps {
     event:
+      | AutoBeAnalyzeScenarioEvent
       | AutoBePrismaComponentsEvent
       | AutoBeInterfaceGroupsEvent
       | AutoBeTestScenarioEvent
@@ -54,6 +56,18 @@ function getState(
   event: AutoBePlaygroundScenarioEventMovie.IProps["event"],
 ): IState {
   switch (event.type) {
+    case "analyzeScenario":
+      return {
+        title: "Analyze Scenario",
+        description: (
+          <>
+            Generating analysis report.
+            <br />
+            <br />
+            Number of documents to write: #{event.files.length}
+          </>
+        ),
+      };
     case "prismaComponents":
       return {
         title: "Prisma Components",
@@ -106,6 +120,7 @@ function getState(
         description: "Resetting test environment.",
       };
     default:
+      event.type satisfies never;
       throw new Error("Unknown event type");
   }
 }

--- a/packages/playground-ui/src/movies/events/AutoBePlaygroundValidateEventMovie.tsx
+++ b/packages/playground-ui/src/movies/events/AutoBePlaygroundValidateEventMovie.tsx
@@ -1,5 +1,4 @@
 import {
-  AutoBeAnalyzeReviewEvent,
   AutoBeInterfaceComplementEvent,
   AutoBeInterfaceOperationsReviewEvent,
   AutoBePrismaInsufficientEvent,
@@ -103,7 +102,6 @@ export function AutoBePlaygroundValidateEventMovie<
 }
 export namespace AutoBePlaygroundValidateEventMovie {
   export type Supported =
-    | AutoBeAnalyzeReviewEvent
     | AutoBePrismaInsufficientEvent
     | AutoBePrismaValidateEvent
     | AutoBeInterfaceOperationsReviewEvent
@@ -122,22 +120,6 @@ function getState<Event extends AutoBePlaygroundValidateEventMovie.Supported>(
 ): IState {
   const last: Event = events[events.length - 1];
   switch (last.type) {
-    case "analyzeReview":
-      return {
-        title: "Analyze Review",
-        description: "Reviewing the analysis results",
-        progress: {
-          completed: last.completed,
-          total: last.total,
-        },
-        project: (event: AutoBeAnalyzeReviewEvent, i: number) => ({
-          title: `Analyze Review Report (${i + 1})`,
-          description: "Report of Analyze Review Event",
-          files: {
-            "review.md": event.review,
-          },
-        }),
-      } satisfies IState<AutoBeAnalyzeReviewEvent> as IState;
     case "prismaInsufficient":
       return {
         title: "Prisma Insufficient",


### PR DESCRIPTION
This pull request updates how the `analyzeReview` event is handled in the playground UI event movies. The main change is moving the handling of `analyzeReview` from the validate event movie to the progress event movie, ensuring it is grouped and displayed consistently with similar progress events.

**Event handling refactor:**

* Moved the handling of the `analyzeReview` event from `AutoBePlaygroundValidateEventMovie` to `AutoBePlaygroundProgressEventMovie`, including its import, type support, and state logic. [[1]](diffhunk://#diff-e32257a7614edcaa4ba9ae9fe5e32689824983071ffc89092dca02b2544f4adbR37) [[2]](diffhunk://#diff-e32257a7614edcaa4ba9ae9fe5e32689824983071ffc89092dca02b2544f4adbL52) [[3]](diffhunk://#diff-56e04fd2f36194c97d12915b7c4130066baa14b3a2da56682c0ad670e329200aR2) [[4]](diffhunk://#diff-56e04fd2f36194c97d12915b7c4130066baa14b3a2da56682c0ad670e329200aR65) [[5]](diffhunk://#diff-56e04fd2f36194c97d12915b7c4130066baa14b3a2da56682c0ad670e329200aR98-R102) [[6]](diffhunk://#diff-7cf5d61904d7e4afcd81b92655119590362ed508bd4797ce411c022ab212884aL2) [[7]](diffhunk://#diff-7cf5d61904d7e4afcd81b92655119590362ed508bd4797ce411c022ab212884aL106) [[8]](diffhunk://#diff-7cf5d61904d7e4afcd81b92655119590362ed508bd4797ce411c022ab212884aL125-L140)

**UI consistency:**

* Updated the UI so that the `analyzeReview` event now appears with other progress events, with appropriate titles and descriptions, rather than as a validate event.