### PR TITLE
feat(ui): integrate @samchon/openapi and enhance AutoBeChat components

### DIFF
--- a/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatBodyMovie.tsx
+++ b/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatBodyMovie.tsx
@@ -1,5 +1,6 @@
 import {
   AutoBeUserMessageContent,
+  IAutoBePlaygroundHeader,
   IAutoBeRpcService,
   IAutoBeTokenUsageJson,
 } from "@autobe/interface";
@@ -10,6 +11,7 @@ import {
 } from "@autobe/ui";
 import { useMediaQuery } from "@autobe/ui/hooks";
 import { Box, Container } from "@mui/material";
+import { ILlmSchema } from "@samchon/openapi";
 import { RefObject, useEffect, useRef } from "react";
 
 import { AutoBePlaygroundGlobal } from "../../AutoBePlaygroundGlobal";
@@ -53,7 +55,9 @@ export const AutoBePlaygroundChatBodyMovie = (
         backgroundColor: "lightblue",
       }}
     >
-      {!isMinWidthLg && <AutoBeChatBanner tokenUsage={props.tokenUsage} />}
+      {!isMinWidthLg && (
+        <AutoBeChatBanner header={props.header} tokenUsage={props.tokenUsage} />
+      )}
 
       <Container
         style={{
@@ -110,5 +114,6 @@ export namespace AutoBePlaygroundChatBodyMovie {
     setError: (error: Error) => void;
     uploadConfig?: IAutoBePlaygroundUploadConfig;
     tokenUsage: IAutoBeTokenUsageJson | null;
+    header: IAutoBePlaygroundHeader<ILlmSchema.Model>;
   }
 }

--- a/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx
+++ b/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx
@@ -110,6 +110,7 @@ export function AutoBePlaygroundChatMovie(
           setError={setError}
           uploadConfig={props.uploadConfig}
           tokenUsage={tokenUsage}
+          header={props.header}
         />
       </div>
     </div>

--- a/apps/vscode-extension/webview-ui/package.json
+++ b/apps/vscode-extension/webview-ui/package.json
@@ -10,17 +10,18 @@
   },
   "packageManager": "pnpm@10.6.4",
   "devDependencies": {
+    "@autobe/interface": "workspace:*",
+    "@autobe/ui": "workspace:^",
+    "@autobe/vscode-extension/interface": "workspace:*",
+    "@samchon/openapi": "catalog:samchon",
     "@tailwindcss/vite": "^4.1.11",
     "@types/react": "catalog:ui",
     "@types/react-dom": "catalog:ui",
     "@types/vscode-webview": "^1.57.5",
-    "@autobe/vscode-extension/interface": "workspace:*",
-    "@autobe/interface": "workspace:*",
     "react": "catalog:ui",
     "react-dom": "catalog:ui",
     "tailwindcss": "^4.1.11",
     "typescript": "catalog:typescript",
-    "@autobe/ui": "workspace:^",
     "vite": "catalog:ui"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@autobe/interface": "workspace:*",
+    "@samchon/openapi": "catalog:samchon",
     "@types/react": "catalog:ui",
     "@types/react-dom": "catalog:ui",
     "react": "catalog:ui",

--- a/packages/ui/src/banner/AutoBeAgentInformation.tsx
+++ b/packages/ui/src/banner/AutoBeAgentInformation.tsx
@@ -1,0 +1,102 @@
+import {
+  IAutoBePlaygroundHeader,
+  IAutoBePlaygroundVendor,
+} from "@autobe/interface";
+import { ILlmSchema } from "@samchon/openapi";
+import { ReactNode } from "react";
+
+import { COLORS } from "../constant/color";
+
+export interface IAutoBeAgentInformationProps {
+  header: Omit<IAutoBePlaygroundHeader<ILlmSchema.Model>, "vendor"> & {
+    vendor: Omit<IAutoBePlaygroundVendor, "apiKey">;
+  };
+}
+
+/** Props interface for InfoRow component */
+interface IInfoRowProps {
+  /** Label text */
+  label: string;
+  /** Value to display */
+  value: ReactNode;
+}
+
+/** Props interface for InfoLabel component */
+interface IInfoLabelProps {
+  /** Label text */
+  children: string;
+}
+
+/** Props interface for InfoValue component */
+interface IInfoValueProps {
+  /** Value content */
+  children: ReactNode;
+}
+
+/** Info row component with consistent flex layout */
+const InfoRow = ({ label, value }: IInfoRowProps) => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "center",
+      padding: "4px 0",
+      gap: "8px",
+    }}
+  >
+    <InfoLabel>{label + ":"}</InfoLabel>
+    <InfoValue>{value}</InfoValue>
+  </div>
+);
+
+/** Info label component with consistent styling */
+const InfoLabel = ({ children }: IInfoLabelProps) => (
+  <span
+    style={{
+      color: COLORS.GRAY_TEXT_MEDIUM,
+      fontWeight: "500",
+      fontSize: "0.875rem",
+    }}
+  >
+    {children}
+  </span>
+);
+
+/** Info value component with styling */
+const InfoValue = ({ children }: IInfoValueProps) => (
+  <span
+    style={{
+      color: COLORS.GRAY_TEXT_DARK,
+      fontWeight: "600",
+      fontSize: "0.875rem",
+    }}
+  >
+    {children}
+  </span>
+);
+
+/**
+ * Agent information component displaying model, locale, and configuration
+ * details
+ *
+ * @param props - Component props
+ * @returns JSX element representing the agent information
+ */
+export const AutoBeAgentInformation = ({
+  header,
+}: IAutoBeAgentInformationProps) => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "6px",
+      }}
+    >
+      <InfoRow label="AI Model" value={header.vendor.model} />
+      <InfoRow label="Schema Model" value={header.model} />
+      <InfoRow label="Locale" value={header.locale} />
+      <InfoRow label="Timezone" value={header.timezone} />
+      <InfoRow label="Semaphore" value={header.vendor.semaphore ?? 16} />
+    </div>
+  );
+};

