### PR TITLE
fix(compiler): block description comment tag

### DIFF
--- a/internals/dependencies/nestjs/package-lock.json
+++ b/internals/dependencies/nestjs/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0",
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@nestia/benchmark": "^7.3.2",
-        "@nestia/core": "^7.3.2",
-        "@nestia/e2e": "^7.3.2",
-        "@nestia/editor": "^7.3.2",
-        "@nestia/fetcher": "^7.3.2",
-        "@nestia/sdk": "^7.3.2",
+        "@nestia/benchmark": "^7.3.3",
+        "@nestia/core": "^7.3.3",
+        "@nestia/e2e": "^7.3.3",
+        "@nestia/editor": "^7.3.3",
+        "@nestia/fetcher": "^7.3.3",
+        "@nestia/sdk": "^7.3.3",
         "@nestjs/common": "^11.1.0",
         "@nestjs/core": "^11.1.0",
         "@nestjs/platform-express": "^11.1.0",
@@ -38,7 +38,7 @@
         "serialize-error": "^4.1.0",
         "tgrid": "^1.1.0",
         "typescript": "~5.9.2",
-        "typia": "^9.7.0"
+        "typia": "^9.7.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -979,28 +979,28 @@
       }
     },
     "node_modules/@nestia/benchmark": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@nestia/benchmark/-/benchmark-7.3.2.tgz",
-      "integrity": "sha512-xGeUSuUc94JMv0hT0G/4i4fkOfuGVEInqsDf0cbvguusWxpj8zAjOLFsWmO7gTpvxantEyaW+WIbrmum8WzXSg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@nestia/benchmark/-/benchmark-7.3.3.tgz",
+      "integrity": "sha512-y7tFa/4+o9pe901s+i5IqOW0caILpBIVk7go6sgP8GiE4ogtOnHygbMovcb6NFB0dII9MJ8lmRo7CJFB+CQ2FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nestia/fetcher": "^7.3.2",
+        "@nestia/fetcher": "^7.3.3",
         "tgrid": "^1.1.0",
         "tstl": "^3.0.0"
       }
     },
     "node_modules/@nestia/core": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@nestia/core/-/core-7.3.2.tgz",
-      "integrity": "sha512-wYaekM6iFlIZkkvZejoioBIjIHKuPfusRD9lLKb0vYQctPpUPHTH2dljMX6GXzsG+6vtXpAdD40e/2HRz+jLig==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@nestia/core/-/core-7.3.3.tgz",
+      "integrity": "sha512-EtI5zCFI0yD18NoDl+mz0purLR/vEvHQYoN1yME2ymk8/TSaqF0WKYVlrJI4riAnXZW57ExJSwLfcKWE3EYGyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nestia/fetcher": "^7.3.2",
+        "@nestia/fetcher": "^7.3.3",
         "@nestjs/common": ">=7.0.1",
         "@nestjs/core": ">=7.0.1",
-        "@samchon/openapi": "^4.7.1",
+        "@samchon/openapi": "^4.5.0",
         "detect-ts-node": "^1.0.5",
         "get-function-location": "^2.0.0",
         "glob": "^11.0.3",
@@ -1009,17 +1009,17 @@
         "reflect-metadata": ">=0.1.12",
         "rxjs": ">=6.0.3",
         "tgrid": "^1.1.0",
-        "typia": "^9.7.0",
+        "typia": "^9.6.1",
         "ws": "^7.5.3"
       },
       "peerDependencies": {
-        "@nestia/fetcher": ">=7.3.2",
+        "@nestia/fetcher": ">=7.3.3",
         "@nestjs/common": ">=7.0.1",
         "@nestjs/core": ">=7.0.1",
         "@samchon/openapi": ">=4.5.0 <5.0.0",
         "reflect-metadata": ">=0.1.12",
         "rxjs": ">=6.0.3",
-        "typia": "^9.7.0"
+        "typia": "^9.6.1"
       }
     },
     "node_modules/@nestia/core/node_modules/glob": {
@@ -1063,71 +1063,71 @@
       }
     },
     "node_modules/@nestia/e2e": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@nestia/e2e/-/e2e-7.3.2.tgz",
