### PR TITLE
refactor(vscode-extension): remove "step" card from history components for cleaner UI

### DIFF
--- a/packages/vscode-extension/webview-ui/src/components/Movie/histories/AutoBeInterfaceHistory.tsx
+++ b/packages/vscode-extension/webview-ui/src/components/Movie/histories/AutoBeInterfaceHistory.tsx
@@ -27,10 +27,6 @@ const AutoBeInterfaceHistoryComponent = (
         {history.document.operations ? history.document.operations.length : 0}개
       </HistoryInfoCard>
 
-      <HistoryInfoCard title="요구사항 분석 단계" theme="purple">
-        {history.step}단계
-      </HistoryInfoCard>
-
       <HistoryInfoCard title="완료 시간" theme="purple">
         {new Date(history.completed_at).toLocaleString("ko-KR", {
           year: "numeric",

--- a/packages/vscode-extension/webview-ui/src/components/Movie/histories/AutoBePrismaHistory.tsx
+++ b/packages/vscode-extension/webview-ui/src/components/Movie/histories/AutoBePrismaHistory.tsx
@@ -52,10 +52,6 @@ const AutoBePrismaHistoryComponent = (props: IAutoBePrismaHistoryProps) => {
           }
         />
       </HistoryInfoCard>
-
-      <HistoryInfoCard title="요구사항 분석 단계" theme="green">
-        {history.step}단계
-      </HistoryInfoCard>
     </HistoryBubble>
   );
 };

--- a/packages/vscode-extension/webview-ui/src/components/Movie/histories/AutoBeRealizeHistory.tsx
+++ b/packages/vscode-extension/webview-ui/src/components/Movie/histories/AutoBeRealizeHistory.tsx
@@ -24,10 +24,6 @@ const AutoBeRealizeHistoryComponent = (props: IAutoBeRealizeHistoryProps) => {
       <HistoryInfoCard title="인증/인가 데코레이터 수" theme="purple">
         {history.authorizations?.length || 0}개
       </HistoryInfoCard>
-
-      <HistoryInfoCard title="요구사항 분석 단계" theme="purple">
-        {history.step}단계
-      </HistoryInfoCard>
     </HistoryBubble>
   );
 };

--- a/packages/vscode-extension/webview-ui/src/components/Movie/histories/AutoBeTestHistory.tsx
+++ b/packages/vscode-extension/webview-ui/src/components/Movie/histories/AutoBeTestHistory.tsx
@@ -43,10 +43,6 @@ const AutoBeTestHistoryComponent = (props: IAutoBeTestHistoryProps) => {
           }
         />
       </HistoryInfoCard>
-
-      <HistoryInfoCard title="요구사항 분석 단계" theme="orange">
-        {history.step}단계
-      </HistoryInfoCard>
     </HistoryBubble>
   );
 };


### PR DESCRIPTION
This pull request removes the display of the "요구사항 분석 단계" (Requirement Analysis Step) information from several backend history components in the Movie feature of the VSCode extension webview UI. This change streamlines the UI by eliminating redundant or unnecessary step indicators across these components.

UI cleanup in history components:

* Removed the "요구사항 분석 단계" card from `AutoBeInterfaceHistoryComponent`, `AutoBePrismaHistoryComponent`, `AutoBeRealizeHistoryComponent`, and `AutoBeTestHistoryComponent` to simplify the information shown in each history bubble. [[1]](diffhunk://#diff-50bf30560a5c8a7be54fd2e34564a9b1b74657dd614b0abb36b7728b2a583159L30-L33) [[2]](diffhunk://#diff-fb534c0e8f2a2daa90051a220d08c65175e765f64ec15b028f7bc8486ed684fbL55-L58) [[3]](diffhunk://#diff-e9eaff90a3ae779d621ead64428b95bd50f62daf29b6fbb11ae1d4807f368aceL27-L30) [[4]](diffhunk://#diff-d8a53daf5cf51eb1806885d2a3519ca9b5bc879b81b7388a32dc7ebd31968ab6L46-L49)