### PR TITLE
feat(vscode-extension): retain webview context when hidden

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -21,6 +21,11 @@ export async function activate(context: ExtensionContext) {
     window.registerWebviewViewProvider(
       "autobe-vscode-extension-views",
       getAutoBeWebviewProvider(context),
+      {
+        webviewOptions: {
+          retainContextWhenHidden: true,
+        },
+      },
     ),
   );
   Logger.info("AutoBe VSCode Extension end activated");


### PR DESCRIPTION
Added webviewOptions to retain context when the webview is hidden, improving user experience by preserving state.

--- 

This pull request makes a small configuration change to the VSCode extension's activation logic. The change ensures that the webview context is retained when the webview is hidden, which can improve user experience by preserving state.

* The `activate` function in `extension.ts` now registers the webview view provider with the option `retainContextWhenHidden: true`, so the webview will not be disposed when hidden.