-      "integrity": "sha512-ZqiDUMuaPQ74gK9R2GKVETfnzL2wXKKBVoPamQ/m3CkJ80Q8VVCqgZ38sminWKaD0r3CthLh0gQCiXA+hAATcA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@nestia/e2e/-/e2e-7.3.3.tgz",
+      "integrity": "sha512-tLFzN/Dua0KGCvZ1DCrZOoC7kadYLZ+GYTLKgHEwJFXnJD9olyUM1RpXJ+I4m9p4f/mjjVJrH4C6rPGjfVZQ2A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@nestia/editor": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@nestia/editor/-/editor-7.3.2.tgz",
-      "integrity": "sha512-99VNy1KfF/j8vmH5d6oqw6LjOhFimHE7X5jWinPAkeRcP+ZgZELFIL9jP8UCQadkMy2sD0PX36qcszleRELR0g==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@nestia/editor/-/editor-7.3.3.tgz",
+      "integrity": "sha512-LUYkuZ3wxoGuZV7oRmgAgdKw4C0XY1tb1HfOTtvrrXQlifSvMJXFRjyMfJitj57dfkQJysZF1lOvp+yLbU6jzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mui/material": "^5.15.6",
-        "@nestia/migrate": "^7.3.2",
-        "@samchon/openapi": "^4.7.1",
+        "@nestia/migrate": "^7.3.3",
+        "@samchon/openapi": "^4.5.0",
         "@stackblitz/sdk": "^1.11.0",
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "js-yaml": "^4.1.0",
         "prettier": "3.3.3",
         "prettier-plugin-jsdoc": "^1.3.2",
         "react-mui-fileuploader": "^0.5.2",
-        "typia": "^9.7.0"
+        "typia": "^9.6.1"
       }
     },
     "node_modules/@nestia/fetcher": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@nestia/fetcher/-/fetcher-7.3.2.tgz",
-      "integrity": "sha512-g7ShVYciZRuqneEMJlCvskn64GZWQ8w3nvBaBaiAEIvAMS5L8E5+3jYA7dVdYZiXimQ1No/fJLCp2Zjz7ytTqw==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@nestia/fetcher/-/fetcher-7.3.3.tgz",
+      "integrity": "sha512-wWRVRY9De5KlfB1sOvccEv/L9NEFDQQDyfyOUZfBRcjcK52CLzjoeUzDSPGYRwNsKaPjCXKRIq2+ica8oIkj2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@samchon/openapi": "^4.7.1"
+        "@samchon/openapi": "^4.5.0"
       }
     },
     "node_modules/@nestia/migrate": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@nestia/migrate/-/migrate-7.3.2.tgz",
-      "integrity": "sha512-k63TljoimiEFAlnXzkyTD5OrM5dyzCMUyta5Dch8Hj3oH0QtmRA09YWMe15bv1fDePT6R/4SVuG8KnkNQBE4Cg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@nestia/migrate/-/migrate-7.3.3.tgz",
+      "integrity": "sha512-aaQvQsfOYxap9+CmX0V+qWVbR7X6398iQCMy3UDGxx48lo66jYKV7MdCEBqp1xMvfUcJZQxGnuiyAOMIJOz4QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@samchon/openapi": "^4.7.1",
+        "@samchon/openapi": "^4.5.0",
         "commander": "10.0.0",
         "inquirer": "8.2.5",
         "prettier": "^3.3.3",
         "prettier-plugin-jsdoc": "^1.3.2",
         "tstl": "^3.0.0",
         "typescript": "~5.9.2",
-        "typia": "^9.7.0"
+        "typia": "^9.6.1"
       },
       "bin": {
         "migrate": "lib/executable/migrate.js"
       }
     },
     "node_modules/@nestia/sdk": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@nestia/sdk/-/sdk-7.3.2.tgz",
