### PR TITLE
feat(vscode-extension): implement session storage management for chat sessions

### DIFF
--- a/packages/vscode-extension/src/constant/key.ts
+++ b/packages/vscode-extension/src/constant/key.ts
@@ -3,5 +3,5 @@ import { misc } from "typia";
 
 export const AUTOBE_API_KEY = "auto-be-api-key";
 export const AUTOBE_CONFIG = "auto-be-config";
-export const AUTOBE_CHAT_SESSION_MAP = "auto-be-chat-session-map";
 export const AUTOBE_EVENT_TYPES = misc.literals<AutoBeEvent.Type>();
+export const AUTOBE_SESSION_STORAGE_FILE_NAME = "auto-be-session-storage.json";


### PR DESCRIPTION
- Added AUTOBE_SESSION_STORAGE_FILE_NAME constant for session storage file.
- Updated AutoBeWrapper to read from and write to the new session storage file.
- Ensured the creation of the storage directory if it does not exist.

---

This pull request updates the way chat session data is stored and retrieved in the VSCode extension, moving from VSCode's global state to a dedicated JSON file in the extension's global storage directory. This change improves data persistence and scalability for session management.

**Session Storage Refactor:**

* Replaced use of `AUTOBE_CHAT_SESSION_MAP` in VSCode's global state with a new file-based storage approach using `auto-be-session-storage.json` for chat session data. [[1]](diffhunk://#diff-16d3e3e69023ca2e8de3ea3431214c07c9eeb46a9f8318f857c26888751c638dL6-R7) [[2]](diffhunk://#diff-c5899899b83e877f9d37ed59afcfbcb7265d7a5272061cd2d39e004c113b5106R13-R23)
* Updated the `initialize` method in `AutoBeWrapper` to read chat session data from the new JSON file, creating the storage directory if necessary and handling file existence checks.
* Modified the `save` method in `AutoBeWrapper` to write chat session data to the JSON file instead of updating VSCode's global state.