### PR TITLE
refactor(agent): migrate v4 to v7 uuid

### DIFF
--- a/packages/agent/src/AutoBeAgent.ts
+++ b/packages/agent/src/AutoBeAgent.ts
@@ -13,7 +13,7 @@ import {
 } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
 import { Semaphore, Singleton } from "tstl";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeAgentBase } from "./AutoBeAgentBase";
 import { AutoBeContext } from "./context/AutoBeContext";
@@ -202,7 +202,7 @@ export class AutoBeAgent<Model extends ILlmSchema.Model>
     this.agentica_.on("assistantMessage", async (message) => {
       const start = new Date();
       const history: AutoBeAssistantMessageHistory = {
-        id: v4(),
+        id: v7(),
         type: "assistantMessage",
         text: await message.join(),
         created_at: start.toISOString(),
@@ -253,7 +253,7 @@ export class AutoBeAgent<Model extends ILlmSchema.Model>
   ): Promise<AutoBeHistory[]> {
     const index: number = this.histories_.length;
     const userMessageHistory: AutoBeUserMessageHistory = {
-      id: v4(),
+      id: v7(),
       type: "userMessage",
       contents:
         typeof content === "string"

--- a/packages/agent/src/AutoBeMockAgent.ts
+++ b/packages/agent/src/AutoBeMockAgent.ts
@@ -11,7 +11,7 @@ import {
   IAutoBePlaygroundReplay,
 } from "@autobe/interface";
 import { Singleton, randint, sleep_for } from "tstl";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeAgentBase } from "./AutoBeAgentBase";
 import { AutoBeState } from "./context/AutoBeState";
@@ -50,7 +50,7 @@ export class AutoBeMockAgent extends AutoBeAgentBase implements IAutoBeAgent {
   ): Promise<AutoBeHistory[]> {
     // THE USER-MESSAGE
     const userMessage: AutoBeUserMessageHistory = {
-      id: v4(),
+      id: v7(),
       type: "userMessage",
       contents:
         typeof content === "string"
@@ -72,7 +72,7 @@ export class AutoBeMockAgent extends AutoBeAgentBase implements IAutoBeAgent {
     if (state.realize !== null) {
       await sleep_for(2_000);
       const assistantMessage: AutoBeAssistantMessageHistory = {
-        id: v4(),
+        id: v7(),
         type: "assistantMessage",
         text: [
           "AutoBE has successfully realized the application.",
@@ -94,7 +94,7 @@ export class AutoBeMockAgent extends AutoBeAgentBase implements IAutoBeAgent {
       if (snapshots === null) {
         this.histories_.push(userMessage);
         this.histories_.push({
-          id: v4(),
+          id: v7(),
           type: "assistantMessage",
           text: [
             "The histories are prepared until current state.",

--- a/packages/agent/src/factory/consentFunctionCall.ts
+++ b/packages/agent/src/factory/consentFunctionCall.ts
@@ -10,7 +10,7 @@ import {
 } from "@autobe/interface";
 import { IPointer } from "tstl";
 import typia from "typia";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../constants/AutoBeSystemPromptConstant";
 import { IAutoBeConfig } from "../structures/IAutoBeConfig";
@@ -37,13 +37,13 @@ export const consentFunctionCall = async (props: {
     },
     histories: [
       {
-        id: v4(),
+        id: v7(),
         type: "systemMessage",
         text: AutoBeSystemPromptConstant.CONSENT_FUNCTION_CALL,
         created_at: new Date().toISOString(),
       } satisfies IAgenticaHistoryJson.ISystemMessage,
       {
-        id: v4(),
+        id: v7(),
         type: "assistantMessage",
         text: props.assistantMessage,
         created_at: new Date().toISOString(),

--- a/packages/agent/src/factory/createAutoBeContext.ts
+++ b/packages/agent/src/factory/createAutoBeContext.ts
@@ -25,7 +25,7 @@ import {
 } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
 import typia from "typia";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../context/AutoBeContext";
 import { AutoBeState } from "../context/AutoBeState";
@@ -218,7 +218,7 @@ const createDispatch = (props: {
         event,
         history: {
           type: "analyze",
-          id: v4(),
+          id: v7(),
           reason: analyzeStart?.reason ?? "",
           prefix: event.prefix,
           roles: event.roles,
@@ -236,7 +236,7 @@ const createDispatch = (props: {
         event,
         history: {
           type: "prisma",
-          id: v4(),
+          id: v7(),
           reason: prismaStart?.reason ?? "",
           schemas: event.schemas,
           result: event.result,
@@ -254,7 +254,7 @@ const createDispatch = (props: {
         event,
         history: {
           type: "interface",
-          id: v4(),
+          id: v7(),
           reason: interfaceStart?.reason ?? "",
           authorizations: event.authorizations,
           document: event.document,
@@ -271,7 +271,7 @@ const createDispatch = (props: {
         event,
         history: {
           type: "test",
-          id: v4(),
+          id: v7(),
           reason: testStart?.reason ?? "",
           files: event.files,
           compiled: event.compiled,
@@ -288,7 +288,7 @@ const createDispatch = (props: {
         event,
         history: {
           type: "realize",
-          id: v4(),
+          id: v7(),
           reason: realizeStart?.reason ?? "",
           authorizations: event.authorizations,
           functions: event.functions,

--- a/packages/agent/src/orchestrate/analyze/histories/transformAnalyzeReviewerHistories.ts
+++ b/packages/agent/src/orchestrate/analyze/histories/transformAnalyzeReviewerHistories.ts
@@ -2,7 +2,7 @@ import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeAnalyzeScenarioEvent } from "@autobe/interface";
 import { AutoBeAnalyzeFile } from "@autobe/interface/src/histories/contents/AutoBeAnalyzeFile";
 import { ILlmSchema } from "@samchon/openapi";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeContext } from "../../../context/AutoBeContext";
@@ -23,7 +23,7 @@ export const transformAnalyzeReviewerHistories = <
   return [
     ...transformAnalyzeWriteHistories(ctx, scenario, myFile),
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [
@@ -41,13 +41,13 @@ export const transformAnalyzeReviewerHistories = <
       ].join("\n"),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.ANALYZE_REVIEW,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [

--- a/packages/agent/src/orchestrate/analyze/histories/transformAnalyzeScenarioHistories.ts
+++ b/packages/agent/src/orchestrate/analyze/histories/transformAnalyzeScenarioHistories.ts
@@ -1,6 +1,6 @@
 import { IMicroAgenticaHistoryJson } from "@agentica/core";
 import { ILlmSchema } from "@samchon/openapi";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeContext } from "../../../context/AutoBeContext";
@@ -13,13 +13,13 @@ export function transformAnalyzeSceHistories<Model extends ILlmSchema.Model>(
       .histories()
       .filter((h) => h.type === "userMessage" || h.type === "assistantMessage"),
     {
-      id: v4(),
+      id: v7(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.ANALYZE_SCENARIO,
       created_at: new Date().toISOString(),
     },
     {
-      id: v4(),
+      id: v7(),
       type: "systemMessage",
       text: [
         "One agent per page of the document you specify will write according to the instructions below.",

--- a/packages/agent/src/orchestrate/analyze/histories/transformAnalyzeWriteHistories.ts
+++ b/packages/agent/src/orchestrate/analyze/histories/transformAnalyzeWriteHistories.ts
@@ -2,7 +2,7 @@ import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeAnalyzeScenarioEvent } from "@autobe/interface";
 import { AutoBeAnalyzeFile } from "@autobe/interface/src/histories/contents/AutoBeAnalyzeFile";
 import { ILlmSchema } from "@samchon/openapi";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeContext } from "../../../context/AutoBeContext";
@@ -35,13 +35,13 @@ export const transformAnalyzeWriteHistories = <Model extends ILlmSchema.Model>(
         };
       }),
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.ANALYZE_WRITE,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [

--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeScenario.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeScenario.ts
@@ -9,7 +9,7 @@ import {
 import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
@@ -45,7 +45,7 @@ export const orchestrateAnalyzeScenario = async <
       ...(histories.at(-1)! as AgenticaAssistantMessageHistory),
       created_at: start.toISOString(),
       completed_at: new Date().toISOString(),
-      id: v4(),
+      id: v7(),
     } satisfies AutoBeAssistantMessageHistory;
   else if (pointer.value === null) {
     // unreachable

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceAssetHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceAssetHistories.ts
@@ -4,7 +4,7 @@ import {
   AutoBePrismaHistory,
   IAutoBePrismaCompileResult,
 } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeState } from "../../../context/AutoBeState";
 
@@ -17,7 +17,7 @@ export const transformInterfaceAssetHistories = (
   const prisma: AutoBePrismaHistory = state.prisma!;
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [
@@ -40,7 +40,7 @@ export const transformInterfaceAssetHistories = (
       ].join("\n"),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceAuthorizationsHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceAuthorizationsHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeAnalyzeRole } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -15,14 +15,14 @@ export const transformInterfaceAuthorizationsHistories = (
   return [
     {
       type: "systemMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: AutoBeSystemPromptConstant.INTERFACE_AUTHORIZATION,
     },
     ...transformInterfaceAssetHistories(state),
     {
       type: "assistantMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: [
         "You have to make API operations for the given role:",

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceComplementHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceComplementHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeOpenApi } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -15,14 +15,14 @@ export const transformInterfaceComplementHistories = (
 > => [
   {
     type: "systemMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: AutoBeSystemPromptConstant.INTERFACE_OPERATION,
   },
   ...transformInterfaceAssetHistories(state),
   {
     type: "assistantMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: [
       "Here is the OpenAPI operations what you AI have made:",
@@ -34,13 +34,13 @@ export const transformInterfaceComplementHistories = (
   },
   {
     type: "systemMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: AutoBeSystemPromptConstant.INTERFACE_SCHEMA,
   },
   {
     type: "assistantMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: [
       "Here is the OpenAPI schemas what you AI have made:",
@@ -52,13 +52,13 @@ export const transformInterfaceComplementHistories = (
   },
   {
     type: "systemMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: AutoBeSystemPromptConstant.INTERFACE_COMPLEMENT,
   },
   {
     type: "assistantMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: [
       "You AI have missed below schema types:",

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceEndpointHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceEndpointHistories.ts
@@ -1,7 +1,7 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeOpenApi } from "@autobe/interface";
 import { AutoBeInterfaceGroup } from "@autobe/interface/src/histories/contents/AutoBeInterfaceGroup";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -16,14 +16,14 @@ export const transformInterfaceEndpointHistories = (
 > => [
   {
     type: "systemMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: AutoBeSystemPromptConstant.INTERFACE_ENDPOINT,
   },
   ...transformInterfaceAssetHistories(state),
   {
     type: "assistantMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: [
       "Here is the target group for the endpoints:",

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceGroupHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceGroupHistories.ts
@@ -1,5 +1,5 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -16,14 +16,14 @@ export const transformInterfaceGroupHistories = (
 
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.INTERFACE_ENDPOINT,
     },
     ...transformInterfaceAssetHistories(state),
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.INTERFACE_GROUP,

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceOperationHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceOperationHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeAnalyzeHistory, AutoBeOpenApi } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -16,14 +16,14 @@ export const transformInterfaceOperationHistories = (
   return [
     {
       type: "systemMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: AutoBeSystemPromptConstant.INTERFACE_OPERATION,
     },
     ...transformInterfaceAssetHistories(state),
     {
       type: "systemMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: [
         `## Service Prefix`,
@@ -40,7 +40,7 @@ export const transformInterfaceOperationHistories = (
     },
     {
       type: "assistantMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: [
         "You have to make API operations for the given endpoints:",

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceOperationsReviewHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceOperationsReviewHistories.ts
@@ -1,7 +1,7 @@
 import { IMicroAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeOpenApi } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeContext } from "../../../context/AutoBeContext";
@@ -16,20 +16,20 @@ export function transformInterfaceOperationsReviewHistories<
   return [
     {
       type: "systemMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: AutoBeSystemPromptConstant.INTERFACE_OPERATION,
     },
     ...transformInterfaceAssetHistories(ctx.state()),
     {
       type: "systemMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: AutoBeSystemPromptConstant.INTERFACE_OPERATION_REVIEW,
     },
     {
       type: "assistantMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: [
         "Review the following API operations:",

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfacePrerequisiteHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfacePrerequisiteHistories.ts
@@ -1,5 +1,5 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeState } from "../../../context/AutoBeState";
 
@@ -11,7 +11,7 @@ export const transformInterfacePrerequisiteHistories = (
   if (state.analyze === null)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -24,7 +24,7 @@ export const transformInterfacePrerequisiteHistories = (
   else if (state.prisma === null)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -37,7 +37,7 @@ export const transformInterfacePrerequisiteHistories = (
   else if (state.analyze.step !== state.prisma.step)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -51,7 +51,7 @@ export const transformInterfacePrerequisiteHistories = (
   else if (state.prisma.compiled.type !== "success")
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceSchemaHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceSchemaHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeOpenApi } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -14,14 +14,14 @@ export const transformInterfaceSchemaHistories = (
 > => [
   {
     type: "systemMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: AutoBeSystemPromptConstant.INTERFACE_SCHEMA,
   },
   ...transformInterfaceAssetHistories(state),
   {
     type: "assistantMessage",
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     text: [
       "Here is the list of API operations you have to implement its types:",

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceSchemasReviewHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceSchemasReviewHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeOpenApi } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -19,20 +19,20 @@ export const transformInterfaceSchemasReviewHistories = (
   return [
     {
       type: "systemMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: AutoBeSystemPromptConstant.INTERFACE_SCHEMA,
     },
     ...transformInterfaceAssetHistories(state),
     {
       type: "systemMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: AutoBeSystemPromptConstant.INTERFACE_SCHEMA_REVIEW,
     },
     {
       type: "assistantMessage",
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       text: [
         "The Schema Agent has generated schemas for the following API operations.",
@@ -46,7 +46,7 @@ export const transformInterfaceSchemasReviewHistories = (
       ].join("\n"),
     },
     {
-      id: v4(),
+      id: v7(),
       type: "assistantMessage",
       created_at: new Date().toISOString(),
       text: [

--- a/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
@@ -9,7 +9,7 @@ import {
 import { AutoBeEndpointComparator } from "@autobe/utils";
 import { ILlmSchema } from "@samchon/openapi";
 import { HashMap, Pair } from "tstl";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { IAutoBeApplicationProps } from "../../context/IAutoBeApplicationProps";
@@ -35,7 +35,7 @@ export const orchestrateInterface =
     if (predicate !== null)
       return ctx.assistantMessage({
         type: "assistantMessage",
-        id: v4(),
+        id: v7(),
         created_at: start.toISOString(),
         text: predicate,
         completed_at: new Date().toISOString(),

--- a/packages/agent/src/orchestrate/prisma/histories/transformPrismaComponentsHistories.ts
+++ b/packages/agent/src/orchestrate/prisma/histories/transformPrismaComponentsHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { NamingConvention } from "typia/lib/utils/NamingConvention";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -17,13 +17,13 @@ export const transformPrismaComponentsHistories = (
   if (prefix) prefix = NamingConvention.snake(prefix);
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.PRISMA_COMPONENT,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [

--- a/packages/agent/src/orchestrate/prisma/histories/transformPrismaCorrectHistories.ts
+++ b/packages/agent/src/orchestrate/prisma/histories/transformPrismaCorrectHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { IAutoBePrismaValidation } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 
@@ -11,13 +11,13 @@ export const transformPrismaCorrectHistories = (
 > => {
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.PRISMA_CORRECT,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [
@@ -29,7 +29,7 @@ export const transformPrismaCorrectHistories = (
       ].join("\n"),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [
@@ -41,7 +41,7 @@ export const transformPrismaCorrectHistories = (
       ].join("\n"),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: [

--- a/packages/agent/src/orchestrate/prisma/histories/transformPrismaReviewHistories.ts
+++ b/packages/agent/src/orchestrate/prisma/histories/transformPrismaReviewHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBePrisma } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 
@@ -14,13 +14,13 @@ export const transformPrismaReviewHistories = (props: {
 > => {
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.PRISMA_SCHEMA,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [
@@ -44,13 +44,13 @@ export const transformPrismaReviewHistories = (props: {
       ].join("\n"),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.PRISMA_REVIEW,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [

--- a/packages/agent/src/orchestrate/prisma/histories/transformPrismaSchemaHistories.ts
+++ b/packages/agent/src/orchestrate/prisma/histories/transformPrismaSchemaHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBePrisma } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 
@@ -13,13 +13,13 @@ export const transformPrismaSchemaHistories = (
 > => {
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.PRISMA_SCHEMA,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [
@@ -35,7 +35,7 @@ export const transformPrismaSchemaHistories = (
       ].join("\n"),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: [

--- a/packages/agent/src/orchestrate/prisma/orchestratePrisma.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrisma.ts
@@ -10,7 +10,7 @@ import {
 } from "@autobe/interface";
 import { AutoBePrismaSchemasEvent } from "@autobe/interface/src/events/AutoBePrismaSchemasEvent";
 import { ILlmSchema } from "@samchon/openapi";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { IAutoBeApplicationProps } from "../../context/IAutoBeApplicationProps";
@@ -30,7 +30,7 @@ export const orchestratePrisma = async <Model extends ILlmSchema.Model>(
   if (predicate !== null)
     return ctx.assistantMessage({
       type: "assistantMessage",
-      id: v4(),
+      id: v7(),
       created_at: start.toISOString(),
       text: predicate,
       completed_at: new Date().toISOString(),

--- a/packages/agent/src/orchestrate/realize/histories/transformRealizeAuthorization.ts
+++ b/packages/agent/src/orchestrate/realize/histories/transformRealizeAuthorization.ts
@@ -1,7 +1,7 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeAnalyzeRole } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeContext } from "../../../context/AutoBeContext";
@@ -16,13 +16,13 @@ export const transformRealizeAuthorizationHistories = <
 > => {
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.REALIZE_AUTHORIZATION,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: [

--- a/packages/agent/src/orchestrate/realize/histories/transformRealizeAuthorizationCorrectHistories.ts
+++ b/packages/agent/src/orchestrate/realize/histories/transformRealizeAuthorizationCorrectHistories.ts
@@ -4,7 +4,7 @@ import {
   IAutoBeTypeScriptCompileResult,
 } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeContext } from "../../../context/AutoBeContext";
@@ -21,19 +21,19 @@ export const transformRealizeAuthorizationCorrectHistories = <
 > => {
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.REALIZE_AUTHORIZATION,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.REALIZE_AUTHORIZATION_CORRECT,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [

--- a/packages/agent/src/orchestrate/realize/histories/transformRealizeCorrectHistories.ts
+++ b/packages/agent/src/orchestrate/realize/histories/transformRealizeCorrectHistories.ts
@@ -3,7 +3,7 @@ import {
   AutoBeRealizeAuthorization,
   IAutoBeTypeScriptCompileResult,
 } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -25,7 +25,7 @@ export function transformRealizeCorrectHistories(props: {
   return [
     ...transformRealizeWriteHistories(props),
     {
-      id: v4(),
+      id: v7(),
       type: "assistantMessage",
       text: [
         `Below is the code you made before. It's also something to review.`,
@@ -40,7 +40,7 @@ export function transformRealizeCorrectHistories(props: {
       created_at: new Date().toISOString(),
     },
     {
-      id: v4(),
+      id: v7(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.REALIZE_CORRECT,
       created_at: new Date().toISOString(),

--- a/packages/agent/src/orchestrate/realize/histories/transformRealizeWriteAuthorizationsHistories.ts
+++ b/packages/agent/src/orchestrate/realize/histories/transformRealizeWriteAuthorizationsHistories.ts
@@ -271,7 +271,7 @@ export const transformRealizeWriteAuthorizationsHistories = (
 
               **DO NOT**:
               - Generate new access tokens with different payload structures
-              - Use random IDs like v7() in the payload
+              - Use random IDs like v4() in the payload
               - Create tokens without verifying the refresh token first
               - Use type annotations like: const payload: UserPayload = {...}
 

--- a/packages/agent/src/orchestrate/realize/histories/transformRealizeWriteAuthorizationsHistories.ts
+++ b/packages/agent/src/orchestrate/realize/histories/transformRealizeWriteAuthorizationsHistories.ts
@@ -1,7 +1,7 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeOpenApi } from "@autobe/interface";
 import { StringUtil } from "@autobe/utils";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 export const transformRealizeWriteAuthorizationsHistories = (
   operation: AutoBeOpenApi.IOperation,
@@ -12,7 +12,7 @@ export const transformRealizeWriteAuthorizationsHistories = (
     operation.authorizationType === "login"
       ? [
           {
-            id: v4(),
+            id: v7(),
             created_at: new Date().toISOString(),
             type: "systemMessage" as const,
             text: StringUtil.trim`
@@ -105,7 +105,7 @@ export const transformRealizeWriteAuthorizationsHistories = (
     operation.authorizationType === "join"
       ? [
           {
-            id: v4(),
+            id: v7(),
             created_at: new Date().toISOString(),
             type: "systemMessage" as const,
             text: StringUtil.trim`
@@ -195,7 +195,7 @@ export const transformRealizeWriteAuthorizationsHistories = (
     operation.authorizationType === "refresh"
       ? [
           {
-            id: v4(),
+            id: v7(),
             created_at: new Date().toISOString(),
             type: "systemMessage" as const,
             text: StringUtil.trim`
@@ -271,7 +271,7 @@ export const transformRealizeWriteAuthorizationsHistories = (
 
               **DO NOT**:
               - Generate new access tokens with different payload structures
-              - Use random IDs like v4() in the payload
+              - Use random IDs like v7() in the payload
               - Create tokens without verifying the refresh token first
               - Use type annotations like: const payload: UserPayload = {...}
 

--- a/packages/agent/src/orchestrate/realize/histories/transformRealizeWriteHistories.ts
+++ b/packages/agent/src/orchestrate/realize/histories/transformRealizeWriteHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeRealizeAuthorization } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -53,7 +53,7 @@ export const transformRealizeWriteHistories = (
   if (props.state.analyze === null)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -66,7 +66,7 @@ export const transformRealizeWriteHistories = (
   else if (props.state.prisma === null)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -79,7 +79,7 @@ export const transformRealizeWriteHistories = (
   else if (props.state.analyze.step !== props.state.prisma.step)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -93,7 +93,7 @@ export const transformRealizeWriteHistories = (
   else if (props.state.prisma.compiled.type !== "success")
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -107,7 +107,7 @@ export const transformRealizeWriteHistories = (
   else if (props.state.interface === null)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -125,14 +125,14 @@ export const transformRealizeWriteHistories = (
 
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.REALIZE_WRITE_TOTAL,
     },
     ...authorizationHistories,
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.REALIZE_WRITE_ARTIFACT.replaceAll(
@@ -144,7 +144,7 @@ export const transformRealizeWriteHistories = (
         .replaceAll(`{input}`, input),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: [
@@ -155,7 +155,7 @@ export const transformRealizeWriteHistories = (
       ].join("\n"),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [

--- a/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
@@ -41,7 +41,7 @@ export const orchestrateRealize =
     if (predicate !== null)
       return ctx.assistantMessage({
         type: "assistantMessage",
-        id: v4(),
+        id: v7(),
         created_at: start.toISOString(),
         text: predicate,
         completed_at: new Date().toISOString(),

--- a/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
@@ -10,7 +10,7 @@ import {
   IAutoBeTypeScriptCompileResult,
 } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
-import { v4, v7 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { IAutoBeApplicationProps } from "../../context/IAutoBeApplicationProps";

--- a/packages/agent/src/orchestrate/test/experimental/transformTestCorrectHistories.ast
+++ b/packages/agent/src/orchestrate/test/experimental/transformTestCorrectHistories.ast
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { IAutoBeTypeScriptCompileResult } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../constants/AutoBeSystemPromptConstant";
 import { IAutoBeTestWriteResult } from "./structures/IAutoBeTestWriteResult";
@@ -14,13 +14,13 @@ export const transformTestCorrectHistories = (
 > => {
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.TEST_WRITE,
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "assistantMessage",
       text: [
@@ -43,7 +43,7 @@ export const transformTestCorrectHistories = (
       ].join("\n"),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.TEST_CORRECT,

--- a/packages/agent/src/orchestrate/test/histories/transformTestCorrectHistories.ts
+++ b/packages/agent/src/orchestrate/test/histories/transformTestCorrectHistories.ts
@@ -1,6 +1,6 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { IAutoBeTypeScriptCompileResult } from "@autobe/interface";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { IAutoBeTestFunction } from "../structures/IAutoBeTestFunction";
@@ -14,7 +14,7 @@ export const transformTestCorrectHistories = (
 > => [
   ...transformTestWriteHistories(func.scenario, func.artifacts),
   {
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     type: "assistantMessage",
     text: [
@@ -32,7 +32,7 @@ export const transformTestCorrectHistories = (
     ].join("\n"),
   },
   {
-    id: v4(),
+    id: v7(),
     created_at: new Date().toISOString(),
     type: "systemMessage",
     text: AutoBeSystemPromptConstant.TEST_CORRECT.replace(

--- a/packages/agent/src/orchestrate/test/histories/transformTestHistories.ts
+++ b/packages/agent/src/orchestrate/test/histories/transformTestHistories.ts
@@ -1,5 +1,5 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeState } from "../../../context/AutoBeState";
 
@@ -11,7 +11,7 @@ export const transformTestHistories = (
   if (state.analyze === null)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -24,7 +24,7 @@ export const transformTestHistories = (
   else if (state.prisma === null)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -37,7 +37,7 @@ export const transformTestHistories = (
   else if (state.analyze.step !== state.prisma.step)
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -51,7 +51,7 @@ export const transformTestHistories = (
   else if (state.prisma.compiled.type !== "success")
     return [
       {
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: [
@@ -64,7 +64,7 @@ export const transformTestHistories = (
     ];
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: [

--- a/packages/agent/src/orchestrate/test/histories/transformTestScenarioHistories.ts
+++ b/packages/agent/src/orchestrate/test/histories/transformTestScenarioHistories.ts
@@ -1,7 +1,7 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
 import { AutoBeInterfaceAuthorization, AutoBeOpenApi } from "@autobe/interface";
 import { MapUtil } from "@autobe/utils";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
@@ -40,13 +40,13 @@ export const transformTestScenarioHistories = (
 
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.TEST_SCENARIO,
     } satisfies IAgenticaHistoryJson.ISystemMessage,
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: [
@@ -75,7 +75,7 @@ export const transformTestScenarioHistories = (
       ].join("\n"),
     } satisfies IAgenticaHistoryJson.ISystemMessage,
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: [

--- a/packages/agent/src/orchestrate/test/histories/transformTestWriteHistories.ts
+++ b/packages/agent/src/orchestrate/test/histories/transformTestWriteHistories.ts
@@ -7,7 +7,7 @@ import {
   OpenApi,
 } from "@samchon/openapi";
 import typia from "typia";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
 import { IAutoBeTestScenarioArtifacts } from "../structures/IAutoBeTestScenarioArtifacts";
@@ -18,7 +18,7 @@ export function transformTestWriteHistories(
 ): Array<IAgenticaHistoryJson.ISystemMessage> {
   return [
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: AutoBeSystemPromptConstant.TEST_WRITE.replace(
@@ -27,7 +27,7 @@ export function transformTestWriteHistories(
       ).replaceAll("{{FUNCTION_NAME}}", scenario.functionName),
     },
     {
-      id: v4(),
+      id: v7(),
       created_at: new Date().toISOString(),
       type: "systemMessage",
       text: StringUtil.trim`

--- a/packages/agent/src/orchestrate/test/orchestrateTest.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTest.ts
@@ -8,7 +8,7 @@ import {
   IAutoBeTypeScriptCompileResult,
 } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { IAutoBeApplicationProps } from "../../context/IAutoBeApplicationProps";
@@ -29,7 +29,7 @@ export const orchestrateTest =
     if (predicate !== null)
       return ctx.assistantMessage({
         type: "assistantMessage",
-        id: v4(),
+        id: v7(),
         created_at: start.toISOString(),
         text: predicate,
         completed_at: new Date().toISOString(),
@@ -46,7 +46,7 @@ export const orchestrateTest =
       ctx.state().interface?.document.operations ?? [];
     if (operations.length === 0)
       return ctx.assistantMessage({
-        id: v4(),
+        id: v7(),
         type: "assistantMessage",
         created_at: start.toISOString(),
         completed_at: new Date().toISOString(),

--- a/test/src/features/compiler/test_compiler_realize_files.ts
+++ b/test/src/features/compiler/test_compiler_realize_files.ts
@@ -3,7 +3,7 @@ import { AutoBeCompiler } from "@autobe/compiler";
 import { FileSystemIterator } from "@autobe/filesystem";
 import cp from "child_process";
 import OpenAI from "openai";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { TestGlobal } from "../../TestGlobal";
 import { TestHistory } from "../../internal/TestHistory";
@@ -28,7 +28,7 @@ export const test_compiler_realize_files = async () => {
         compiled: {
           type: "success",
         },
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         completed_at: new Date().toISOString(),
         reason: "Realize files for compiler",

--- a/test/src/internal/TestHistory.ts
+++ b/test/src/internal/TestHistory.ts
@@ -7,7 +7,7 @@ import {
 } from "@autobe/interface";
 import fs from "fs";
 import typia from "typia";
-import { v4 } from "uuid";
+import { v7 } from "uuid";
 
 import { TestGlobal } from "../TestGlobal";
 import { TestProject } from "../structures/TestProject";
@@ -32,7 +32,7 @@ export namespace TestHistory {
     return [
       {
         type: "userMessage",
-        id: v4(),
+        id: v7(),
         created_at: new Date().toISOString(),
         contents: [
           {


### PR DESCRIPTION
This pull request updates the agent codebase to use the new `v7` UUID generation method instead of `v4` across all modules. This change affects how unique IDs are generated for message histories, events, and other entities throughout the agent workflow, ensuring more robust and time-sortable UUIDs.

**Migration to UUID v7:**

* Replaced all instances of `v4` UUID generation with `v7` in message history creation within `AutoBeAgent`, `AutoBeMockAgent`, and related factories and orchestrators (`AutoBeAgent.ts`, `AutoBeMockAgent.ts`, `factory/consentFunctionCall.ts`, `factory/createAutoBeContext.ts`). [[1]](diffhunk://#diff-eb5845bde058399222e7eb37fcc40ccd00bee27a5d2531830decea25dc197e73L16-R16) [[2]](diffhunk://#diff-eb5845bde058399222e7eb37fcc40ccd00bee27a5d2531830decea25dc197e73L205-R205) [[3]](diffhunk://#diff-eb5845bde058399222e7eb37fcc40ccd00bee27a5d2531830decea25dc197e73L256-R256) [[4]](diffhunk://#diff-376bdf7ff06c32d6cdb27148ce31325fdc2caea8a5539d08195e3efeadde6e17L14-R14) [[5]](diffhunk://#diff-376bdf7ff06c32d6cdb27148ce31325fdc2caea8a5539d08195e3efeadde6e17L53-R53) [[6]](diffhunk://#diff-376bdf7ff06c32d6cdb27148ce31325fdc2caea8a5539d08195e3efeadde6e17L75-R75) [[7]](diffhunk://#diff-376bdf7ff06c32d6cdb27148ce31325fdc2caea8a5539d08195e3efeadde6e17L97-R97) [[8]](diffhunk://#diff-8a095d8180de26c2aaf67615d051e9588ae2be98458ebb284da5e93bcefed018L13-R13) [[9]](diffhunk://#diff-8a095d8180de26c2aaf67615d051e9588ae2be98458ebb284da5e93bcefed018L40-R46) [[10]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eL28-R28) [[11]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eL221-R221) [[12]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eL239-R239) [[13]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eL257-R257) [[14]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eL274-R274) [[15]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eL291-R291)
* Updated all orchestrator modules to use `v7` for history IDs, including analyze and interface history transformations (`transformAnalyzeReviewerHistories.ts`, `transformAnalyzeScenarioHistories.ts`, `transformAnalyzeWriteHistories.ts`, `orchestrateAnalyzeScenario.ts`, `transformInterfaceAssetHistories.ts`, `transformInterfaceAuthorizationsHistories.ts`, `transformInterfaceComplementHistories.ts`). [[1]](diffhunk://#diff-0a88efb5ee5aaa48ade969d5b0b9f4408ff2ba37b342f57c6aad25b39bb89a0eL5-R5) [[2]](diffhunk://#diff-0a88efb5ee5aaa48ade969d5b0b9f4408ff2ba37b342f57c6aad25b39bb89a0eL26-R26) [[3]](diffhunk://#diff-0a88efb5ee5aaa48ade969d5b0b9f4408ff2ba37b342f57c6aad25b39bb89a0eL44-R50) [[4]](diffhunk://#diff-1a242953a1c1a75896771a8071d377002ec81ccba1419174d6de6651148d1bfdL3-R3) [[5]](diffhunk://#diff-1a242953a1c1a75896771a8071d377002ec81ccba1419174d6de6651148d1bfdL16-R22) [[6]](diffhunk://#diff-b3d4a71ddd090fb5cd8e5133d9f1d50b4b404406524e5d2169b34a07b82ca657L5-R5) [[7]](diffhunk://#diff-b3d4a71ddd090fb5cd8e5133d9f1d50b4b404406524e5d2169b34a07b82ca657L38-R44) [[8]](diffhunk://#diff-b1561375a9a73a7e2f9576b33181d80a0a35e5c1d6887f4897fea9497a9eeeacL12-R12) [[9]](diffhunk://#diff-b1561375a9a73a7e2f9576b33181d80a0a35e5c1d6887f4897fea9497a9eeeacL48-R48) [[10]](diffhunk://#diff-4d99abd4e71d9360ce516abfe1042d4631108d02569f36899cbeef4769123730L7-R7) [[11]](diffhunk://#diff-4d99abd4e71d9360ce516abfe1042d4631108d02569f36899cbeef4769123730L20-R20) [[12]](diffhunk://#diff-4d99abd4e71d9360ce516abfe1042d4631108d02569f36899cbeef4769123730L43-R43) [[13]](diffhunk://#diff-b745198914dab82b63446c21697f6087b8ebb8b65c076652ae7fec1584b16b27L3-R3) [[14]](diffhunk://#diff-b745198914dab82b63446c21697f6087b8ebb8b65c076652ae7fec1584b16b27L18-R25) [[15]](diffhunk://#diff-e39d2461fab073c869e0a67c0e7048356c6d61235846914c3a52d687b6787540L3-R3) [[16]](diffhunk://#diff-e39d2461fab073c869e0a67c0e7048356c6d61235846914c3a52d687b6787540L18-R25) [[17]](diffhunk://#diff-e39d2461fab073c869e0a67c0e7048356c6d61235846914c3a52d687b6787540L37-R43) [[18]](diffhunk://#diff-e39d2461fab073c869e0a67c0e7048356c6d61235846914c3a52d687b6787540L55-R61)

This change ensures all newly created history and event objects use the more modern, time-sortable UUID format, improving consistency and future-proofing the agent infrastructure.