### PR TITLE
fix(test): wrong token usage tracing on archiver.

### DIFF
--- a/test/src/executable/archive.ts
+++ b/test/src/executable/archive.ts
@@ -1,0 +1,32 @@
+import cp from "child_process";
+
+import { TestGlobal } from "../TestGlobal";
+
+const STEPS = ["analyze", "prisma", "interface", "test", "realize"];
+
+const main = async () => {
+  const project: string | undefined = TestGlobal.getArguments("project")[0];
+  const from: string | undefined = TestGlobal.getArguments("from")[0];
+  const to: string | undefined = TestGlobal.getArguments("to")[0];
+
+  const postfix: string = project ? `_${project}` : "";
+  const start: number = STEPS.indexOf(from);
+  const end: number = to ? STEPS.indexOf(to) : STEPS.length;
+  const execute = (step: string) =>
+    cp.execSync(
+      `pnpm start --include ${step}_main${postfix} --archive --trace`,
+      {
+        stdio: "inherit",
+        cwd: TestGlobal.ROOT,
+      },
+    );
+  STEPS.forEach((step, i) => {
+    if (i < start) return;
+    if (i > end) return;
+    execute(step);
+  });
+};
+main().catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/test/src/features/interface/internal/validate_agent_interface_main.ts
+++ b/test/src/features/interface/internal/validate_agent_interface_main.ts
@@ -87,7 +87,7 @@ export const validate_agent_interface_main = async (
         snapshots.map((s) => ({
           event: s.event,
           tokenUsage: new AutoBeTokenUsage(s.tokenUsage)
-            .decrement(zero)
+            .increment(zero)
             .toJSON(),
         })),
       ),

--- a/test/src/features/prisma/internal/validate_agent_prisma_main.ts
+++ b/test/src/features/prisma/internal/validate_agent_prisma_main.ts
@@ -138,7 +138,7 @@ export const validate_agent_prisma_main = async (
         snapshots.map((s) => ({
           event: s.event,
           tokenUsage: new AutoBeTokenUsage(s.tokenUsage)
-            .decrement(zero)
+            .increment(zero)
             .toJSON(),
         })),
       ),

--- a/test/src/features/realize/internal/validate_agent_realize_main.ts
+++ b/test/src/features/realize/internal/validate_agent_realize_main.ts
@@ -70,7 +70,7 @@ export const validate_agent_realize_main = async (
         snapshots.map((s) => ({
           event: s.event,
           tokenUsage: new AutoBeTokenUsage(s.tokenUsage)
-            .decrement(zero)
+            .increment(zero)
             .toJSON(),
         })),
       ),

--- a/test/src/internal/TestHistory.ts
+++ b/test/src/internal/TestHistory.ts
@@ -81,7 +81,7 @@ export namespace TestHistory {
   }): Promise<IAutoBeTokenUsageJson> => {
     const snapshots: AutoBeEventSnapshot[] = JSON.parse(
       await fs.promises.readFile(
-        `${TestGlobal.ROOT}/assets/histories/${TestGlobal.getVendorModel()}/${props.project}.${props.type}.json`,
+        `${TestGlobal.ROOT}/assets/histories/${TestGlobal.getVendorModel()}/${props.project}.${props.type}.snapshots.json`,
         "utf8",
       ),
     );


### PR DESCRIPTION
This pull request updates how token usage snapshots are processed and stored in several agent validation test scripts. The main change is to use the `increment` method instead of `decrement` when handling token usage, and to ensure that the correct file naming conventions are used for snapshot files. Additionally, there are minor improvements to imports and variable handling.

**Token usage processing changes:**

* Replaced `.decrement(zero)` with `.increment(zero)` when processing `tokenUsage` in the snapshot mapping logic in `validate_agent_interface_main.ts`, `validate_agent_prisma_main.ts`, `validate_agent_realize_main.ts`, and `validate_agent_test_main.ts`. This ensures token usage is correctly incremented rather than decremented before serialization. [[1]](diffhunk://#diff-1faf281eb9d0ca871e9907ef7aa3857a51f745cd48b5acbe6b0097dd39971059L90-R90) [[2]](diffhunk://#diff-0fb56a3035156778e908fc3a0dcbeafaa78c5634810cdc7d43340935055b6facL141-R141) [[3]](diffhunk://#diff-349b6515684935e7916cf1f13de86b890bb5c976d3486630a19d891336bd0c73L73-R73) [[4]](diffhunk://#diff-33d48b68dc459507466717f8cdc6de963d14b5c488f1b1730ea0eaaf60cf641fL74-R82)

**Test script improvements:**

* Updated the call to `prepare_agent_test` in `validate_agent_test_main.ts` to destructure and use the `zero` variable, aligning it with the new token usage logic.
* Added a missing import for `AutoBeTokenUsage` in `validate_agent_test_main.ts`.

**Snapshot file handling:**

* Changed the file path in `TestHistory.loadSnapshots` to use the `.snapshots.json` suffix, ensuring the correct snapshot files are loaded.