### PR TITLE
fix(agent): interface agent to validate unique accessor

### DIFF
--- a/packages/agent/prompts/INTERFACE_ENDPOINT.md
+++ b/packages/agent/prompts/INTERFACE_ENDPOINT.md
@@ -104,20 +104,18 @@ Examples:
 For EACH independent entity identified in the requirements document, Prisma DB Schema, and API endpoint groups, you MUST include these standard endpoints:
 
 #### Standard CRUD operations:
-1. `GET /entity-plural` - Simple collection listing
-2. `PATCH /entity-plural` - Collection listing with searching/filtering (with requestBody)
-3. `GET /entity-plural/{id}` - Get specific entity by ID
-4. `POST /entity-plural` - Create new entity
-5. `PUT /entity-plural/{id}` - Update existing entity
-6. `DELETE /entity-plural/{id}` - Delete entity
+1. `PATCH /entity-plural` - Collection listing with searching/filtering (with requestBody)
+2. `GET /entity-plural/{id}` - Get specific entity by ID
+3. `POST /entity-plural` - Create new entity
+4. `PUT /entity-plural/{id}` - Update existing entity
+5. `DELETE /entity-plural/{id}` - Delete entity
 
 #### Nested resource operations (when applicable):
-7. `GET /parent-entities/{parentId}/child-entities` - Simple list of child entities under parent
-8. `PATCH /parent-entities/{parentId}/child-entities` - List child entities with search/filtering
-9. `GET /parent-entities/{parentId}/child-entities/{childId}` - Get specific child entity
-10. `POST /parent-entities/{parentId}/child-entities` - Create child entity under parent
-11. `PUT /parent-entities/{parentId}/child-entities/{childId}` - Update child entity
-12. `DELETE /parent-entities/{parentId}/child-entities/{childId}` - Delete child entity
+6. `PATCH /parent-entities/{parentId}/child-entities` - List child entities with search/filtering
+7. `GET /parent-entities/{parentId}/child-entities/{childId}` - Get specific child entity
+8.  `POST /parent-entities/{parentId}/child-entities` - Create child entity under parent
+9.  `PUT /parent-entities/{parentId}/child-entities/{childId}` - Update child entity
+10.  `DELETE /parent-entities/{parentId}/child-entities/{childId}` - Delete child entity
 
 **CRITICAL**: The DELETE operation behavior depends on the Prisma schema:
 - If the entity has soft delete fields (e.g., `deleted_at`, `is_deleted`), the DELETE endpoint will perform soft delete
@@ -270,7 +268,7 @@ Below are example projects that demonstrate the proper endpoint formatting.
 - Clean camelCase entity names
 - Hierarchical relationships preserved in nested paths
 - Both simple GET and complex PATCH endpoints for collections
-- Standard CRUD pattern: GET (simple list), PATCH (search), GET (single), POST (create), PUT (update), DELETE (delete)
+- Standard CRUD pattern: PATCH (search), GET (single), POST (create), PUT (update), DELETE (delete)
 
 ### 10.2. Shopping Mall
 

--- a/packages/agent/prompts/INTERFACE_OPERATION.md
+++ b/packages/agent/prompts/INTERFACE_OPERATION.md
@@ -88,11 +88,6 @@ Follow these patterns based on the endpoint method:
   - Response: Main entity type (e.g., `IUser`)
   - Name: `"at"`
 
-- **Simple Collection Listing**: `GET /entities`
-  - Returns basic list without complex filtering
-  - Response: Simple array or paginated results (e.g., `IPageIUser.ISummary`)
-  - Name: `"index"`
-
 #### PATCH Operations
 - **Complex Collection Search**: `PATCH /entities`
   - Supports complex search, filtering, sorting, pagination
@@ -183,7 +178,27 @@ For example, if the service prefix is "shopping":
   - "user-management" → "UserManagement" → `IUserManagementUser`
   - "blog_service" → "BlogService" → `IBlogServicePost`
 
