### PR TITLE
feat(events): refactor AutoBeEventsMovie and ProgressEventsMovie for improved event handling

### DIFF
--- a/packages/vscode-extension/webview-ui/src/components/Movie/events/AutoBeEventsMovie.tsx
+++ b/packages/vscode-extension/webview-ui/src/components/Movie/events/AutoBeEventsMovie.tsx
@@ -1,9 +1,15 @@
-import { AutoBeEvent, AutoBeUserMessageHistory } from "@autobe/interface";
+import {
+  AutoBeEvent,
+  AutoBeProgressEventBase,
+  AutoBeUserMessageHistory,
+} from "@autobe/interface";
 
 import AssistantMessage from "../AutoBeAssistantMessage";
 import AutoBeUserMessage from "../AutoBeUserMessage";
 import AutoBeStartEvent from "./AutoBeStartEvent";
-import ProgressEventsMovie from "./ProgressEventsMovie";
+import ProgressEventsMovie, {
+  IProgressEventsMovieProps,
+} from "./ProgressEventsMovie";
 import AnalyzeComplete from "./analyze/AnalyzeComplete";
 import AnalyzeScenario from "./analyze/AnalyzeScenario";
 import PrismaComponents from "./prisma/PrismaComponents";
@@ -12,8 +18,23 @@ interface IAutoBeEventsMovieProps {
   event: AutoBeEvent;
 }
 
