### PR TITLE
feat(agent): system prompt tuning a little bit

### DIFF
--- a/packages/agent/prompts/ANALYZE_REVIEW.md
+++ b/packages/agent/prompts/ANALYZE_REVIEW.md
@@ -10,12 +10,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the document content directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/ANALYZE_WRITE.md
+++ b/packages/agent/prompts/ANALYZE_WRITE.md
@@ -9,12 +9,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ **ALWAYS** execute the function immediately
 - ✅ **ALWAYS** generate the document content directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/INTERFACE_AUTHORIZATION.md
+++ b/packages/agent/prompts/INTERFACE_AUTHORIZATION.md
@@ -10,12 +10,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the operations directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Ask for user permission to execute the function
-- ❌ Present a plan and wait for approval
-- ❌ Respond with assistant messages when all requirements are met
-- ❌ Say "I will now call the function..." or similar announcements
-- ❌ Request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/INTERFACE_COMPLEMENT.md
+++ b/packages/agent/prompts/INTERFACE_COMPLEMENT.md
@@ -8,12 +8,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the schemas directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/INTERFACE_ENDPOINT.md
+++ b/packages/agent/prompts/INTERFACE_ENDPOINT.md
@@ -10,12 +10,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the endpoints directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/INTERFACE_GROUP.md
+++ b/packages/agent/prompts/INTERFACE_GROUP.md
@@ -10,12 +10,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the groups directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/INTERFACE_OPERATION.md
+++ b/packages/agent/prompts/INTERFACE_OPERATION.md
@@ -22,12 +22,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the operations directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/INTERFACE_OPERATION_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_OPERATION_REVIEW.md
@@ -12,12 +12,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the review report directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/INTERFACE_SCHEMA.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA.md
@@ -10,12 +10,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the schemas directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/INTERFACE_SCHEMA_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_REVIEW.md
@@ -8,12 +8,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the review results directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/PRISMA_COMPONENT.md
+++ b/packages/agent/prompts/PRISMA_COMPONENT.md
@@ -12,12 +12,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the component analysis directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/PRISMA_CORRECT.md
+++ b/packages/agent/prompts/PRISMA_CORRECT.md
@@ -8,12 +8,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the corrections directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/PRISMA_REVIEW.md
+++ b/packages/agent/prompts/PRISMA_REVIEW.md
@@ -15,12 +15,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the review directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/PRISMA_SCHEMA.md
+++ b/packages/agent/prompts/PRISMA_SCHEMA.md
@@ -64,12 +64,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the schemas directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/REALIZE_AUTHORIZATION.md
+++ b/packages/agent/prompts/REALIZE_AUTHORIZATION.md
@@ -21,12 +21,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the authorization implementation directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/REALIZE_AUTHORIZATION_CORRECT.md
+++ b/packages/agent/prompts/REALIZE_AUTHORIZATION_CORRECT.md
@@ -8,12 +8,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the corrections directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/REALIZE_CODER.md
+++ b/packages/agent/prompts/REALIZE_CODER.md
@@ -10,12 +10,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the code directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/TEST_CORRECT.md
+++ b/packages/agent/prompts/TEST_CORRECT.md
@@ -10,12 +10,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the test corrections directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/TEST_SCENARIO.md
+++ b/packages/agent/prompts/TEST_SCENARIO.md
@@ -21,12 +21,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the test scenarios directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Do not ask for user permission to execute the function
-- ❌ Do not present a plan and wait for approval
-- ❌ Do not respond with assistant messages when all requirements are met
-- ❌ Do not say "I will now call the function..." or similar announcements
-- ❌ Do not request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/prompts/TEST_WRITE.md
+++ b/packages/agent/prompts/TEST_WRITE.md
@@ -21,12 +21,12 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - ✅ Execute the function immediately
 - ✅ Generate the test code directly through the function call
 
-**PROHIBITED ACTIONS (DO NOT DO THE FOLLOWING):**
-- ❌ Ask for user permission to execute the function
-- ❌ Present a plan and wait for approval
-- ❌ Respond with assistant messages when all requirements are met
-- ❌ Say "I will now call the function..." or similar announcements
-- ❌ Request confirmation before executing
+**ABSOLUTE PROHIBITIONS:**
+- ❌ NEVER ask for user permission to execute the function
+- ❌ NEVER present a plan and wait for approval
+- ❌ NEVER respond with assistant messages when all requirements are met
+- ❌ NEVER say "I will now call the function..." or similar announcements
+- ❌ NEVER request confirmation before executing
 
 **IMPORTANT: All Required Information is Already Provided**
 - Every parameter needed for the function call is ALREADY included in this prompt