-### 5.6. Authorization Roles
+### 5.6. Operation Name Uniqueness Rule
+
+Each operation must have a globally unique accessor within the API. The accessor combines the path structure with the operation name.
+
+**Accessor Formation:**
+1. Extract non-parameter segments from the path (ignore `{...}` parts)
+2. Join these segments with dots
+3. Append the operation name to create the final accessor
+
+**Examples:**
+- Path: `/shopping/sale/{saleId}/review/{reviewId}`, Name: `at`
+  → Accessor: `shopping.sale.review.at`
+- Path: `/users/{userId}/posts`, Name: `index`
+  → Accessor: `users.posts.index`
+- Path: `/shopping/customer/orders`, Name: `create`
+  → Accessor: `shopping.customer.orders.create`
+
+**Global Uniqueness:**
+Every accessor must be unique across the entire API. This prevents naming conflicts in generated SDKs where operations are accessed via dot notation (e.g., `api.shopping.sale.review.at()`)
+
+### 5.7. Authorization Roles
 
 The `authorizationRoles` field must specify which user roles can access the endpoint:
 

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
@@ -327,9 +327,8 @@ function createController<Model extends ILlmSchema.Model>(props: {
             "Here is the list of elements of duplicated operation names.",
             "Check them, and consider which operation name would be proper to modify.",
             "",
-            ...Array.from(indexes.keys())
             ...indexes
-              .map(idx => `- ${operations[idx].name} (accessor: ${key})`)
+              .map((idx) => `- ${operations[idx].name} (accessor: ${key})`)
               .join("\n"),
           ].join("\n"),
         });

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
@@ -1,5 +1,6 @@
 import { IAgenticaController, MicroAgentica } from "@agentica/core";
 import { AutoBeOpenApi } from "@autobe/interface";
+import { AutoBeEndpointComparator } from "@autobe/utils";
 import { ILlmApplication, ILlmSchema, IValidation } from "@samchon/openapi";
 import { HashMap, HashSet, IPointer } from "tstl";
 import typia from "typia";
@@ -8,6 +9,7 @@ import { NamingConvention } from "typia/lib/utils/NamingConvention";
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
 import { divideArray } from "../../utils/divideArray";
+import { emplaceMap } from "../../utils/emplaceMap";
 import { forceRetry } from "../../utils/forceRetry";
 import { transformInterfaceOperationHistories } from "./histories/transformInterfaceOperationHistories";
 import { orchestrateInterfaceOperationsReview } from "./orchestrateInterfaceOperationsReview";