-      "integrity": "sha512-MTJdQ499iNq7Mt/Om2Tv80GvoUoAUqZuJzV35/sYRUgmKCi1z1Qxh7h0LkghnRCjOXoNv9TmrernFOVOkEh7TA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@nestia/sdk/-/sdk-7.3.3.tgz",
+      "integrity": "sha512-qqnmPe70xBnCNiXB/cT/+bMx7EQa9A0oegXfW2RVOQgdv1JgcKl/3kF5TsghtTdF8EgIm/aMPZ+I5Mfp2R9Org==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nestia/core": "^7.3.2",
-        "@nestia/fetcher": "^7.3.2",
-        "@samchon/openapi": "^4.7.1",
+        "@nestia/core": "^7.3.3",
+        "@nestia/fetcher": "^7.3.3",
+        "@samchon/openapi": "^4.5.0",
         "cli": "^1.0.1",
         "get-function-location": "^2.0.0",
         "glob": "^11.0.3",
@@ -1137,13 +1137,13 @@
         "tsconfck": "^2.1.2",
         "tsconfig-paths": "^4.1.1",
         "tstl": "^3.0.0",
-        "typia": "^9.7.0"
+        "typia": "^9.6.1"
       },
       "bin": {
         "sdk": "lib/executable/sdk.js"
       },
       "peerDependencies": {
-        "@nestia/core": ">=7.3.2"
+        "@nestia/core": ">=7.3.3"
       }
     },
     "node_modules/@nestia/sdk/node_modules/glob": {
@@ -6003,9 +6003,9 @@
       }
     },
     "node_modules/typia": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-9.7.0.tgz",
-      "integrity": "sha512-TjzPPlMfDED2dm3jYEVB0n7vgkCKrXCislI1c40JDjN58Cpog29odxlF6N/JsjN3LWXvjwi7DoOKwihE4U+giw==",
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-9.7.1.tgz",
+      "integrity": "sha512-HY9hhvAPhFvFHfjA3Ny1DmucUyrbsFalt+wr58oBJyNBFUxE6nTF8aJSpLOv1Bav6dZslNh39MEez0s7qLB1jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/internals/dependencies/nestjs/package.json
+++ b/internals/dependencies/nestjs/package.json
@@ -5,12 +5,12 @@
   "author": "Wrtn Technologies",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@nestia/benchmark": "^7.3.2",
-    "@nestia/core": "^7.3.2",
-    "@nestia/e2e": "^7.3.2",
-    "@nestia/editor": "^7.3.2",
-    "@nestia/fetcher": "^7.3.2",
-    "@nestia/sdk": "^7.3.2",
+    "@nestia/benchmark": "^7.3.3",
+    "@nestia/core": "^7.3.3",
+    "@nestia/e2e": "^7.3.3",
+    "@nestia/editor": "^7.3.3",
+    "@nestia/fetcher": "^7.3.3",
+    "@nestia/sdk": "^7.3.3",
     "@nestjs/common": "^11.1.0",
     "@nestjs/core": "^11.1.0",
     "@nestjs/platform-express": "^11.1.0",
@@ -34,6 +34,6 @@
     "serialize-error": "^4.1.0",
     "tgrid": "^1.1.0",
     "typescript": "~5.9.2",
-    "typia": "^9.7.0"
+    "typia": "^9.7.1"
   }
 }

--- a/internals/dependencies/test/package-lock.json
+++ b/internals/dependencies/test/package-lock.json
@@ -9,29 +9,29 @@
       "version": "0.0.0",
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@nestia/e2e": "^7.3.2",
-        "@nestia/fetcher": "^7.3.2",
+        "@nestia/e2e": "^7.3.3",
+        "@nestia/fetcher": "^7.3.3",
         "@samchon/openapi": "^4.7.1",
         "@types/node": "^22.15.3",
         "typescript": "~5.9.2",
-        "typia": "^9.7.0"
+        "typia": "^9.7.1"
       }
     },
     "node_modules/@nestia/e2e": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@nestia/e2e/-/e2e-7.3.2.tgz",
