### PR TITLE
fix(interface): nullable json schema

### DIFF
--- a/packages/interface/src/openapi/AutoBeOpenApi.ts
+++ b/packages/interface/src/openapi/AutoBeOpenApi.ts
@@ -931,7 +931,8 @@ export namespace AutoBeOpenApi {
     | IJsonSchema.IArray
     | IJsonSchema.IObject
     | IJsonSchema.IReference
-    | IJsonSchema.IOneOf;
+    | IJsonSchema.IOneOf
+    | IJsonSchema.INull;
   export namespace IJsonSchema {
     /** Constant value type. */
     export interface IConstant {


### PR DESCRIPTION
This pull request makes a small update to the `AutoBeOpenApi` namespace, specifically to the type definitions for JSON schemas. The change adds support for the `INull` type, allowing schemas to explicitly represent null values.

- Type definitions update:
  * [`packages/interface/src/openapi/AutoBeOpenApi.ts`](diffhunk://#diff-8df15ff497605818e5b8b37a95eb2c6eb84dc94b58db557c9f383f4d3100baf0L934-R935): Added `IJsonSchema.INull` to the union type for JSON schema definitions, enabling explicit null type support.