### PR TITLE
fix(ui): restore zip file download

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,5 +28,9 @@
     "react": "catalog:ui",
     "react-dom": "catalog:ui",
     "typescript": "catalog:typescript"
+  },
+  "dependencies": {
+    "jszip": "^3.10.1",
+    "tstl": "catalog:samchon"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,7 +719,7 @@ importers:
         specifier: ^3.10.1
         version: 3.10.1
       tstl:
-        specifier: ^3.0.0
+        specifier: catalog:samchon
         version: 3.0.0
     devDependencies:
       '@autobe/interface':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,6 +714,13 @@ importers:
         version: 5.9.2
 
   packages/ui:
+    dependencies:
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
+      tstl:
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
       '@autobe/interface':
         specifier: workspace:*


### PR DESCRIPTION
This pull request updates the file download functionality in the `AutoBeCompleteEventMovie` component to package exported files as a ZIP archive instead of a single JSON file. It introduces new dependencies to support this feature and refactors the download logic accordingly.

**Feature enhancement:**
* The download button now creates and downloads a ZIP archive containing the exported files, preserving their folder structure, instead of a JSON file. This is implemented using the `jszip` library and the `VariadicSingleton` utility from `tstl`.

**Dependency updates:**
* Added `jszip` and `tstl` as new dependencies in `packages/ui/package.json` and updated the lockfile to ensure these packages are installed. [[1]](diffhunk://#diff-1ae5a5e8c23bd3bc31ea590a9cbe48eb9ad3bbddc0fb5732d08c04a53c8ad51dR31-R34) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR717-R723)

**Code imports:**
* Updated imports in `AutoBeCompleteEventMovie.tsx` to include `jszip` and `VariadicSingleton` for the new ZIP functionality.