+const isAutoBeProgressEventBase = (
+  event: AutoBeEvent,
+): event is IProgressEventsMovieProps["event"] => {
+  return (
+    "total" in event &&
+    "completed" in event &&
+    typeof event.total === "number" &&
+    typeof event.completed === "number"
+  );
+};
 const AutoBeEventsMovie = (props: IAutoBeEventsMovieProps) => {
   const { event } = props;
+
+  if (isAutoBeProgressEventBase(event)) {
+    return <ProgressEventsMovie event={event} />;
+  }
+
   switch (event.type) {
     case "assistantMessage":
       return (
@@ -38,44 +59,24 @@ const AutoBeEventsMovie = (props: IAutoBeEventsMovieProps) => {
     case "prismaComponents": {
       return <PrismaComponents event={event} />;
     }
-
-    case "analyzeWrite":
-    case "analyzeReview":
-    case "prismaSchemas":
-    case "prismaReview":
-    case "interfaceEndpoints":
-    case "interfaceOperationsReview":
-    case "interfaceSchemas":
-    case "interfaceSchemasReview": {
-      return <ProgressEventsMovie event={event} />;
-    }
-
     case "analyzeComplete":
       return <AnalyzeComplete event={event} />;
     case "interfaceGroups":
-    case "interfaceOperations":
-    case "interfaceAuthorization":
     case "interfaceComplement":
     case "interfaceComplete":
     case "prismaInsufficient":
     case "prismaValidate":
     case "prismaCorrect":
     case "prismaComplete":
-    case "testScenarios":
-    case "testWrite":
     case "testValidate":
     case "testCorrect":
     case "testComplete":
-    case "realizeWrite":
-    case "realizeCorrect":
     case "realizeValidate":
     case "realizeComplete":
-    case "realizeAuthorizationWrite":
     case "realizeAuthorizationValidate":
     case "realizeAuthorizationCorrect":
     case "realizeAuthorizationComplete":
     case "realizeTestReset":
-    case "realizeTestOperation":
     case "realizeTestComplete":
       return <div>{event.type}</div>;
     default:

--- a/packages/vscode-extension/webview-ui/src/components/Movie/events/ProgressEventsMovie.tsx
+++ b/packages/vscode-extension/webview-ui/src/components/Movie/events/ProgressEventsMovie.tsx
@@ -1,29 +1,12 @@
-import {
-  AutoBeAnalyzeReviewEvent,
-  AutoBeAnalyzeWriteEvent,
-  AutoBeInterfaceEndpointsEvent,
-  AutoBeInterfaceOperationsReviewEvent,
-  AutoBeInterfaceSchemasEvent,
-  AutoBeInterfaceSchemasReviewEvent,
-  AutoBePrismaReviewEvent,
-  AutoBePrismaSchemasEvent,
-} from "@autobe/interface";
+import { AutoBeEvent, AutoBeProgressEventBase } from "@autobe/interface";
 
 import ChatBubble from "../../ChatBubble";
 
-interface IProgressEventsMovieProps {
-  event: /** Analyze */
-  | AutoBeAnalyzeWriteEvent
-    | AutoBeAnalyzeReviewEvent
-    /** Prisma */
-    | AutoBePrismaSchemasEvent
-    | AutoBePrismaReviewEvent
-
-    /** Interface */
-    | AutoBeInterfaceEndpointsEvent
-    | AutoBeInterfaceOperationsReviewEvent
-    | AutoBeInterfaceSchemasEvent
-    | AutoBeInterfaceSchemasReviewEvent;
+type ExtractTarget<T extends AutoBeEvent> = T extends AutoBeProgressEventBase
+  ? T
+  : never;
+export interface IProgressEventsMovieProps {
+  event: ExtractTarget<AutoBeEvent>;
 }
 
 const ProgressEventsMovie = (props: IProgressEventsMovieProps) => {
@@ -60,28 +43,27 @@ const generateProgressBar = (percent: number): string => {
   return `[${filled}${empty}]`;
 };
 
+const TITLE_MAP = {
+  analyzeWrite: "분석 초안 작성",
+  analyzeReview: "분석안 퇴고",
+  prismaSchemas: "데이터베이스 스키마 (Prisma)",
+  prismaReview: "데이터베이스 스키마 (Prisma) 퇴고",
+  interfaceEndpoints: "API 인터페이스 (Interface)",
+  interfaceOperationsReview: "API 인터페이스 (Interface) 퇴고",
+  interfaceSchemas: "API 인터페이스 (Interface) 스키마",
+  interfaceSchemasReview: "API 인터페이스 (Interface) 스키마 퇴고",
+  interfaceAuthorization: "API 인터페이스 (Interface) 권한 설정",
+  interfaceOperations: "API 인터페이스 (Interface) 작업",
+  testScenarios: "테스트 시나리오",
+  testWrite: "테스트 초안 작성",
+  realizeWrite: "코드 구현 초안 작성",
+  realizeCorrect: "코드 구현 퇴고",
+  realizeAuthorizationWrite: "권한 코드 구현",
+  realizeTestOperation: "테스트 코드 구현",
+} satisfies Record<ExtractTarget<AutoBeEvent>["type"], string>;
+
 const getTitle = (event: IProgressEventsMovieProps["event"]) => {
-  switch (event.type) {
-    case "analyzeWrite": {
-      return "분석 초안 작성";
-    }
-    case "analyzeReview": {
-      return "분석안 퇴고";
-    }
-    case "prismaSchemas":
-    case "prismaReview": {
-      return "데이터베이스 스키마 (Prisma)";
-    }
-    case "interfaceEndpoints":
-    case "interfaceOperationsReview":
-    case "interfaceSchemas":
-    case "interfaceSchemasReview": {
-      return "API 인터페이스 (Interface)";
-    }
-    default: {
-      return "알 수 없음";
-    }
-  }
+  return TITLE_MAP[event.type] ?? "아무튼 무언가 작업 중";
 };
 
 export default ProgressEventsMovie;


### PR DESCRIPTION
- Added type guard for AutoBeProgressEventBase in AutoBeEventsMovie.
- Simplified event type handling in ProgressEventsMovie using a mapping object.
- Removed redundant event cases to streamline code and enhance maintainability.

---

This pull request refactors how progress events are handled and displayed in the movie event components, improving type safety and maintainability. The main changes are the introduction of a type guard for progress events, a simplified and extensible mapping for event titles, and the removal of redundant switch cases in the main event component.

**Progress event handling improvements:**

* Added a type guard function `isAutoBeProgressEventBase` to `AutoBeEventsMovie.tsx` to identify progress events based on their structure (`total` and `completed` properties), allowing for more flexible and robust event type checking.
* Updated the props and type definitions in `ProgressEventsMovie.tsx` to use a generic `AutoBeProgressEventBase` type, replacing the previous union of specific event types, which simplifies type management and future extensibility.

**Code simplification and maintainability:**

* Removed the large switch-case block for progress event types in `AutoBeEventsMovie.tsx`, delegating rendering responsibility to the type guard and reducing code duplication.
* Replaced the switch statement for event titles in `ProgressEventsMovie.tsx` with a centralized `TITLE_MAP` object, making it easier to add or update event titles and ensuring all progress events are covered.

**Type and import clean-up:**

* Updated imports in both files to reflect the new event type structure and removed unused specific event imports. [[1]](diffhunk://#diff-0c52ccc36f05387819de9933608b5d99cc75f25394619838714f884fdcf30498L1-R12) [[2]](diffhunk://#diff-e2c09423277a46d5d4b098709505b8a567ad467acd6783ee8f82dcc1d7b98249L1-R9)