### PR TITLE
fix(ui): wrong command

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "prepack": "publint && pnpm build"
+    "prepack": "pnpm build"
   },
   "devDependencies": {
     "@autobe/interface": "workspace:*",


### PR DESCRIPTION
This pull request makes a minor update to the `packages/ui/package.json` file by removing the `publint` check from the `prepack` script, so now only the build step runs before packaging.

* Removed `publint` from the `prepack` script in `package.json`, so only `pnpm build` runs before packaging.