### PR TITLE
fix(Chat): streamline session deletion logic by removing confirmation prompt

### DIFF
--- a/packages/vscode-extension/webview-ui/src/pages/Chat.tsx
+++ b/packages/vscode-extension/webview-ui/src/pages/Chat.tsx
@@ -83,20 +83,17 @@ const WelcomeMessage = (props: {
               <button
                 className="absolute top-3 right-3 w-7 h-7 bg-white hover:bg-red-50 text-gray-400 hover:text-red-500 border border-gray-200 hover:border-red-300 rounded-full flex items-center justify-center transition-all duration-200 shadow-sm hover:shadow-md"
                 onClick={(e) => {
-                  e.stopPropagation();
-                  if (confirm("이 세션을 삭제하시겠습니까?")) {
-                    vscode.postMessage({
-                      type: "req_remove_session",
-                      data: {
-                        sessionId: session.sessionId,
-                      },
-                    });
+                  vscode.postMessage({
+                    type: "req_remove_session",
+                    data: {
+                      sessionId: session.sessionId,
+                    },
+                  });
 
-                    setSessionList((prev) =>
-                      prev.filter((s) => s.sessionId !== session.sessionId),
-                    );
-                    props.onDeleteSession?.(session.sessionId);
-                  }
+                  setSessionList((prev) =>
+                    prev.filter((s) => s.sessionId !== session.sessionId),
+                  );
+                  props.onDeleteSession?.(session.sessionId);
                 }}
                 title="세션 삭제"
               >


### PR DESCRIPTION
This pull request simplifies the session deletion logic in the `WelcomeMessage` component in `Chat.tsx`. The confirmation dialog has been removed, making session deletion immediate when the delete button is clicked.

User experience changes:

* Removed the confirmation dialog when deleting a session, so clicking the delete button now immediately triggers session deletion. [[1]](diffhunk://#diff-c6ab1c3ab1defb9821effd830661ee24f90644f61063b3006be30a512004a758L86-L87) [[2]](diffhunk://#diff-c6ab1c3ab1defb9821effd830661ee24f90644f61063b3006be30a512004a758L99)