@@ -241,6 +243,7 @@ function createController<Model extends ILlmSchema.Model>(props: {
       result.data.operations;
     const errors: IValidation.IError[] = [];
     operations.forEach((op, i) => {
+      // get method has request body
       if (op.method === "get" && op.requestBody !== null)
         errors.push({
           path: `$input.operations[${i}].requestBody`,
@@ -248,6 +251,7 @@ function createController<Model extends ILlmSchema.Model>(props: {
             "GET method should not have request body. Change method, or re-design the operation.",
           value: op.requestBody,
         });
+      // validate roles
       if (props.roles.length === 0) op.authorizationRoles = [];
       else if (op.authorizationRoles.length !== 0 && props.roles.length !== 0)
         op.authorizationRoles.forEach((role, j) => {
@@ -266,6 +270,72 @@ function createController<Model extends ILlmSchema.Model>(props: {
           });
         });
     });
+
+    // validate duplicated endpoints
+    const endpoints: HashMap<AutoBeOpenApi.IEndpoint, number[]> = new HashMap(
+      AutoBeEndpointComparator.hashCode,
+      AutoBeEndpointComparator.equals,
+    );
+    operations.forEach((op, i) => {
+      const key: AutoBeOpenApi.IEndpoint = {
+        path: op.path,
+        method: op.method,
+      };
+      const it = endpoints.find(key);
+      if (it.equals(endpoints.end()) === false) {
+        const indexes: number[] = it.second;
+        errors.push({
+          path: `$input.operations[${i}].{"path"|"method"}`,
+          expected: "Unique endpoint (path and method)",
+          value: key,
+          description: [
+            `Duplicated endpoint detected (method: ${op.method}, path: ${op.path}).`,
+            "",
+            "The duplicated endpoints of others are located in below accessors.",
+            "Check them, and consider which operation endpoint would be proper to modify.",
+            ...indexes.map(
+              (idx) => `- $input.operations.[${idx}].{"path"|"method"}`,
+            ),
+          ].join("\n"),
+        });
+        indexes.push(i);
+      } else endpoints.emplace(key, [i]);
+    });
+
+    // validate duplicated method names
+    const accessors: Map<string, number[]> = new Map();
+    operations.forEach((op, i) => {
+      const key: string =
+        op.path
+          .split("/")
+          .filter((e) => e[0] !== "{" && e.at(-1) !== "}")
+          .filter((e) => e.length !== 0)
+          .join(".") + `.${op.name}`;
+      const indexes: number[] = emplaceMap(accessors, key, () => []);
+      if (indexes.length !== 0) {
+        errors.push({
+          path: `$input.operations[${i}].name`,
+          expected: "Unique name in the same accessor scope.",
+          value: op.name,
+          description: [
+            `Duplicated operation accessor detected (name: ${op.name}, accessor: ${key}).`,
+            "",
+            "The operation name must be unique within the parent accessor.",
+            "In other worlds, the operation accessor determined by the name",
+            "must be unique in the OpenAPI document.",
+            "",
+            "Here is the list of elements of duplicated operation names.",
+            "Check them, and consider which operation name would be proper to modify.",
+            "",
+            ...Array.from(indexes.keys())
+              .map((name) => `- ${name}`)
+              .join("\n"),
+          ].join("\n"),
+        });
+      }
+      indexes.push(i);
+    });
+
     if (errors.length !== 0)
       return {
         success: false,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
@@ -328,7 +328,8 @@ function createController<Model extends ILlmSchema.Model>(props: {
             "Check them, and consider which operation name would be proper to modify.",
             "",
             ...Array.from(indexes.keys())
-              .map((name) => `- ${name}`)
+            ...indexes
+              .map(idx => `- ${operations[idx].name} (accessor: ${key})`)
               .join("\n"),
           ].join("\n"),
         });

--- a/packages/interface/src/openapi/AutoBeOpenApi.ts
+++ b/packages/interface/src/openapi/AutoBeOpenApi.ts
@@ -506,8 +506,31 @@ export namespace AutoBeOpenApi {
      * - `GET /shopping/orders/{orderId}/items` → `name: "index"` (lists items)
      * - `POST /shopping/orders/{orderId}/cancel` → `name: "cancel"`
      * - `PUT /users/{userId}/password` → `name: "updatePassword"`
+     *
+     * ## Uniqueness Rule
+     *
+     * The `name` must be unique within the API's accessor namespace. The
+     * accessor is formed by combining the path segments (excluding parameters)
+     * with the operation name.
+     *
+     * Accessor formation:
+     * 1. Extract non-parameter segments from the path (remove `{...}` parts)
+     * 2. Join segments with dots
+     * 3. Append the operation name
+     *
+     * Examples:
+     * - Path: `/shopping/sale/{saleId}/review/{reviewId}`, Name: `at`
+     *   → Accessor: `shopping.sale.review.at`
+     * - Path: `/users/{userId}/posts`, Name: `index`
+     *   → Accessor: `users.posts.index`
+     * - Path: `/auth/login`, Name: `signIn`
+     *   → Accessor: `auth.login.signIn`
+     *
+     * Each accessor must be globally unique across the entire API. This ensures
+     * operations can be uniquely identified in generated SDKs and prevents
+     * naming conflicts.
      */
-    name: string;
+    name: string & tags.MinLength<1>;
   }
 
   /**


### PR DESCRIPTION
This pull request introduces improvements to the API endpoint and operation validation process, updates documentation to clarify endpoint standards and naming conventions, and adds new validation logic to enforce uniqueness for both endpoints and operation accessors. These changes help ensure that generated APIs are more robust, consistent, and less prone to naming conflicts.

**Documentation updates and endpoint standards:**

* Updated `INTERFACE_ENDPOINT.md` to clarify the standard CRUD and nested resource endpoint patterns, removing the simple `GET` collection listing in favor of `PATCH` for search/filtering, and reordering the examples for clarity. [[1]](diffhunk://#diff-62fa45ca8e9fda448c4b29fdabd4747235c4ac663621825d4645ff710dbb8d76L107-R118) [[2]](diffhunk://#diff-62fa45ca8e9fda448c4b29fdabd4747235c4ac663621825d4645ff710dbb8d76L273-R271)
* Updated `INTERFACE_OPERATION.md` to remove the "Simple Collection Listing" (`GET /entities`) pattern, emphasizing `PATCH` for complex collection searches, and added a new section detailing the global uniqueness rule for operation accessors, including examples. [[1]](diffhunk://#diff-ebb95536e362925acc78f439c515010f5460944a1907e3e411a6261fe3cbc217L91-L95) [[2]](diffhunk://#diff-ebb95536e362925acc78f439c515010f5460944a1907e3e411a6261fe3cbc217L186-R201)
* Enhanced the `AutoBeOpenApi.IEndpoint` interface documentation to describe the accessor uniqueness rule and provide clear examples.

**Validation logic improvements:**

* Added logic in `orchestrateInterfaceOperations.ts` to:
  - Validate that each endpoint (combination of path and method) is unique, reporting detailed errors if duplicates are found.
  - Enforce that each operation accessor (dot-joined path segments plus operation name) is globally unique, with error reporting for conflicts.
  - Ensure `GET` methods do not have a request body, with explicit error messages.
* Added imports for `AutoBeEndpointComparator` and `emplaceMap` utilities to support the new validation logic. [[1]](diffhunk://#diff-707e88ad2b5a1dc0ef2103e899e40ebf21bbcff5fe9f65ef9fd70bbb7434189bR3) [[2]](diffhunk://#diff-707e88ad2b5a1dc0ef2103e899e40ebf21bbcff5fe9f65ef9fd70bbb7434189bR12)