-      "integrity": "sha512-ZqiDUMuaPQ74gK9R2GKVETfnzL2wXKKBVoPamQ/m3CkJ80Q8VVCqgZ38sminWKaD0r3CthLh0gQCiXA+hAATcA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@nestia/e2e/-/e2e-7.3.3.tgz",
+      "integrity": "sha512-tLFzN/Dua0KGCvZ1DCrZOoC7kadYLZ+GYTLKgHEwJFXnJD9olyUM1RpXJ+I4m9p4f/mjjVJrH4C6rPGjfVZQ2A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@nestia/fetcher": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@nestia/fetcher/-/fetcher-7.3.2.tgz",
-      "integrity": "sha512-g7ShVYciZRuqneEMJlCvskn64GZWQ8w3nvBaBaiAEIvAMS5L8E5+3jYA7dVdYZiXimQ1No/fJLCp2Zjz7ytTqw==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@nestia/fetcher/-/fetcher-7.3.3.tgz",
+      "integrity": "sha512-wWRVRY9De5KlfB1sOvccEv/L9NEFDQQDyfyOUZfBRcjcK52CLzjoeUzDSPGYRwNsKaPjCXKRIq2+ica8oIkj2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@samchon/openapi": "^4.7.1"
+        "@samchon/openapi": "^4.5.0"
       }
     },
     "node_modules/@samchon/openapi": {
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/typia": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-9.7.0.tgz",
-      "integrity": "sha512-TjzPPlMfDED2dm3jYEVB0n7vgkCKrXCislI1c40JDjN58Cpog29odxlF6N/JsjN3LWXvjwi7DoOKwihE4U+giw==",
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-9.7.1.tgz",
+      "integrity": "sha512-HY9hhvAPhFvFHfjA3Ny1DmucUyrbsFalt+wr58oBJyNBFUxE6nTF8aJSpLOv1Bav6dZslNh39MEez0s7qLB1jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/internals/dependencies/test/package.json
+++ b/internals/dependencies/test/package.json
@@ -5,11 +5,11 @@
   "author": "Wrtn Technologies",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@nestia/e2e": "^7.3.2",
-    "@nestia/fetcher": "^7.3.2",
+    "@nestia/e2e": "^7.3.3",
+    "@nestia/fetcher": "^7.3.3",
     "@samchon/openapi": "^4.7.1",
     "@types/node": "^22.15.3",
     "typescript": "~5.9.2",
-    "typia": "^9.7.0"
+    "typia": "^9.7.1"
   }
 }

--- a/internals/template/realize/package.json
+++ b/internals/template/realize/package.json
@@ -49,9 +49,9 @@
   "homepage": "https://github.com/samchon/nestia-start#readme",
   "devDependencies": {
     "@autobe/interface": "^0.10.6",
-    "@nestia/benchmark": "^7.3.2",
-    "@nestia/e2e": "^7.3.2",
-    "@nestia/sdk": "^7.3.2",
+    "@nestia/benchmark": "^7.3.3",
+    "@nestia/e2e": "^7.3.3",
+    "@nestia/sdk": "^7.3.3",
     "@nestjs/cli": "^11.0.7",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
@@ -73,7 +73,7 @@
     "eslint-plugin-deprecation": "^3.0.0",
     "express": "^4.18.2",
     "fastify": "^5.4.0",
-    "nestia": "^7.3.2",
+    "nestia": "^7.3.3",
     "prettier": "^3.2.4",
     "prettier-plugin-prisma": "^5.0.0",
     "prisma-markdown": "^3.0.1",
@@ -91,8 +91,8 @@
     "write-file-webpack-plugin": "^4.5.1"
   },
   "dependencies": {
-    "@nestia/core": "^7.3.2",
-    "@nestia/fetcher": "^7.3.2",
+    "@nestia/core": "^7.3.3",
+    "@nestia/fetcher": "^7.3.3",
     "@nestjs/common": "^11.1.3",
     "@nestjs/core": "^11.1.3",
     "@nestjs/platform-express": "^11.1.3",
@@ -108,7 +108,7 @@
     "serialize-error": "^4.1.0",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^9.7.0",
+    "typia": "^9.7.1",
     "uuid": "^9.0.0"
   },
   "stackblitz": {

--- a/internals/template/test/package.json
+++ b/internals/template/test/package.json
@@ -46,9 +46,9 @@
   },
   "homepage": "https://github.com/samchon/nestia-start#readme",
   "devDependencies": {
-    "@nestia/benchmark": "^7.3.2",
-    "@nestia/e2e": "^7.3.2",
-    "@nestia/sdk": "^7.3.2",
+    "@nestia/benchmark": "^7.3.3",
+    "@nestia/e2e": "^7.3.3",
+    "@nestia/sdk": "^7.3.3",
     "@nestjs/cli": "^11.0.7",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
@@ -67,7 +67,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "eslint-plugin-deprecation": "^3.0.0",
     "express": "^4.18.2",
-    "nestia": "^7.3.2",
+    "nestia": "^7.3.3",
     "prettier": "^3.2.4",
     "prettier-plugin-prisma": "^5.0.0",
     "prisma-markdown": "^3.0.1",
@@ -85,8 +85,8 @@
     "write-file-webpack-plugin": "^4.5.1"
   },
   "dependencies": {
-    "@nestia/core": "^7.3.2",
-    "@nestia/fetcher": "^7.3.2",
+    "@nestia/core": "^7.3.3",
+    "@nestia/fetcher": "^7.3.3",
     "@nestjs/common": "^11.1.3",
     "@nestjs/core": "^11.1.3",
     "@nestjs/platform-express": "^11.1.3",
@@ -99,7 +99,7 @@
     "serialize-error": "^4.1.0",
     "tgrid": "^1.1.0",
     "tstl": "^3.0.0",
-    "typia": "^9.7.0",
+    "typia": "^9.7.1",
     "uuid": "^9.0.0"
   },
   "stackblitz": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,17 +15,17 @@ catalogs:
       version: 5.12.1
   samchon:
     '@nestia/core':
