### PR TITLE
feat: add database engine compatibility guidelines for Prisma usage

### DIFF
--- a/packages/agent/prompts/REALIZE_WRITE_TOTAL.md
+++ b/packages/agent/prompts/REALIZE_WRITE_TOTAL.md
@@ -1429,6 +1429,68 @@ MyGlobal.prisma.users.findFirst({
 
 ## 📚 Prisma Usage Guide
 
+### 🏛️ Database Engine Compatibility
+
+**CRITICAL**: Our system supports both **PostgreSQL** and **SQLite** database engines. All Prisma operations, methods, and options MUST be compatible with both engines.
+
+**ABSOLUTE REQUIREMENTS:**
+- ✅ **Use only cross-compatible Prisma methods** that work identically on both PostgreSQL and SQLite
+- ✅ **Use only cross-compatible query options** (where, orderBy, select, include, etc.)
+- ✅ **Use only cross-compatible data types** and field configurations
+- ❌ **NEVER use PostgreSQL-specific features** (e.g., PostgreSQL arrays, JSON operators, full-text search)
+- ❌ **NEVER use SQLite-specific features** that don't exist in PostgreSQL
+- ❌ **NEVER use database-specific SQL functions** in raw queries
+
+**Common Compatibility Issues to Avoid:**
+- Database-specific JSON operations (`@db.JsonB` vs `@db.Text`)
+- Engine-specific date/time functions and formatting
+- Platform-specific data type behaviors (BigInt handling differences)
+- Database-specific indexing strategies (partial indexes, expression indexes)
+- Raw SQL queries with engine-specific syntax
+- Database-specific constraints and triggers
+
+**Examples of Forbidden Operations:**
+```typescript
+// ❌ PostgreSQL-specific JSON operations
+where: {
+  metadata: {
+    path: ["settings", "enabled"],
+    equals: true
+  }
+}
+
+// ❌ Database-specific raw queries
+await prisma.$queryRaw`SELECT * FROM users WHERE created_at::date = current_date`
+
+// ❌ PostgreSQL-specific array operations
+where: {
+  tags: {
+    has: "important"
+  }
+}
+```
+
+**✅ Use Cross-Compatible Patterns:**
+```typescript
+// ✅ Standard Prisma operations that work on both engines
+where: {
+  created_at: {
+    gte: startDate,
+    lte: endDate
+  }
+}
+
+// ✅ Standard string operations
+where: {
+  title: {
+    contains: searchTerm,
+    mode: "insensitive"
+  }
+}
+```
+
+**Rule**: When in doubt, test the operation on both PostgreSQL and SQLite environments before implementation.
+
 When working with Prisma, follow these critical rules to ensure consistency and correctness:
 
 1. **`null` vs `undefined` - Critical Distinction**


### PR DESCRIPTION
When the Realize Agent writes code, I have added a prompt that forces Prisma to write only code that is compatible with both Sqlite and Postgres. I haven't tested it yet, so it's not confirmed if it works well.