### PR TITLE
refactor(playground-ui): integrate AutoBeChatUploadSendButton component and clean up AutoBePlaygroundChatUploadMovie

### DIFF
--- a/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatUploadMovie.tsx
+++ b/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatUploadMovie.tsx
@@ -288,7 +288,7 @@ export const AutoBePlaygroundChatUploadMovie = (
             />
           ) : null}
           <AutoBeChatUploadSendButton
-            conversate={conversate}
+            onClick={() => conversate()}
             enabled={enabled}
           />
         </Box>

--- a/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatUploadMovie.tsx
+++ b/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatUploadMovie.tsx
@@ -1,15 +1,7 @@
 import { AutoBeUserMessageContent } from "@autobe/interface";
-import { AutoBeFileUploadBox } from "@autobe/ui";
-import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import { AutoBeChatUploadSendButton, AutoBeFileUploadBox } from "@autobe/ui";
 import CloseIcon from "@mui/icons-material/Close";
-import {
-  Box,
-  Chip,
-  IconButton,
-  Paper,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, Chip, Paper, TextField, Typography } from "@mui/material";
 import { ReactNode, RefObject, useEffect, useRef, useState } from "react";
 
 import { IAutoBePlaygroundBucket } from "../../structures/IAutoBePlaygroundBucket";
@@ -295,7 +287,7 @@ export const AutoBePlaygroundChatUploadMovie = (
               complete={(b) => setBuckets((o) => [...o, b])}
             />
           ) : null}
-          <AutoBePlaygroundChatUploadSendButton
+          <AutoBeChatUploadSendButton
             conversate={conversate}
             enabled={enabled}
           />
@@ -304,35 +296,6 @@ export const AutoBePlaygroundChatUploadMovie = (
     </Paper>
   );
 };
-
-const AutoBePlaygroundChatUploadSendButton = (props: {
-  conversate: () => Promise<void>;
-  enabled: boolean;
-}) => {
-  return (
-    <IconButton
-      size="small"
-      color="primary"
-      onClick={() => void props.conversate()}
-      disabled={!props.enabled}
-      sx={{
-        p: 0.75,
-        backgroundColor: "primary.main",
-        color: "primary.contrastText",
-        "&:hover": {
-          backgroundColor: "primary.dark",
-        },
-        "&.Mui-disabled": {
-          backgroundColor: "action.disabledBackground",
-          color: "action.disabled",
-        },
-      }}
-    >
-      <ArrowUpwardIcon fontSize="small" />
-    </IconButton>
-  );
-};
-
 export namespace AutoBePlaygroundChatUploadMovie {
   export interface IProps {
     listener: RefObject<IListener>;

--- a/packages/ui/src/AutoBeChatUploadSendButton.tsx
+++ b/packages/ui/src/AutoBeChatUploadSendButton.tsx
@@ -1,0 +1,66 @@
+/** Props interface for AutoBeChatUploadSendButton component */
+interface IAutoBeChatUploadSendButtonProps {
+  /** Function to trigger conversation */
+  conversate: () => Promise<void>;
+  /** Whether the button is enabled */
+  enabled: boolean;
+}
+
+/**
+ * Chat upload send button component for triggering conversations
+ *
+ * @param props - Component props
+ * @returns JSX element representing the send button
+ */
+export const AutoBeChatUploadSendButton = (
+  props: IAutoBeChatUploadSendButtonProps,
+) => {
+  const baseStyles: React.CSSProperties = {
+    padding: "6px",
+    border: "none",
+    borderRadius: "50%", // 4px에서 50%로 변경하여 둥글게
+    backgroundColor: props.enabled ? "#1976d2" : "#e0e0e0",
+    color: props.enabled ? "#ffffff" : "#9e9e9e",
+    cursor: props.enabled ? "pointer" : "not-allowed",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    transition: "background-color 0.3s ease",
+    outline: "none",
+    width: "32px",
+    height: "32px",
+  };
+
+  const hoverStyles: React.CSSProperties = {
+    ...baseStyles,
+    backgroundColor: props.enabled ? "#1565c0" : "#e0e0e0",
+  };
+
+  return (
+    <button
+      style={baseStyles}
+      onClick={() => void props.conversate()}
+      disabled={!props.enabled}
+      onMouseEnter={(e) => {
+        if (props.enabled) {
+          Object.assign(e.currentTarget.style, hoverStyles);
+        }
+      }}
+      onMouseLeave={(e) => {
+        Object.assign(e.currentTarget.style, baseStyles);
+      }}
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        style={{ display: "block" }}
+      >
+        <path d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.59 5.58L20 12l-8-8-8 8z" />
+      </svg>
+    </button>
+  );
+};
+
+export default AutoBeChatUploadSendButton;

--- a/packages/ui/src/AutoBeChatUploadSendButton.tsx
+++ b/packages/ui/src/AutoBeChatUploadSendButton.tsx
@@ -1,7 +1,7 @@
 /** Props interface for AutoBeChatUploadSendButton component */
 interface IAutoBeChatUploadSendButtonProps {
   /** Function to trigger conversation */
-  conversate: () => Promise<void>;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
   /** Whether the button is enabled */
   enabled: boolean;
 }
@@ -39,7 +39,7 @@ export const AutoBeChatUploadSendButton = (
   return (
     <button
       style={baseStyles}
-      onClick={() => void props.conversate()}
+      onClick={(e) => void props.onClick?.(e)}
       disabled={!props.enabled}
       onMouseEnter={(e) => {
         if (props.enabled) {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,6 +6,7 @@ export {
   type AutoBeFileUploadBox as IAutoBeFileUploadBox,
 } from "./AutoBeFileUploadBox";
 export { default as ChatBubble } from "./common/ChatBubble";
+export { AutoBeChatUploadSendButton } from "./AutoBeChatUploadSendButton";
 export type {
   IChatBubbleProps,
   IContentRendererProps,


### PR DESCRIPTION
This pull request refactors the chat upload send button in the playground chat UI to use a shared, reusable component from the UI package instead of a locally defined one. The new component features improved styling and better encapsulation, enhancing maintainability and consistency across the codebase.

**Component Refactoring and Reuse:**

* Replaced the locally defined `AutoBePlaygroundChatUploadSendButton` in `AutoBePlaygroundChatUploadMovie.tsx` with the new shared `AutoBeChatUploadSendButton` from the UI package, simplifying the chat upload button logic and usage.

**UI Component Improvements:**

* Added a new `AutoBeChatUploadSendButton` component to `packages/ui/src/AutoBeChatUploadSendButton.tsx`, featuring custom styling, hover effects, and a built-in SVG icon, designed for reusability and accessibility.
* Exported the new `AutoBeChatUploadSendButton` from the UI package's entry point (`index.ts`), making it available for use throughout the project.

**Code Cleanup:**

* Removed the local implementation of the chat upload send button and unused imports in `AutoBePlaygroundChatUploadMovie.tsx`, reducing duplication and streamlining the file. [[1]](diffhunk://#diff-e27d70189660a5c5b2edcc66b69de90ff6fd94ee223de5569b950f57d0ea07c6L2-R4) [[2]](diffhunk://#diff-e27d70189660a5c5b2edcc66b69de90ff6fd94ee223de5569b950f57d0ea07c6L298-L335)