-      specifier: ^7.3.2
-      version: 7.3.2
+      specifier: ^7.3.3
+      version: 7.3.3
     '@nestia/e2e':
-      specifier: ^7.3.2
-      version: 7.3.2
+      specifier: ^7.3.3
+      version: 7.3.3
     '@nestia/fetcher':
-      specifier: ^7.3.2
-      version: 7.3.2
+      specifier: ^7.3.3
+      version: 7.3.3
     '@nestia/migrate':
-      specifier: ^7.3.2
-      version: 7.3.2
+      specifier: ^7.3.3
+      version: 7.3.3
     '@samchon/openapi':
       specifier: ^4.7.1
       version: 4.7.1
@@ -45,7 +45,7 @@ catalogs:
       specifier: ^3.0.0
       version: 3.0.0
     typia:
-      specifier: ^9.7.0
+      specifier: ^9.7.1
       version: 9.7.1
   typescript:
     ts-node:
@@ -97,13 +97,13 @@ importers:
         version: link:../../packages/rpc
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.3.2(@nestia/fetcher@7.3.2)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))
+        version: 7.3.3(@nestia/fetcher@7.3.3)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))
       '@nestia/e2e':
         specifier: catalog:samchon
-        version: 7.3.2
+        version: 7.3.3
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.3.2
+        version: 7.3.3
       '@nestjs/common':
         specifier: ^11.1.3
         version: 11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -210,10 +210,10 @@ importers:
         version: link:../utils
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.3.2(@nestia/fetcher@7.3.2)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))
+        version: 7.3.3(@nestia/fetcher@7.3.3)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.3.2
+        version: 7.3.3
       '@samchon/openapi':
         specifier: catalog:samchon
         version: 4.7.1
@@ -653,16 +653,16 @@ importers:
         version: link:../packages/utils
       '@nestia/core':
         specifier: catalog:samchon
-        version: 7.3.2(@nestia/fetcher@7.3.2)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))
+        version: 7.3.3(@nestia/fetcher@7.3.3)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))
       '@nestia/e2e':
         specifier: catalog:samchon
-        version: 7.3.2
+        version: 7.3.3
       '@nestia/fetcher':
         specifier: catalog:samchon
-        version: 7.3.2
+        version: 7.3.3
       '@nestia/migrate':
         specifier: catalog:samchon
-        version: 7.3.2
+        version: 7.3.3
       '@samchon/openapi':
         specifier: catalog:samchon
         version: 4.7.1
@@ -1695,10 +1695,10 @@ packages:
   '@napi-rs/wasm-runtime@1.0.3':
     resolution: {integrity: sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==}
 
