### PR TITLE
fix(compiler): prisma's duplicated names between field and relations

### DIFF
--- a/packages/agent/src/factory/createAutoBeContext.ts
+++ b/packages/agent/src/factory/createAutoBeContext.ts
@@ -283,10 +283,10 @@ const transformAndDispatch = <
 
 const forceRetry = async <T>(
   task: () => Promise<T>,
-  count: number = 2,
+  count: number = 5,
 ): Promise<T> => {
   let error: unknown = undefined;
-  for (let i: number = 0; i <= count; ++i)
+  for (let i: number = 0; i < count; ++i)
     try {
       return await task();
     } catch (e) {

--- a/packages/compiler/src/prisma/validatePrismaApplication.ts
+++ b/packages/compiler/src/prisma/validatePrismaApplication.ts
@@ -152,11 +152,14 @@ function validateDuplicatedFields(
   MapUtil.take(group, model.primaryField.name, () => []).push(
     `${accessor}.primaryField.name`,
   );
-  model.foreignFields.forEach((field, i) =>
+  model.foreignFields.forEach((field, i) => {
     MapUtil.take(group, field.name, () => []).push(
       `${accessor}.foreignFields[${i}].name`,
-    ),
-  );
+    );
+    MapUtil.take(group, field.relation.name, () => []).push(
+      `${accessor}.foreignFields[${i}].relation.name`,
+    );
+  });
   model.plainFields.forEach((field, i) =>
     MapUtil.take(group, field.name, () => []).push(
       `${accessor}.plainFields[${i}].name`,
@@ -441,6 +444,8 @@ function validateReferences(
   const errors: IAutoBePrismaValidation.IError[] = [];
 
   model.foreignFields.forEach((field, i) => {
+    // DUPLICATED NAME
+
     const target = dict.get(field.relation.targetModel);
     if (target === undefined) {
       // CHECK EXISTENCE


### PR DESCRIPTION
This pull request introduces improvements to error handling and validation logic in the codebase, focusing on increasing retry attempts for async tasks and enhancing duplicate field validation in Prisma models.

**Error handling improvements:**

* Increased the retry count in the `forceRetry` utility function from 2 to 5 and corrected the loop condition to properly attempt the specified number of retries. (`createAutoBeContext.ts`)

**Prisma validation enhancements:**

* Updated the `validateDuplicatedFields` function to also check for duplicate relation names in `foreignFields`, not just field names, improving the detection of naming conflicts in Prisma models. (`validatePrismaApplication.ts`)
* Added a comment marker for duplicated name checking in the `validateReferences` function to clarify the validation process. (`validatePrismaApplication.ts`)