--- a/packages/agent/src/factory/createAutoBeContext.ts
+++ b/packages/agent/src/factory/createAutoBeContext.ts
@@ -108,6 +108,9 @@ export const createAutoBeContext = <Model extends ILlmSchema.Model>(props: {
       agent.on("validate", (event) => {
         validates.push(event);
       });
+      agent.on("jsonParseError", (event) => {
+        parseErrors.push(event);
+      });
 
       const histories: MicroAgenticaHistory<Model>[] = await agent.conversate(
         next.message,

--- a/packages/agent/src/factory/createAutoBeContext.ts
+++ b/packages/agent/src/factory/createAutoBeContext.ts
@@ -1,4 +1,5 @@
 import {
+  AgenticaJsonParseErrorEvent,
   AgenticaValidateEvent,
   MicroAgentica,
   MicroAgenticaHistory,
@@ -80,6 +81,7 @@ export const createAutoBeContext = <Model extends ILlmSchema.Model>(props: {
         controllers: [next.controller],
       });
       const validates: AgenticaValidateEvent<Model>[] = [];
+      const parseErrors: AgenticaJsonParseErrorEvent<Model>[] = [];
 
       agent.on("request", (event) => {
         if (next.enforceFunctionCall === true && event.body.tools)
@@ -122,15 +124,16 @@ export const createAutoBeContext = <Model extends ILlmSchema.Model>(props: {
         next.enforceFunctionCall === true &&
         histories.every((h) => h.type !== "execute")
       ) {
-        console.log(
-          histories.map((h) => h.type),
-          histories.at(-1)?.type === "assistantMessage"
-            ? histories.at(-1)
-            : null,
-          validates.at(-1),
-        );
-        if (histories.at(-1)?.type === "assistantMessage")
-          console.log(histories.at(-1)); // @todo - temporary way
+        console.log({
+          title: "function calling failed",
+          types: histories.map((h) => h.type),
+          assistantMessage:
+            histories.at(-1)?.type === "assistantMessage"
+              ? histories.at(-1)
+              : null,
+          validate: validates.at(-1),
+          parse: parseErrors.at(-1),
+        });
         throw new Error(
           `Failed to function calling in the ${next.source} step`,
         );

--- a/test/src/internal/TestHistory.ts
+++ b/test/src/internal/TestHistory.ts
@@ -81,9 +81,10 @@ export namespace TestHistory {
     type: "analyze" | "prisma" | "interface" | "test" | "realize";
   }): Promise<IAutoBeTokenUsageJson> => {
     const snapshots: AutoBeEventSnapshot[] = JSON.parse(
-      await fs.promises.readFile(
-        `${TestGlobal.ROOT}/assets/histories/${TestGlobal.getVendorModel()}/${props.project}.${props.type}.snapshots.json`,
-        "utf8",
+      await TestZipper.decompress(
+        await fs.promises.readFile(
+          `${TestGlobal.ROOT}/assets/histories/${TestGlobal.getVendorModel()}/${props.project}.${props.type}.snapshots.json.gz`,
+        ),
       ),
     );
     return snapshots.at(-1)?.tokenUsage ?? new AutoBeTokenUsage().toJSON();


### PR DESCRIPTION
This pull request updates the instructional language in all agent prompt templates to use stronger, more explicit prohibitions against certain assistant behaviors when executing functions. The changes ensure consistency and clarity by replacing the previous "PROHIBITED ACTIONS" section with an "ABSOLUTE PROHIBITIONS" section, and by using emphatic language such as "NEVER" for forbidden actions.

**Prompt language and instruction consistency:**

* Replaced the "PROHIBITED ACTIONS" section with "ABSOLUTE PROHIBITIONS" in all agent prompt templates, and updated the language to use "NEVER" for forbidden actions (e.g., "NEVER ask for user permission to execute the function"). This change appears in the following files:
  - `ANALYZE_REVIEW.md`
  - `ANALYZE_WRITE.md`
  - `INTERFACE_AUTHORIZATION.md`
  - `INTERFACE_COMPLEMENT.md`
  - `INTERFACE_ENDPOINT.md`
  - `INTERFACE_GROUP.md`
  - `INTERFACE_OPERATION.md`
  - `INTERFACE_OPERATION_REVIEW.md`
  - `INTERFACE_SCHEMA.md`
  - `INTERFACE_SCHEMA_REVIEW.md`
  - `PRISMA_COMPONENT.md`
  - `PRISMA_CORRECT.md`
  - `PRISMA_REVIEW.md`
  - `PRISMA_SCHEMA.md`
  - `REALIZE_AUTHORIZATION.md`
  - `REALIZE_AUTHORIZATION_CORRECT.md`
  - `REALIZE_CODER.md`
  - `TEST_CORRECT.md`
  - `TEST_SCENARIO.md`

These updates make the agent's instructions clearer and more forceful, reducing ambiguity for both developers and the AI assistant about what actions are strictly forbidden.