### PR TITLE
feat(compiler): try catch tracing statement in controller

### DIFF
--- a/packages/compiler/src/realize/writeRealizeControllers.ts
+++ b/packages/compiler/src/realize/writeRealizeControllers.ts
@@ -73,6 +73,40 @@ export const writeRealizeControllers = async (
                 ),
               ],
         );
+        const tryCatch = ts.factory.createTryStatement(
+          ts.factory.createBlock(
+            [
+              ts.factory.createReturnStatement(
+                ts.factory.createAwaitExpression(call),
+              ),
+            ],
+            true,
+          ),
+          ts.factory.createCatchClause(
+            ts.factory.createVariableDeclaration(
+              ts.factory.createIdentifier("error"),
+              undefined,
+              undefined,
+              undefined,
+            ),
+            ts.factory.createBlock(
+              [
+                ts.factory.createExpressionStatement(
+                  ts.factory.createCallExpression(
+                    ts.factory.createIdentifier("console.log"),
+                    undefined,
+                    [ts.factory.createIdentifier("error")],
+                  ),
+                ),
+                ts.factory.createThrowStatement(
+                  ts.factory.createIdentifier("error"),
+                ),
+              ],
+              true,
+            ),
+          ),
+          undefined,
+        );
         return ts.factory.updateMethodDeclaration(
           method,
           method.modifiers,
@@ -126,7 +160,7 @@ export const writeRealizeControllers = async (
               ]
             : method.parameters,
           method.type,
-          ts.factory.createBlock([ts.factory.createReturnStatement(call)]),
+          ts.factory.createBlock([tryCatch]),
         );
       },
     },


### PR DESCRIPTION
This pull request refactors the way controller method calls are handled in the `writeRealizeControllers` function to improve error handling. The main change is that method calls are now wrapped in a `try/catch` block that logs and rethrows errors, instead of directly returning the result.

Error handling improvements:

* Controller method calls are now wrapped in a `try/catch` block. If an error occurs during the awaited call, it is logged with `console.log` and then rethrown to ensure errors are not silently swallowed. (`packages/compiler/src/realize/writeRealizeControllers.ts`, [[1]](diffhunk://#diff-4a18adcb2adbaf3ed13c6d82249e9cb6bdc1c6279bc2eb37d3b8efe6a363d61cR76-R109) [[2]](diffhunk://#diff-4a18adcb2adbaf3ed13c6d82249e9cb6bdc1c6279bc2eb37d3b8efe6a363d61cL129-R163)