### PR TITLE
feat(test): simplify event listener functions

### DIFF
--- a/packages/vscode-extension/interface/src/message.dto.ts
+++ b/packages/vscode-extension/interface/src/message.dto.ts
@@ -3,7 +3,6 @@ import {
   AutoBeHistory,
   IAutoBeTokenUsageJson,
 } from "@autobe/interface";
-import { ILlmSchema } from "@samchon/openapi";
 
 export type IAutoBeWebviewMessage =
   | IRequestGetConfig

--- a/test/src/features/analyze/internal/validate_agent_analyze_main.ts
+++ b/test/src/features/analyze/internal/validate_agent_analyze_main.ts
@@ -37,11 +37,8 @@ export const validate_agent_analyze_main = async (
     });
   };
   agent.on("assistantMessage", listen);
-  agent.on("analyzeStart", listen);
-  agent.on("analyzeScenario", listen);
-  agent.on("analyzeWrite", listen);
-  agent.on("analyzeReview", listen);
-  agent.on("analyzeComplete", listen);
+  for (const type of typia.misc.literals<AutoBeEvent.Type>())
+    if (type.startsWith("analyze")) agent.on(type, listen);
 
   // GENERATE REPORT
   const zero: AutoBeTokenUsage = new AutoBeTokenUsage(

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -11,6 +11,7 @@ import {
 } from "@autobe/interface";
 import { AutoBePrismaComponentsEvent } from "@autobe/interface/src/events/AutoBePrismaComponentsEvent";
 import { AutoBePrismaSchemasEvent } from "@autobe/interface/src/events/AutoBePrismaSchemasEvent";
+import typia from "typia";
 
 import { TestFactory } from "../../../TestFactory";
 import { TestGlobal } from "../../../TestGlobal";
@@ -33,14 +34,9 @@ export const validate_agent_prisma_main = async (
       tokenUsage: agent.getTokenUsage().toJSON(),
     });
   };
-  agent.on("prismaStart", listen);
-  agent.on("prismaComponents", listen);
-  agent.on("prismaSchemas", listen);
-  agent.on("prismaInsufficient", listen);
-  agent.on("prismaReview", listen);
-  agent.on("prismaCorrect", listen);
-  agent.on("prismaValidate", listen);
-  agent.on("prismaComplete", listen);
+  agent.on("assistantMessage", listen);
+  for (const type of typia.misc.literals<AutoBeEvent.Type>())
+    if (type.startsWith("prisma")) agent.on(type, listen);
 
   let start: AutoBePrismaStartEvent | null = null;
   let components: AutoBePrismaComponentsEvent | null = null;

--- a/test/src/features/test/internal/validate_agent_test_main.ts
+++ b/test/src/features/test/internal/validate_agent_test_main.ts
@@ -8,6 +8,7 @@ import {
   AutoBeTestHistory,
 } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
+import typia from "typia";
 
 import { TestFactory } from "../../../TestFactory";
 import { TestGlobal } from "../../../TestGlobal";
@@ -24,18 +25,15 @@ export const validate_agent_test_main = async (
   // PREPARE AGENT
   const { agent } = await prepare_agent_test(factory, project);
   const snapshots: AutoBeEventSnapshot[] = [];
-  const enroll = (event: AutoBeEvent) => {
+  const listen = (event: AutoBeEvent) => {
     snapshots.push({
       event,
       tokenUsage: agent.getTokenUsage().toJSON(),
     });
   };
-  agent.on("testStart", enroll);
-  agent.on("testScenario", enroll);
-  agent.on("testWrite", enroll);
-  agent.on("testValidate", enroll);
-  agent.on("testCorrect", enroll);
-  agent.on("testComplete", enroll);
+  agent.on("assistantMessage", listen);
+  for (const type of typia.misc.literals<AutoBeEvent.Type>())
+    if (type.startsWith("test")) agent.on(type, listen);
 
   // DO TEST GENERATION
   const go = (reason: string) =>


### PR DESCRIPTION
This pull request refactors the event listener registration in several agent validation test files to use a more dynamic and scalable approach. Instead of individually registering listeners for each event type, the code now iterates through all event types and registers the listener for those matching a specific prefix (e.g., "analyze", "interface", "prisma", "realize", "test"). This reduces boilerplate and makes it easier to maintain and extend event handling as new event types are added. Additionally, some unused imports and code related to event handling have been cleaned up.

**Dynamic event listener registration and code cleanup:**

* Replaced multiple explicit `agent.on` calls for each event type with a loop that registers the listener for all event types starting with the relevant prefix (e.g., "analyze", "interface", "prisma", "realize", "test") using `typia.misc.literals<AutoBeEvent.Type>()`. This change was applied in `validate_agent_analyze_main.ts`, `validate_agent_interface_main.ts`, `validate_agent_prisma_main.ts`, `validate_agent_realize_main.ts`, and `validate_agent_test_main.ts`. [[1]](diffhunk://#diff-7e85d7f89034dac2641e5f95767dadb30db5a736f3de6e79b14719eb971fbbb3L40-R41) [[2]](diffhunk://#diff-1faf281eb9d0ca871e9907ef7aa3857a51f745cd48b5acbe6b0097dd39971059L35-R36) [[3]](diffhunk://#diff-0fb56a3035156778e908fc3a0dcbeafaa78c5634810cdc7d43340935055b6facL36-R39) [[4]](diffhunk://#diff-349b6515684935e7916cf1f13de86b890bb5c976d3486630a19d891336bd0c73L41-R47) [[5]](diffhunk://#diff-33d48b68dc459507466717f8cdc6de963d14b5c488f1b1730ea0eaaf60cf641fL27-R36)

* Updated the event listener function name from `enroll` to `listen` for consistency and clarity in `validate_agent_realize_main.ts` and `validate_agent_test_main.ts`. [[1]](diffhunk://#diff-349b6515684935e7916cf1f13de86b890bb5c976d3486630a19d891336bd0c73L27-R28) [[2]](diffhunk://#diff-33d48b68dc459507466717f8cdc6de963d14b5c488f1b1730ea0eaaf60cf641fL27-R36)

**Dependency and import cleanup:**

* Removed unused imports such as `OpenApiEndpointComparator` and `HashSet`, and added the `typia` import where necessary to support the new dynamic event registration logic. [[1]](diffhunk://#diff-1faf281eb9d0ca871e9907ef7aa3857a51f745cd48b5acbe6b0097dd39971059L2) [[2]](diffhunk://#diff-1faf281eb9d0ca871e9907ef7aa3857a51f745cd48b5acbe6b0097dd39971059L11-R10) [[3]](diffhunk://#diff-0fb56a3035156778e908fc3a0dcbeafaa78c5634810cdc7d43340935055b6facR14) [[4]](diffhunk://#diff-349b6515684935e7916cf1f13de86b890bb5c976d3486630a19d891336bd0c73R11) [[5]](diffhunk://#diff-33d48b68dc459507466717f8cdc6de963d14b5c488f1b1730ea0eaaf60cf641fR11)

**Interface event snapshot handling:**

* Simplified the creation of the endpoints snapshot by removing the use of `HashSet` and related comparator logic in `validate_agent_interface_main.ts`.