### PR TITLE
feat(agent): add unique event ID to various orchestrate functions

### DIFF
--- a/packages/agent/src/AutoBeAgent.ts
+++ b/packages/agent/src/AutoBeAgent.ts
@@ -212,6 +212,7 @@ export class AutoBeAgent<Model extends ILlmSchema.Model>
       this.histories_.push(history);
       this.dispatch({
         type: "assistantMessage",
+        id: history.id,
         text: history.text,
         created_at: history.created_at,
       }).catch(() => {});

--- a/packages/agent/src/factory/consentFunctionCall.ts
+++ b/packages/agent/src/factory/consentFunctionCall.ts
@@ -79,6 +79,7 @@ export const consentFunctionCall = async (props: {
   }
   props.dispatch({
     type: "consentFunctionCall",
+    id: v7(),
     source: props.source,
     assistantMessage: props.assistantMessage,
     result: pointer.value,

--- a/packages/agent/src/factory/createAutoBeContext.ts
+++ b/packages/agent/src/factory/createAutoBeContext.ts
@@ -109,6 +109,7 @@ export const createAutoBeContext = <Model extends ILlmSchema.Model>(props: {
         void props
           .dispatch({
             type: "jsonValidateError",
+            id: v7(),
             source: next.source,
             result: event.result,
             created_at: event.created_at,

--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyze.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyze.ts
@@ -27,6 +27,7 @@ export const orchestrateAnalyze =
 
     ctx.dispatch({
       type: "analyzeStart",
+      id: v7(),
       reason: props.reason,
       step,
       created_at: startTime.toISOString(),
@@ -41,28 +42,29 @@ export const orchestrateAnalyze =
 
     // write documents
     const writeProgress: AutoBeProgressEventBase = {
-      id: v7(),
       total: scenario.files.length,
       completed: 0,
     };
+    const progressId: string = v7();
     const fileList: AutoBeAnalyzeFile[] = await Promise.all(
       scenario.files.map(async (file) => {
-        const event: AutoBeAnalyzeWriteEvent = await orchestrateAnalyzeWrite(
+        const event: AutoBeAnalyzeWriteEvent = await orchestrateAnalyzeWrite({
           ctx,
           scenario,
           file,
-          writeProgress,
-        );
+          progress: writeProgress,
+          id: progressId,
+        });
         return event.file;
       }),
     );
 
     // review documents
     const reviewProgress: AutoBeProgressEventBase = {
-      id: v7(),
       total: fileList.length,
       completed: 0,
     };
+    const reviewProgressId: string = v7();
     const newFiles: AutoBeAnalyzeFile[] = await Promise.all(
       fileList.map(async (file, i) => {
         try {
@@ -73,6 +75,7 @@ export const orchestrateAnalyze =
               fileList.filter((_, j) => j !== i), // other files
               file,
               reviewProgress,
+              reviewProgressId,
             );
           return {
             ...event.file,
@@ -87,6 +90,7 @@ export const orchestrateAnalyze =
     // Complete the analysis
     return ctx.dispatch({
       type: "analyzeComplete",
+      id: v7(),
       roles: scenario.roles,
       prefix: scenario.prefix,
       files: newFiles,

--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeReview.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeReview.ts
@@ -20,6 +20,7 @@ export const orchestrateAnalyzeReview = async <Model extends ILlmSchema.Model>(
   otherFiles: AutoBeAnalyzeFile[],
   myFile: AutoBeAnalyzeFile,
   progress: AutoBeProgressEventBase,
+  id: string,
 ): Promise<AutoBeAnalyzeReviewEvent> => {
   const pointer: IPointer<IAutoBeAnalyzeReviewApplication.IProps | null> = {
     value: null,
@@ -41,7 +42,7 @@ export const orchestrateAnalyzeReview = async <Model extends ILlmSchema.Model>(
 
   const event: AutoBeAnalyzeReviewEvent = {
     type: "analyzeReview",
-    id: progress.id,
+    id: id,
     file: myFile,
     plan: pointer.value.plan,
     review: pointer.value.review,

--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeScenario.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeScenario.ts
@@ -53,6 +53,7 @@ export const orchestrateAnalyzeScenario = async <
   }
   return {
     type: "analyzeScenario",
+    id: v7(),
     prefix: pointer.value.prefix,
     language: pointer.value.language,
     roles: pointer.value.roles,

--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeWrite.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeWrite.ts
@@ -14,12 +14,16 @@ import { assertSchemaModel } from "../../context/assertSchemaModel";
 import { transformAnalyzeWriteHistories } from "./histories/transformAnalyzeWriteHistories";
 import { IAutoBeAnalyzeWriteApplication } from "./structures/IAutoBeAnalyzeWriteApplication";
 
-export const orchestrateAnalyzeWrite = async <Model extends ILlmSchema.Model>(
-  ctx: AutoBeContext<Model>,
-  scenario: AutoBeAnalyzeScenarioEvent,
-  file: AutoBeAnalyzeFile.Scenario,
-  progress: AutoBeProgressEventBase,
-): Promise<AutoBeAnalyzeWriteEvent> => {
+export const orchestrateAnalyzeWrite = async <
+  Model extends ILlmSchema.Model,
+>(props: {
+  ctx: AutoBeContext<Model>;
+  scenario: AutoBeAnalyzeScenarioEvent;
+  file: AutoBeAnalyzeFile.Scenario;
+  progress: AutoBeProgressEventBase;
+  id: string;
+}): Promise<AutoBeAnalyzeWriteEvent> => {
+  const { ctx, scenario, file, progress, id } = props;
   const pointer: IPointer<IAutoBeAnalyzeWriteApplication.IProps | null> = {
     value: null,
   };
@@ -40,7 +44,7 @@ export const orchestrateAnalyzeWrite = async <Model extends ILlmSchema.Model>(
 
   const event: AutoBeAnalyzeWriteEvent = {
     type: "analyzeWrite",
-    id: progress.id,
+    id: id,
     file: {
       ...file,
       content: pointer.value.content,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
@@ -42,6 +42,7 @@ export const orchestrateInterface =
       });
     ctx.dispatch({
       type: "interfaceStart",
+      id: v7(),
       created_at: start.toISOString(),
       reason: props.reason,
       step: ctx.state().analyze?.step ?? 0,
@@ -101,6 +102,7 @@ export const orchestrateInterface =
     // DO COMPILE
     return ctx.dispatch({
       type: "interfaceComplete",
+      id: v7(),
       document,
       authorizations,
       created_at: new Date().toISOString(),

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceAuthorizations.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceAuthorizations.ts
@@ -22,16 +22,17 @@ export async function orchestrateInterfaceAuthorizations<
 >(ctx: AutoBeContext<Model>): Promise<AutoBeInterfaceAuthorization[]> {
   const roles: AutoBeAnalyzeRole[] = ctx.state().analyze?.roles ?? [];
   const progress: AutoBeProgressEventBase = {
-    id: v7(),
     total: roles.length,
     completed: 0,
   };
+  const progressId: string = v7();
   const authorizations: AutoBeInterfaceAuthorization[] = await Promise.all(
     roles.map(async (role) => {
       const event: AutoBeInterfaceAuthorizationEvent = await process(
         ctx,
         role,
         progress,
+        progressId,
       );
       ctx.dispatch(event);
       return {
@@ -48,6 +49,7 @@ async function process<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   role: AutoBeAnalyzeRole,
   progress: AutoBeProgressEventBase,
+  progressId: string,
 ): Promise<AutoBeInterfaceAuthorizationEvent> {
   const pointer: IPointer<IAutoBeInterfaceAuthorizationsApplication.IProps | null> =
     {
@@ -71,7 +73,7 @@ async function process<Model extends ILlmSchema.Model>(
 
   return {
     type: "interfaceAuthorization",
-    id: progress.id,
+    id: progressId,
     operations: pointer.value.operations,
     completed: ++progress.completed,
     tokenUsage,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
@@ -8,6 +8,7 @@ import {
 import { OpenApiV3_1Emender } from "@samchon/openapi/lib/converters/OpenApiV3_1Emender";
 import { IPointer } from "tstl";
 import typia from "typia";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
@@ -70,6 +71,7 @@ async function step<Model extends ILlmSchema.Model>(
     );
   ctx.dispatch({
     type: "interfaceComplement",
+    id: v7(),
     missed,
     schemas: pointer.value,
     tokenUsage,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceEndpoints.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceEndpoints.ts
@@ -24,14 +24,16 @@ export async function orchestrateInterfaceEndpoints<
   authorizations: AutoBeOpenApi.IOperation[],
   content: string = `Make endpoints for the given assets`,
 ): Promise<AutoBeOpenApi.IEndpoint[]> {
+  const progressId: string = v7();
   const progress: AutoBeProgressEventBase = {
-    id: v7(),
     total: groups.length,
     completed: 0,
   };
   const endpoints: AutoBeOpenApi.IEndpoint[] = (
     await Promise.all(
-      groups.map((g) => process(ctx, g, content, progress, authorizations)),
+      groups.map((g) =>
+        process(ctx, g, content, progress, authorizations, progressId),
+      ),
     )
   ).flat();
   return new HashSet(
@@ -47,6 +49,7 @@ async function process<Model extends ILlmSchema.Model>(
   message: string,
   progress: AutoBeProgressEventBase,
   authorizations: AutoBeOpenApi.IOperation[],
+  progressId: string,
 ): Promise<AutoBeOpenApi.IEndpoint[]> {
   const start: Date = new Date();
   const pointer: IPointer<AutoBeOpenApi.IEndpoint[] | null> = {
@@ -73,7 +76,7 @@ async function process<Model extends ILlmSchema.Model>(
 
   const event: AutoBeInterfaceEndpointsEvent = {
     type: "interfaceEndpoints",
-    id: progress.id,
+    id: progressId,
     endpoints: new HashSet(
       pointer.value,
       OpenApiEndpointComparator.hashCode,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceGroups.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceGroups.ts
@@ -3,6 +3,7 @@ import { AutoBeInterfaceGroupsEvent } from "@autobe/interface";
 import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
@@ -34,6 +35,7 @@ export async function orchestrateInterfaceGroups<
   if (pointer.value === null) throw new Error("Failed to generate groups."); // unreachable
   return {
     type: "interfaceGroups",
+    id: v7(),
     created_at: start.toISOString(),
     groups: pointer.value.groups,
     tokenUsage,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperations.ts
@@ -32,16 +32,7 @@ export async function orchestrateInterfaceOperations<
     array: endpoints,
     capacity,
   });
-  const operationsProgress: AutoBeProgressEventBase = {
-    id: v7(),
-    total: endpoints.length,
-    completed: 0,
-  };
-  const operationsReviewProgress: AutoBeProgressEventBase = {
-    id: v7(),
-    total: matrix.length,
-    completed: 0,
-  };
+
   return (
     await Promise.all(
       matrix.map(async (it) => {
@@ -49,8 +40,16 @@ export async function orchestrateInterfaceOperations<
           ctx,
           it,
           3,
-          operationsProgress,
-          operationsReviewProgress,
+          {
+            total: matrix.length,
+            completed: 0,
+            id: v7(),
+          },
+          {
+            total: matrix.length,
+            completed: 0,
+            id: v7(),
+          },
         );
         return row;
       }),
@@ -62,8 +61,8 @@ async function divideAndConquer<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   endpoints: AutoBeOpenApi.IEndpoint[],
   retry: number,
-  operationsProgress: AutoBeProgressEventBase,
-  operationsReviewProgress: AutoBeProgressEventBase,
+  operationsProgress: AutoBeProgressEventBase & { id: string },
+  operationsReviewProgress: AutoBeProgressEventBase & { id: string },
 ): Promise<AutoBeOpenApi.IOperation[]> {
   const remained: HashSet<AutoBeOpenApi.IEndpoint> = new HashSet(
     endpoints,
@@ -161,6 +160,7 @@ async function process<Model extends ILlmSchema.Model>(
 
   ctx.dispatch({
     type: "interfaceOperations",
+    id: v7(),
     operations: pointer.value,
     tokenUsage,
     ...progress,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperationsReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperationsReview.ts
@@ -7,6 +7,7 @@ import {
 import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { transformInterfaceOperationsReviewHistories } from "./histories/transformInterfaceOperationsReviewHistories";
@@ -51,7 +52,7 @@ export async function orchestrateInterfaceOperationsReview<
 
     ctx.dispatch({
       type: "interfaceOperationsReview",
-      id: progress.id,
+      id: v7(),
       operations: content,
       review: pointer.value.review,
       plan: pointer.value.plan,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
@@ -35,15 +35,15 @@ export async function orchestrateInterfaceSchemas<
     capacity,
   });
   const progress: AutoBeProgressEventBase = {
-    id: v7(),
     total: typeNames.size,
     completed: 0,
   };
+  const progressId: string = v7();
   const reviewProgress: AutoBeProgressEventBase = {
-    id: v7(),
     total: matrix.length,
     completed: 0,
   };
+  const reviewProgressId: string = v7();
   const roles: string[] =
     ctx.state().analyze?.roles.map((role) => role.name) ?? [];
 
@@ -56,13 +56,14 @@ export async function orchestrateInterfaceSchemas<
   for (const y of await Promise.all(
     matrix.map(async (it) => {
       const row: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
-        await divideAndConquer(ctx, operations, it, 3, progress);
+        await divideAndConquer(ctx, operations, it, 3, progress, progressId);
       const newbie: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
         await orchestrateInterfaceSchemasReview(
           ctx,
           operations,
           row,
           reviewProgress,
+          reviewProgressId,
         );
       return { ...row, ...newbie };
     }),
@@ -79,13 +80,14 @@ async function divideAndConquer<Model extends ILlmSchema.Model>(
   typeNames: string[],
   retry: number,
   progress: AutoBeProgressEventBase,
+  progressId: string,
 ): Promise<Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>> {
   const remained: Set<string> = new Set(typeNames);
   const schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> = {};
   for (let i: number = 0; i < retry; ++i) {
     if (remained.size === 0) break;
     const newbie: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
-      await process(ctx, operations, schemas, remained, progress);
+      await process(ctx, operations, schemas, remained, progress, progressId);
     for (const key of Object.keys(newbie)) {
       schemas[key] = newbie[key];
       remained.delete(key);
@@ -100,6 +102,7 @@ async function process<Model extends ILlmSchema.Model>(
   oldbie: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>,
   remained: Set<string>,
   progress: AutoBeProgressEventBase,
+  progressId: string,
 ): Promise<Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>> {
   const already: string[] = Object.keys(oldbie);
   const pointer: IPointer<Record<
@@ -150,7 +153,7 @@ async function process<Model extends ILlmSchema.Model>(
     ).schemas ?? {};
   ctx.dispatch({
     type: "interfaceSchemas",
-    id: progress.id,
+    id: progressId,
     schemas,
     tokenUsage,
     completed: (progress.completed += Object.keys(schemas).length),

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
@@ -25,6 +25,7 @@ export async function orchestrateInterfaceSchemasReview<
     AutoBeOpenApi.IJsonSchemaDescriptive<AutoBeOpenApi.IJsonSchema>
   >,
   progress: AutoBeProgressEventBase,
+  progressId: string,
 ): Promise<Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>> {
   try {
     const pointer: IPointer<IAutoBeInterfaceSchemasReviewApplication.IProps | null> =
@@ -61,7 +62,7 @@ export async function orchestrateInterfaceSchemasReview<
       ).schemas ?? {};
     ctx.dispatch({
       type: "interfaceSchemasReview",
-      id: progress.id,
+      id: progressId,
       schemas: schemas,
       review: pointer.value.review,
       plan: pointer.value.plan,

--- a/packages/agent/src/orchestrate/prisma/orchestratePrisma.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrisma.ts
@@ -37,6 +37,7 @@ export const orchestratePrisma = async <Model extends ILlmSchema.Model>(
     });
   ctx.dispatch({
     type: "prismaStart",
+    id: v7(),
     created_at: start.toISOString(),
     reason: props.reason,
     step: ctx.state().analyze?.step ?? 0,
@@ -93,6 +94,7 @@ export const orchestratePrisma = async <Model extends ILlmSchema.Model>(
   // PROPAGATE
   return ctx.dispatch({
     type: "prismaComplete",
+    id: v7(),
     result,
     schemas: finalSchemas,
     compiled: await compiler.prisma.compile({

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaComponent.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaComponent.ts
@@ -3,6 +3,7 @@ import { AutoBePrismaComponentsEvent } from "@autobe/interface/src/events/AutoBe
 import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
@@ -36,6 +37,7 @@ export async function orchestratePrismaComponents<
     throw new Error("Failed to extract files and tables."); // unreachable
   return {
     type: "prismaComponents",
+    id: v7(),
     created_at: start.toISOString(),
     thinking: pointer.value.thinking,
     review: pointer.value.review,

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
@@ -8,6 +8,7 @@ import {
 import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
@@ -49,6 +50,7 @@ async function iterate<Model extends ILlmSchema.Model>(
   );
   ctx.dispatch({
     type: "prismaValidate",
+    id: v7(),
     result,
     schemas,
     compiled: await compiler.prisma.compile({
@@ -144,6 +146,7 @@ async function execute<Model extends ILlmSchema.Model>(
   };
   ctx.dispatch({
     type: "prismaCorrect",
+    id: v7(),
     failure,
     planning: pointer.value.planning,
     correction: correction,

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaReview.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaReview.ts
@@ -18,15 +18,15 @@ export async function orchestratePrismaReview<Model extends ILlmSchema.Model>(
   componentList: AutoBePrisma.IComponent[],
 ): Promise<AutoBePrismaReviewEvent[]> {
   const progress: AutoBeProgressEventBase = {
-    id: v7(),
     completed: 0,
     total: componentList.length,
   };
+  const id: string = v7();
   return (
     await Promise.all(
       componentList.map(async (component) => {
         try {
-          return await step(ctx, application, schemas, component, progress);
+          return await step(ctx, application, schemas, component, progress, id);
         } catch {
           ++progress.completed;
           return null;
@@ -42,6 +42,7 @@ async function step<Model extends ILlmSchema.Model>(
   schemas: Record<string, string>,
   component: AutoBePrisma.IComponent,
   progress: AutoBeProgressEventBase,
+  id: string,
 ): Promise<AutoBePrismaReviewEvent> {
   const start: Date = new Date();
   const pointer: IPointer<IAutoBePrismaReviewApplication.IProps | null> = {
@@ -74,7 +75,7 @@ async function step<Model extends ILlmSchema.Model>(
 
   const event: AutoBePrismaReviewEvent = {
     type: "prismaReview",
-    id: progress.id,
+    id,
     created_at: start.toISOString(),
     filename: component.filename,
     review: pointer.value.review,

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchemas.ts
@@ -123,6 +123,7 @@ function createController<Model extends ILlmSchema.Model>(
 
     ctx.dispatch({
       type: "prismaInsufficient",
+      id: v7(),
       created_at: new Date().toISOString(),
       component: props.targetComponent,
       actual,

--- a/packages/agent/src/orchestrate/realize/internal/compile.ts
+++ b/packages/agent/src/orchestrate/realize/internal/compile.ts
@@ -6,6 +6,7 @@ import {
   IAutoBeTypeScriptCompileResult,
 } from "@autobe/interface";
 import { ILlmSchema } from "@samchon/openapi";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../../context/AutoBeContext";
 
@@ -54,6 +55,7 @@ export async function compile<Model extends ILlmSchema.Model>(
 
   const event: AutoBeRealizeValidateEvent = {
     type: "realizeValidate",
+    id: v7(),
     result: compiled,
     files: Object.fromEntries(
       compiled.type === "failure"

--- a/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
@@ -48,6 +48,7 @@ export const orchestrateRealize =
       });
     ctx.dispatch({
       type: "realizeStart",
+      id: v7(),
       created_at: start.toISOString(),
       reason: props.reason,
       step: ctx.state().test?.step ?? 0,
@@ -68,10 +69,10 @@ export const orchestrateRealize =
       });
 
     const writeProgress: AutoBeProgressEventBase = {
-      id: v7(),
       total: scenarios.length,
       completed: 0,
     };
+    const writeProgressId: string = v7();
     const writeEvents: AutoBeRealizeWriteEvent[] = await Promise.all(
       scenarios.map(async (scenario) => {
         const code = await orchestrateRealizeWrite(ctx, {
@@ -79,6 +80,7 @@ export const orchestrateRealize =
           authorization: scenario.decoratorEvent ?? null,
           scenario,
           progress: writeProgress,
+          id: writeProgressId,
         });
         return code;
       }),
@@ -171,6 +173,7 @@ export const orchestrateRealize =
 
     return ctx.dispatch({
       type: "realizeComplete",
+      id: v7(),
       created_at: new Date().toISOString(),
       functions,
       authorizations,

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeAuthorization.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeAuthorization.ts
@@ -30,16 +30,17 @@ export async function orchestrateRealizeAuthorization<
 >(ctx: AutoBeContext<Model>): Promise<AutoBeRealizeAuthorization[]> {
   ctx.dispatch({
     type: "realizeAuthorizationStart",
+    id: v7(),
     step: ctx.state().test?.step ?? 0,
     created_at: new Date().toISOString(),
   });
 
   const roles: AutoBeAnalyzeRole[] = ctx.state().analyze?.roles ?? [];
   const progress: AutoBeProgressEventBase = {
-    id: v7(),
     total: roles.length,
     completed: 0,
   };
+  const progressId: string = v7();
   const templateFiles = await (await ctx.compiler()).realize.getTemplate();
   const authorizations: AutoBeRealizeAuthorization[] = await Promise.all(
     roles.map((role) =>
@@ -50,11 +51,13 @@ export async function orchestrateRealizeAuthorization<
           [el]: templateFiles[el],
         })).reduce((acc, cur) => Object.assign(acc, cur), {}),
         progress,
+        progressId,
       ),
     ),
   );
   ctx.dispatch({
     type: "realizeAuthorizationComplete",
+    id: v7(),
     created_at: new Date().toISOString(),
     step: ctx.state().test?.step ?? 0,
   });
@@ -66,6 +69,7 @@ async function process<Model extends ILlmSchema.Model>(
   role: AutoBeAnalyzeRole,
   templateFiles: Record<string, string>,
   progress: AutoBeProgressEventBase,
+  progressId: string,
 ): Promise<AutoBeRealizeAuthorization> {
   const pointer: IPointer<IAutoBeRealizeAuthorizationApplication.IProps | null> =
     {
@@ -116,7 +120,7 @@ async function process<Model extends ILlmSchema.Model>(
 
   ctx.dispatch({
     type: "realizeAuthorizationWrite",
-    id: progress.id,
+    id: progressId,
     created_at: new Date().toISOString(),
     authorization: authorization,
     tokenUsage,

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeAuthorizationCorrect.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeAuthorizationCorrect.ts
@@ -8,6 +8,7 @@ import {
 import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
@@ -58,6 +59,7 @@ export async function orchestrateRealizeAuthorizationCorrect<
 
   ctx.dispatch({
     type: "realizeAuthorizationValidate",
+    id: v7(),
     created_at: new Date().toISOString(),
     authorization: authorization,
     result: compiled,
@@ -120,6 +122,7 @@ export async function orchestrateRealizeAuthorizationCorrect<
   ctx.dispatch({
     ...pointer.value,
     type: "realizeAuthorizationCorrect",
+    id: v7(),
     created_at: new Date().toISOString(),
     authorization: result,
     result: compiled,

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeCorrect.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeCorrect.ts
@@ -7,6 +7,7 @@ import {
 import { ILlmApplication, ILlmController, ILlmSchema } from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
@@ -72,7 +73,7 @@ export async function orchestrateRealizeCorrect<Model extends ILlmSchema.Model>(
 
   const event: AutoBeRealizeCorrectEvent = {
     type: "realizeCorrect",
-    id: props.progress.id,
+    id: v7(),
     location: props.scenario.location,
     content: pointer.value.implementationCode,
     tokenUsage,

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeWrite.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeWrite.ts
@@ -23,6 +23,7 @@ export async function orchestrateRealizeWrite<Model extends ILlmSchema.Model>(
     authorization: AutoBeRealizeAuthorization | null;
     scenario: IAutoBeRealizeScenarioApplication.IProps;
     progress: AutoBeProgressEventBase;
+    id: string;
   },
 ): Promise<AutoBeRealizeWriteEvent> {
   const artifacts: IAutoBeTestScenarioArtifacts =
@@ -77,7 +78,7 @@ export async function orchestrateRealizeWrite<Model extends ILlmSchema.Model>(
 
   const event: AutoBeRealizeWriteEvent = {
     type: "realizeWrite",
-    id: props.progress.id,
+    id: props.id,
     location: props.scenario.location,
     content: pointer.value.implementationCode,
     tokenUsage,

--- a/packages/agent/src/orchestrate/test/orchestrateTest.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTest.ts
@@ -36,6 +36,7 @@ export const orchestrateTest =
       });
     ctx.dispatch({
       type: "testStart",
+      id: v7(),
       created_at: start.toISOString(),
       reason: props.reason,
       step: ctx.state().analyze?.step ?? 0,
@@ -87,6 +88,7 @@ export const orchestrateTest =
       });
     return ctx.dispatch({
       type: "testComplete",
+      id: v7(),
       created_at: new Date().toISOString(),
       files: success.map((s) => s.file),
       compiled,

--- a/packages/agent/src/orchestrate/test/orchestrateTestCorrect.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestCorrect.ts
@@ -8,6 +8,7 @@ import { StringUtil } from "@autobe/utils";
 import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
 import { IPointer } from "tstl";
 import typia from "typia";
+import { v7 } from "uuid";
 
 import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
@@ -65,6 +66,7 @@ const compile = async <Model extends ILlmSchema.Model>(
   });
   return {
     type: "testValidate",
+    id: v7(),
     file: {
       scenario: func.scenario,
       location: func.location,
@@ -125,6 +127,7 @@ const correct = async <Model extends ILlmSchema.Model>(
 
   ctx.dispatch({
     type: "testCorrect",
+    id: v7(),
     created_at: new Date().toISOString(),
     file: validate.file,
     result: validate.result,

--- a/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
@@ -54,10 +54,10 @@ export async function orchestrateTestScenario<Model extends ILlmSchema.Model>(
   ].join("\n");
 
   const progress: AutoBeProgressEventBase = {
-    id: v7(),
     total: operations.length,
     completed: 0,
   };
+  const id: string = v7();
   const exclude: IAutoBeTestScenarioApplication.IScenarioGroup[] = [];
   let include: AutoBeOpenApi.IOperation[] = Array.from(operations);
 
@@ -77,6 +77,7 @@ export async function orchestrateTestScenario<Model extends ILlmSchema.Model>(
             include,
             exclude.map((x) => x.endpoint),
             progress,
+            id,
           )),
         );
       }),
@@ -114,7 +115,8 @@ const divideAndConquer = async <Model extends ILlmSchema.Model>(
   include: AutoBeOpenApi.IOperation[],
   exclude: AutoBeOpenApi.IEndpoint[],
   progress: AutoBeProgressEventBase,
-) => {
+  id: string,
+): Promise<IAutoBeTestScenarioApplication.IScenarioGroup[]> => {
   const pointer: IPointer<IAutoBeTestScenarioApplication.IScenarioGroup[]> = {
     value: [],
   };
@@ -146,7 +148,7 @@ const divideAndConquer = async <Model extends ILlmSchema.Model>(
   if (pointer.value.length === 0) return [];
   ctx.dispatch({
     type: "testScenarios",
-    id: progress.id,
+    id: id,
     tokenUsage,
     scenarios: pointer.value
       .map((v) =>

--- a/packages/agent/src/orchestrate/test/orchestrateTestWrite.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestWrite.ts
@@ -24,10 +24,10 @@ export async function orchestrateTestWrite<Model extends ILlmSchema.Model>(
   scenarios: AutoBeTestScenario[],
 ): Promise<IAutoBeTestWriteResult[]> {
   const progress: AutoBeProgressEventBase = {
-    id: v7(),
     total: scenarios.length,
     completed: 0,
   };
+  const id: string = v7();
   const result: Array<IAutoBeTestWriteResult | null> = await Promise.all(
     /**
      * Generate test code for each scenario. Maps through plans array to create
@@ -38,12 +38,13 @@ export async function orchestrateTestWrite<Model extends ILlmSchema.Model>(
       try {
         const artifacts: IAutoBeTestScenarioArtifacts =
           await getTestScenarioArtifacts(ctx, scenario);
-        const event: AutoBeTestWriteEvent = await process(
+        const event: AutoBeTestWriteEvent = await process({
           ctx,
           scenario,
           artifacts,
           progress,
-        );
+          id,
+        });
         ctx.dispatch(event);
         return {
           scenario,
@@ -67,12 +68,14 @@ export async function orchestrateTestWrite<Model extends ILlmSchema.Model>(
  * @param scenario - The test scenario information to generate code for
  * @param artifacts - The artifacts containing the reference files and schemas
  */
-async function process<Model extends ILlmSchema.Model>(
-  ctx: AutoBeContext<Model>,
-  scenario: AutoBeTestScenario,
-  artifacts: IAutoBeTestScenarioArtifacts,
-  progress: AutoBeProgressEventBase,
-): Promise<AutoBeTestWriteEvent> {
+async function process<Model extends ILlmSchema.Model>(props: {
+  ctx: AutoBeContext<Model>;
+  scenario: AutoBeTestScenario;
+  artifacts: IAutoBeTestScenarioArtifacts;
+  progress: AutoBeProgressEventBase;
+  id: string;
+}): Promise<AutoBeTestWriteEvent> {
+  const { ctx, scenario, artifacts, progress, id } = props;
   const pointer: IPointer<IAutoBeTestWriteApplication.IProps | null> = {
     value: null,
   };
@@ -95,7 +98,7 @@ async function process<Model extends ILlmSchema.Model>(
   pointer.value.final = await compiler.typescript.beautify(pointer.value.final);
   return {
     type: "testWrite",
-    id: progress.id,
+    id: id,
     created_at: new Date().toISOString(),
     location: `test/features/api/${pointer.value.domain}/${scenario.functionName}.ts`,
     ...pointer.value,

--- a/packages/interface/src/events/AutoBeEventBase.ts
+++ b/packages/interface/src/events/AutoBeEventBase.ts
@@ -17,6 +17,24 @@ import { tags } from "typia";
  */
 export interface AutoBeEventBase<Type extends string> {
   /**
+   * A unique identifier for the event group.
+   *
+   * Ensures that event occurrences can be distinguished even when they share
+   * the same name. This prevents metric collisions across different event
+   * sources or instances, enabling accurate tracking and aggregation.
+   *
+   * Especially critical when accumulating `completed` counts: multiple events
+   * with the same name can still be tracked independently thanks to this ID.
+   *
+   * Example use cases:
+   *
+   * - Distinguishing between similar code-generation tasks running in parallel.
+   * - Separating progress metrics for identical interface design steps triggered
+   *   by different agents.
+   */
+  id: string;
+
+  /**
    * Unique identifier for the event type.
    *
    * A literal string that discriminates between different event types in the

--- a/packages/interface/src/events/AutoBeProgressEventBase.ts
+++ b/packages/interface/src/events/AutoBeProgressEventBase.ts
@@ -13,24 +13,6 @@
  */
 export interface AutoBeProgressEventBase {
   /**
-   * A unique identifier for the event group.
-   *
-   * Ensures that event occurrences can be distinguished even when they share
-   * the same name. This prevents metric collisions across different event
-   * sources or instances, enabling accurate tracking and aggregation.
-   *
-   * Especially critical when accumulating `completed` counts: multiple events
-   * with the same name can still be tracked independently thanks to this ID.
-   *
-   * Example use cases:
-   *
-   * - Distinguishing between similar code-generation tasks running in parallel.
-   * - Separating progress metrics for identical interface design steps triggered
-   *   by different agents.
-   */
-  id: string;
-
-  /**
    * Total number of items to process.
    *
    * Represents the complete count of operations, files, endpoints, or other


### PR DESCRIPTION
- Introduced a unique event ID to multiple orchestrate functions to enhance event tracking and prevent collisions.
- Updated dispatch calls in orchestrateAnalyze, orchestrateInterface, orchestrateRealize, and others to include the new ID.
- Ensured consistency across the codebase by applying the ID to progress events and related structures.