--- a/packages/ui/src/banner/AutoBeChatBanner.tsx
+++ b/packages/ui/src/banner/AutoBeChatBanner.tsx
@@ -2,10 +2,16 @@ import { IAutoBeTokenUsageJson } from "@autobe/interface";
 
 import { Collapsible } from "../common";
 import { COLORS, SHADOWS } from "../constant/color";
+import {
+  AutoBeAgentInformation,
+  IAutoBeAgentInformationProps,
+} from "./AutoBeAgentInformation";
 import { AutoBeTokenUsage } from "./AutoBeTokenUsage";
 
 /** Props interface for AutoBeChatBanner component */
 interface IAutoBeChatBannerProps {
+  /** Agent information to display */
+  header: IAutoBeAgentInformationProps["header"];
   /** Token usage data to display */
   tokenUsage: IAutoBeTokenUsageJson | null;
 }
@@ -32,6 +38,14 @@ export const AutoBeChatBanner = (props: IAutoBeChatBannerProps) => {
         }}
       >
         <h3>Summaries</h3>
+
+        <Collapsible
+          title="Agent Information"
+          defaultCollapsed={false}
+          animated={true}
+        >
+          <AutoBeAgentInformation header={props.header} />
+        </Collapsible>
 
         <Collapsible
           title="Token Usage"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,9 @@ importers:
       '@autobe/vscode-extension/interface':
         specifier: workspace:*
         version: link:../interface
+      '@samchon/openapi':
+        specifier: catalog:samchon
+        version: 4.7.1
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.1.11(vite@6.3.5(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
@@ -728,6 +731,9 @@ importers:
       '@autobe/interface':
         specifier: workspace:*
         version: link:../interface
+      '@samchon/openapi':
+        specifier: catalog:samchon
+        version: 4.7.1
       '@types/react':
         specifier: catalog:ui
         version: 19.1.10


### PR DESCRIPTION
- Added @samchon/openapi dependency to pnpm-lock.yaml and package.json.
- Updated AutoBePlaygroundChatBodyMovie and AutoBePlaygroundChatMovie to include header prop for AutoBeChatBanner.
- Introduced AutoBeAgentInformation component for displaying agent details.
- Enhanced AutoBeChatBanner to include collapsible section for agent information.
- Updated UI components to improve responsiveness and data handling.