### PR TITLE
feat(agent): bump up agentica for `qwen3` and `gpt-5`

### DIFF
--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyze.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyze.ts
@@ -62,17 +62,22 @@ export const orchestrateAnalyze =
     };
     const newFiles: AutoBeAnalyzeFile[] = await Promise.all(
       fileList.map(async (file, i) => {
-        const event: AutoBeAnalyzeReviewEvent = await orchestrateAnalyzeReview(
-          ctx,
-          scenario,
-          fileList.filter((_, j) => j !== i), // other files
-          file,
-          reviewProgress,
-        );
-        return {
-          ...event.file,
-          content: event.content,
-        };
+        try {
+          const event: AutoBeAnalyzeReviewEvent =
+            await orchestrateAnalyzeReview(
+              ctx,
+              scenario,
+              fileList.filter((_, j) => j !== i), // other files
+              file,
+              reviewProgress,
+            );
+          return {
+            ...event.file,
+            content: event.content,
+          };
+        } catch {
+          return file;
+        }
       }),
     );
 

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperationsReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperationsReview.ts
@@ -35,7 +35,11 @@ export async function orchestrateInterfaceOperationsReview<
     enforceFunctionCall: false,
     message: "Review the operations",
   });
-  if (pointer.value === null) throw new Error("Failed to review operations.");
+  if (pointer.value === null) {
+    progress.completed += operations.length;
+    console.error("Failed to review operations.");
+    return [];
+  }
 
   ctx.dispatch({
     type: "interfaceOperationsReview",
@@ -47,7 +51,7 @@ export async function orchestrateInterfaceOperationsReview<
     created_at: new Date().toISOString(),
     step: ctx.state().analyze?.step ?? 0,
     total: progress.total,
-    completed: ++progress.completed,
+    completed: (progress.completed += operations.length),
   } satisfies AutoBeInterfaceOperationsReviewEvent);
   return pointer.value.content;
 }

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
@@ -45,12 +45,14 @@ export async function orchestrateInterfaceSchemas<
     matrix.map(async (it) => {
       const row: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
         await divideAndConquer(ctx, operations, it, 3, progress);
-      return orchestrateInterfaceSchemasReview(
-        ctx,
-        operations,
-        row,
-        reviewProgress,
-      );
+      const newbie: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
+        await orchestrateInterfaceSchemasReview(
+          ctx,
+          operations,
+          row,
+          reviewProgress,
+        );
+      return { ...row, ...newbie };
     }),
   )) {
     Object.assign(x, y);

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
@@ -26,7 +26,6 @@ export async function orchestrateInterfaceSchemasReview<
     {
       value: null,
     };
-
   const { tokenUsage } = await ctx.conversate({
     source: "interfaceSchemasReview",
     controller: createController({
@@ -42,8 +41,11 @@ export async function orchestrateInterfaceSchemasReview<
     enforceFunctionCall: true,
     message: "Review type schemas.",
   });
-  if (pointer.value === null)
-    throw new Error("Failed to extract review information.");
+  if (pointer.value === null) {
+    console.error("Failed to extract review information.");
+    ++progress.completed;
+    return {};
+  }
 
   ctx.dispatch({
     type: "interfaceSchemasReview",

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaReview.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaReview.ts
@@ -20,11 +20,18 @@ export async function orchestratePrismaReview<Model extends ILlmSchema.Model>(
     completed: 0,
     total: componentList.length,
   };
-  return await Promise.all(
-    componentList.map((component) =>
-      step(ctx, application, schemas, component, progress),
-    ),
-  );
+  return (
+    await Promise.all(
+      componentList.map(async (component) => {
+        try {
+          return await step(ctx, application, schemas, component, progress);
+        } catch {
+          ++progress.completed;
+          return null;
+        }
+      }),
+    )
+  ).filter((v) => v !== null);
 }
 
 async function step<Model extends ILlmSchema.Model>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   agentica:
     '@agentica/core':
-      specifier: ^0.31.1
-      version: 0.31.1
+      specifier: ^0.31.2
+      version: 0.31.2
   libs:
     openai:
       specifier: ^5.12.2
@@ -137,7 +137,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.31.1(@modelcontextprotocol/sdk@1.17.2)(@samchon/openapi@4.7.1)(openai@5.12.2(ws@8.18.3)(zod@3.25.76))(typia@9.7.1(typescript@5.9.2))
+        version: 0.31.2(@modelcontextprotocol/sdk@1.17.2)(@samchon/openapi@4.7.1)(openai@5.12.2(ws@8.18.3)(zod@3.25.76))(typia@9.7.1(typescript@5.9.2))
       '@autobe/interface':
         specifier: workspace:^
         version: link:../interface
@@ -755,8 +755,8 @@ importers:
 
 packages:
 
-  '@agentica/core@0.31.1':
-    resolution: {integrity: sha512-z2UJPsa2FHBC3ZJ+kPqVO/iSYLAC7twgxoNZgp+aHOTPcWc8nKX3hbOT4e7g/XxDSD1eusG1kM7SJGm3IiE0dg==}
+  '@agentica/core@0.31.2':
+    resolution: {integrity: sha512-D14Ha80Fo5iN6X+7ZGB4XwyFbOKKVNa1Nsupur5oyrdsJvHW1qmhAsxOwsBG1rcC2M/tzP3PZYKGSKpKHK8GkQ==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.12.0
       '@samchon/openapi': ^4.7.1
@@ -6961,7 +6961,7 @@ packages:
 
 snapshots:
 
-  '@agentica/core@0.31.1(@modelcontextprotocol/sdk@1.17.2)(@samchon/openapi@4.7.1)(openai@5.12.2(ws@8.18.3)(zod@3.25.76))(typia@9.7.1(typescript@5.9.2))':
+  '@agentica/core@0.31.2(@modelcontextprotocol/sdk@1.17.2)(@samchon/openapi@4.7.1)(openai@5.12.2(ws@8.18.3)(zod@3.25.76))(typia@9.7.1(typescript@5.9.2))':
     dependencies:
       '@samchon/openapi': 4.7.1
       openai: 5.12.2(ws@8.18.3)(zod@3.25.76)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,8 @@ packages:
   - website
 catalogs:
   agentica:
-    "@agentica/core": ^0.31.1
-    "@agentica/rpc": ^0.31.1
+    "@agentica/core": ^0.31.2
+    "@agentica/rpc": ^0.31.2
   samchon:
     "@nestia/benchmark": ^7.3.3
     "@nestia/core": ^7.3.3


### PR DESCRIPTION
This pull request improves error handling and progress tracking in several orchestrator functions within the agent package. It ensures that failures during review steps do not halt the entire process but instead log errors, update progress counters, and continue gracefully. Additionally, the pull request updates the `@agentica/core` dependency to version 0.31.2.

**Error Handling and Progress Tracking Improvements:**

* The orchestrator functions for analyzing files, reviewing Prisma components, interface operations, and interface schema reviews now catch errors, log them, increment progress counters, and return fallback values instead of throwing exceptions. This prevents the process from stopping due to individual failures. [[1]](diffhunk://#diff-b9d5e2b6585091c8e6fdb8862e5794072327782b6dc63890e052a4c11166768bL65-R67) [[2]](diffhunk://#diff-b9d5e2b6585091c8e6fdb8862e5794072327782b6dc63890e052a4c11166768bR78-R80) [[3]](diffhunk://#diff-2d19213671f0b90e0fb2b553abcc5cc6b55b8683376104e0945914b275c03effL23-R34) [[4]](diffhunk://#diff-551b6f3e684dbfae646d9d4716b4599e5bff41dbe0d83272f74d3d3ad9761535L38-R42) [[5]](diffhunk://#diff-551b6f3e684dbfae646d9d4716b4599e5bff41dbe0d83272f74d3d3ad9761535L50-R54) [[6]](diffhunk://#diff-149e865311d6c8b3ffbd019c94ce0745effd5d68a52d0183b2e998d7b002c066L45-R48)

* The progress counters are updated more accurately to reflect completed steps, even when errors occur. [[1]](diffhunk://#diff-551b6f3e684dbfae646d9d4716b4599e5bff41dbe0d83272f74d3d3ad9761535L50-R54) [[2]](diffhunk://#diff-149e865311d6c8b3ffbd019c94ce0745effd5d68a52d0183b2e998d7b002c066L45-R48) [[3]](diffhunk://#diff-2d19213671f0b90e0fb2b553abcc5cc6b55b8683376104e0945914b275c03effL23-R34)

* In `orchestrateInterfaceSchemas`, the results from schema reviews are now merged with the original row to ensure all information is retained.

**Dependency Updates:**

* Updated `@agentica/core` and `@agentica/rpc` to version 0.31.2 in both `pnpm-lock.yaml` and `pnpm-workspace.yaml` to ensure compatibility and receive the latest fixes. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R11) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL140-R140) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL758-R759) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6964-R6964) [[5]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL11-R12)