-  '@nestia/core@7.3.2':
-    resolution: {integrity: sha512-wYaekM6iFlIZkkvZejoioBIjIHKuPfusRD9lLKb0vYQctPpUPHTH2dljMX6GXzsG+6vtXpAdD40e/2HRz+jLig==}
+  '@nestia/core@7.3.3':
+    resolution: {integrity: sha512-EtI5zCFI0yD18NoDl+mz0purLR/vEvHQYoN1yME2ymk8/TSaqF0WKYVlrJI4riAnXZW57ExJSwLfcKWE3EYGyg==}
     peerDependencies:
-      '@nestia/fetcher': '>=7.3.2'
+      '@nestia/fetcher': '>=7.3.3'
       '@nestjs/common': '>=7.0.1'
       '@nestjs/core': '>=7.0.1'
       '@samchon/openapi': '>=4.5.0 <5.0.0'
@@ -1706,14 +1706,14 @@ packages:
       rxjs: '>=6.0.3'
       typia: ^9.6.1
 
-  '@nestia/e2e@7.3.2':
-    resolution: {integrity: sha512-ZqiDUMuaPQ74gK9R2GKVETfnzL2wXKKBVoPamQ/m3CkJ80Q8VVCqgZ38sminWKaD0r3CthLh0gQCiXA+hAATcA==}
+  '@nestia/e2e@7.3.3':
+    resolution: {integrity: sha512-tLFzN/Dua0KGCvZ1DCrZOoC7kadYLZ+GYTLKgHEwJFXnJD9olyUM1RpXJ+I4m9p4f/mjjVJrH4C6rPGjfVZQ2A==}
 
-  '@nestia/fetcher@7.3.2':
-    resolution: {integrity: sha512-g7ShVYciZRuqneEMJlCvskn64GZWQ8w3nvBaBaiAEIvAMS5L8E5+3jYA7dVdYZiXimQ1No/fJLCp2Zjz7ytTqw==}
+  '@nestia/fetcher@7.3.3':
+    resolution: {integrity: sha512-wWRVRY9De5KlfB1sOvccEv/L9NEFDQQDyfyOUZfBRcjcK52CLzjoeUzDSPGYRwNsKaPjCXKRIq2+ica8oIkj2Q==}
 
-  '@nestia/migrate@7.3.2':
-    resolution: {integrity: sha512-k63TljoimiEFAlnXzkyTD5OrM5dyzCMUyta5Dch8Hj3oH0QtmRA09YWMe15bv1fDePT6R/4SVuG8KnkNQBE4Cg==}
+  '@nestia/migrate@7.3.3':
+    resolution: {integrity: sha512-aaQvQsfOYxap9+CmX0V+qWVbR7X6398iQCMy3UDGxx48lo66jYKV7MdCEBqp1xMvfUcJZQxGnuiyAOMIJOz4QA==}
     hasBin: true
 
   '@nestjs/common@11.1.6':
@@ -8762,9 +8762,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.0
     optional: true
 
-  '@nestia/core@7.3.2(@nestia/fetcher@7.3.2)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))':
+  '@nestia/core@7.3.3(@nestia/fetcher@7.3.3)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))':
     dependencies:
-      '@nestia/fetcher': 7.3.2
+      '@nestia/fetcher': 7.3.3
       '@nestjs/common': 11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@samchon/openapi': 4.7.1
@@ -8782,13 +8782,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@nestia/e2e@7.3.2': {}
+  '@nestia/e2e@7.3.3': {}
 
-  '@nestia/fetcher@7.3.2':
+  '@nestia/fetcher@7.3.3':
     dependencies:
       '@samchon/openapi': 4.7.1
 
-  '@nestia/migrate@7.3.2':
+  '@nestia/migrate@7.3.3':
     dependencies:
       '@samchon/openapi': 4.7.1
       commander: 10.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,20 +11,20 @@ catalogs:
     "@agentica/core": ^0.31.1
     "@agentica/rpc": ^0.31.1
   samchon:
-    "@nestia/benchmark": ^7.3.2
-    "@nestia/core": ^7.3.2
-    "@nestia/e2e": ^7.3.2
-    "@nestia/editor": ^7.3.2
-    "@nestia/fetcher": ^7.3.2
-    "@nestia/migrate": ^7.3.2
-    "@nestia/sdk": ^7.3.2
+    "@nestia/benchmark": ^7.3.3
+    "@nestia/core": ^7.3.3
+    "@nestia/e2e": ^7.3.3
+    "@nestia/editor": ^7.3.3
+    "@nestia/fetcher": ^7.3.3
+    "@nestia/migrate": ^7.3.3
+    "@nestia/sdk": ^7.3.3
     "@samchon/openapi": ^4.7.1
     embed-prisma: ^1.1.0
     embed-typescript: ^1.0.1
     prisma-markdown: ^3.0.0
     tgrid: ^1.2.0
     tstl: ^3.0.0
-    typia: ^9.7.0
+    typia: ^9.7.1
   typescript:
     ts-node: ^10.9.2
     ts-patch: ^3.3.0


### PR DESCRIPTION
This pull request updates several dependencies across the project, primarily focusing on bumping the versions of the `@nestia` packages and `typia` to their latest patch releases. These changes help ensure compatibility, bring in bug fixes, and maintain up-to-date development tools.

Dependency updates:

* Bumped all `@nestia` packages (`@nestia/benchmark`, `@nestia/core`, `@nestia/e2e`, `@nestia/editor`, `@nestia/fetcher`, `@nestia/migrate`, `@nestia/sdk`) from version `7.3.2` to `7.3.3` in `internals/dependencies/nestjs/package.json`, `internals/dependencies/nestjs/package-lock.json`, `internals/dependencies/test/package.json`, `internals/dependencies/test/package-lock.json`, `internals/template/realize/package.json`, `internals/template/test/package.json`, and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L12-R17) [[2]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L982-R1003) [[3]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L1066-R1130) [[4]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L1140-R1146) [[5]](diffhunk://#diff-ee9f5efdbc699d4ab23f46f2fb6321d51365ea3249f841d46d6d820dacd6cc8cL8-R13) [[6]](diffhunk://#diff-9f429a1beadcd2ad9be884af5e20ea5d8866d56f228889fdca32fb7cb79ccb62L52-R54) [[7]](diffhunk://#diff-9f429a1beadcd2ad9be884af5e20ea5d8866d56f228889fdca32fb7cb79ccb62L94-R95) [[8]](diffhunk://#diff-c7d7f1f27421e276745f8bff873cae0f1100b6db00eec253fee74a3052306eeeL49-R51) [[9]](diffhunk://#diff-c7d7f1f27421e276745f8bff873cae0f1100b6db00eec253fee74a3052306eeeL88-R89) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18-R28) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL100-R106) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL213-R216)

* Updated `typia` dependency from `^9.7.0` to `^9.7.1` (and in some cases to `^9.6.1` for sub-dependencies) in all relevant `package.json` and lock files to ensure the latest bug fixes and improvements are included. [[1]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L41-R41) [[2]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L1012-R1022) [[3]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L1140-R1146) [[4]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L6006-R6008) [[5]](diffhunk://#diff-ee9f5efdbc699d4ab23f46f2fb6321d51365ea3249f841d46d6d820dacd6cc8cL37-R37) [[6]](diffhunk://#diff-b59e0dfceec23e396c30131d2fb558afdf5ca3c4b4b4c3d2657b208a5cc100f3L12-R34) [[7]](diffhunk://#diff-b59e0dfceec23e396c30131d2fb558afdf5ca3c4b4b4c3d2657b208a5cc100f3L840-R842) [[8]](diffhunk://#diff-f3ecf80ce69bcd4bea2b3f9e3527914195e25a481a780ff196cde8f88372fb0fL8-R13) [[9]](diffhunk://#diff-9f429a1beadcd2ad9be884af5e20ea5d8866d56f228889fdca32fb7cb79ccb62L111-R111) [[10]](diffhunk://#diff-c7d7f1f27421e276745f8bff873cae0f1100b6db00eec253fee74a3052306eeeL102-R102) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL48-R48)

Other dependency adjustments:

* Downgraded `@samchon/openapi` dependency from `^4.7.1` to `^4.5.0` in some `@nestia` package dependencies to match upstream requirements. [[1]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L982-R1003) [[2]](diffhunk://#diff-00d98ae79a0ac9881771abf7ed8f21ce62c7f1e94fbc70d88ba7a7802fa51736L1066-R1130)

These updates are routine maintenance and do not introduce new features or breaking changes.