### PR TITLE
feat(ui): refactor chat components to use AutoBeListener and related structures

### DIFF
--- a/apps/playground-ui/src/index.ts
+++ b/apps/playground-ui/src/index.ts
@@ -2,5 +2,3 @@ export * from "./AutoBePlaygroundApplication";
 
 export * from "./movies/configure/AutoBePlaygroundConfigureMovie";
 export * from "./movies/chat/AutoBePlaygroundChatMovie";
-
-export * from "./structures/AutoBePlaygroundListener";

--- a/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatBodyMovie.tsx
+++ b/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatBodyMovie.tsx
@@ -8,6 +8,7 @@ import {
   AutoBeChatBanner,
   AutoBeChatUploadBox,
   AutoBeEventMovie,
+  IAutoBeEventGroup,
 } from "@autobe/ui";
 import { useMediaQuery } from "@autobe/ui/hooks";
 import { Box, Container } from "@mui/material";
@@ -15,7 +16,6 @@ import { ILlmSchema } from "@samchon/openapi";
 import { RefObject, useEffect, useRef } from "react";
 
 import { AutoBePlaygroundGlobal } from "../../AutoBePlaygroundGlobal";
-import { IAutoBePlaygroundEventGroup } from "../../structures/IAutoBePlaygroundEventGroup";
 import { IAutoBePlaygroundUploadConfig } from "../../structures/IAutoBePlaygroundUploadConfig";
 
 export const AutoBePlaygroundChatBodyMovie = (
@@ -108,7 +108,7 @@ export const AutoBePlaygroundChatBodyMovie = (
 export namespace AutoBePlaygroundChatBodyMovie {
   export interface IProps {
     isMobile: boolean;
-    eventGroups: IAutoBePlaygroundEventGroup[];
+    eventGroups: IAutoBeEventGroup[];
     service: IAutoBeRpcService;
     conversate: (messages: AutoBeUserMessageContent[]) => Promise<void>;
     setError: (error: Error) => void;

--- a/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx
+++ b/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatMovie.tsx
@@ -3,13 +3,12 @@ import {
   IAutoBeRpcService,
   IAutoBeTokenUsageJson,
 } from "@autobe/interface";
+import { AutoBeListener, IAutoBeEventGroup } from "@autobe/ui";
 import { useMediaQuery } from "@autobe/ui/hooks";
 import { AppBar, Container, Toolbar, Typography } from "@mui/material";
 import { ILlmSchema } from "@samchon/openapi";
 import { useEffect, useState } from "react";
 
-import { AutoBePlaygroundListener } from "../../structures/AutoBePlaygroundListener";
-import { IAutoBePlaygroundEventGroup } from "../../structures/IAutoBePlaygroundEventGroup";
 import { IAutoBePlaygroundUploadConfig } from "../../structures/IAutoBePlaygroundUploadConfig";
 import { AutoBePlaygroundChatBodyMovie } from "./AutoBePlaygroundChatBodyMovie";
 import { AutoBePlaygroundChatSideMovie } from "./AutoBePlaygroundChatSideMovie";
@@ -22,7 +21,7 @@ export function AutoBePlaygroundChatMovie(
   //----
   // STATES
   const [error, setError] = useState<Error | null>(null);
-  const [eventGroups, setEventGroups] = useState<IAutoBePlaygroundEventGroup[]>(
+  const [eventGroups, setEventGroups] = useState<IAutoBeEventGroup[]>(
     props?.eventGroups ?? [],
   );
   const [tokenUsage, setTokenUsage] = useState<IAutoBeTokenUsageJson | null>(
@@ -123,8 +122,8 @@ export namespace AutoBePlaygroundChatMovie {
   export interface IContext {
     header: IAutoBePlaygroundHeader<ILlmSchema.Model>;
     service: IAutoBeRpcService;
-    listener: AutoBePlaygroundListener;
-    eventGroups?: IAutoBePlaygroundEventGroup[];
+    listener: AutoBeListener;
+    eventGroups?: IAutoBeEventGroup[];
     uploadConfig?: IAutoBePlaygroundUploadConfig;
   }
 }

--- a/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatSideMovie.tsx
+++ b/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatSideMovie.tsx
@@ -2,10 +2,10 @@ import {
   IAutoBePlaygroundHeader,
   IAutoBeTokenUsageJson,
 } from "@autobe/interface";
+import { AutoBeListenerState } from "@autobe/ui";
 import { Typography } from "@mui/material";
 import { ILlmSchema } from "@samchon/openapi";
 
-import { AutoBePlaygroundState } from "../../structures/AutoBePlaygroundState";
 import { AutoBePlaygroundChatSideHeaderMovie } from "./AutoBePlaygroundChatSideHeaderMovie";
 import { AutoBePlaygroundChatSideStateMovie } from "./AutoBePlaygroundChatSideStateMovie";
 import { AutoBePlaygroundChatTokenUsageMovie } from "./AutoBePlaygroundChatTokenUsageMovie";
@@ -41,7 +41,7 @@ export function AutoBePlaygroundChatSideMovie(
 export namespace AutoBePlaygroundChatSideMovie {
   export interface IProps {
     header: IAutoBePlaygroundHeader<ILlmSchema.Model>;
-    state: AutoBePlaygroundState;
+    state: AutoBeListenerState;
     tokenUsage: IAutoBeTokenUsageJson | null;
     error: Error | null;
   }

--- a/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatSideStateMovie.tsx
+++ b/apps/playground-ui/src/movies/chat/AutoBePlaygroundChatSideStateMovie.tsx
@@ -1,3 +1,4 @@
+import { AutoBeListenerState } from "@autobe/ui";
 import {
   Table,
   TableBody,
@@ -6,8 +7,6 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-
-import { AutoBePlaygroundState } from "../../structures/AutoBePlaygroundState";
 
 export const AutoBePlaygroundChatSideStateMovie = (
   props: AutoBePlaygroundChatSideStateMovie.IProps,
@@ -108,6 +107,6 @@ export const AutoBePlaygroundChatSideStateMovie = (
 };
 export namespace AutoBePlaygroundChatSideStateMovie {
   export interface IProps {
-    state: AutoBePlaygroundState;
+    state: AutoBeListenerState;
   }
 }

--- a/apps/playground-ui/src/movies/configure/AutoBePlaygroundConfigureMovie.tsx
+++ b/apps/playground-ui/src/movies/configure/AutoBePlaygroundConfigureMovie.tsx
@@ -3,6 +3,7 @@ import {
   IAutoBePlaygroundVendor,
 } from "@autobe/interface";
 import pApi from "@autobe/playground-api";
+import { AutoBeListener } from "@autobe/ui";
 import {
   Button,
   Divider,
@@ -17,7 +18,6 @@ import {
 import { ILlmSchema } from "@samchon/openapi";
 import { useEffect, useState } from "react";
 
-import { AutoBePlaygroundListener } from "../../structures/AutoBePlaygroundListener";
 import { AutoBePlaygroundConfigureValidator } from "../../utils/AutoBePlaygroundConfigureValidator";
 import { AutoBePlaygroundChatMovie } from "../chat/AutoBePlaygroundChatMovie";
 import { AutoBePlaygroundConfigureVendorMovie } from "./AutoBePlaygroundConfigureVendorMovie";
@@ -54,7 +54,7 @@ export function AutoBePlaygroundConfigureMovie(
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         locale,
       };
-      const listener: AutoBePlaygroundListener = new AutoBePlaygroundListener();
+      const listener: AutoBeListener = new AutoBeListener();
       const { driver: service } = await pApi.functional.autobe.playground.start(
         {
           host: serverURL,

--- a/apps/playground-ui/src/movies/replay/AutoBePlaygroundReplayGetMovie.tsx
+++ b/apps/playground-ui/src/movies/replay/AutoBePlaygroundReplayGetMovie.tsx
@@ -3,6 +3,7 @@ import {
   IAutoBePlaygroundReplay,
 } from "@autobe/interface";
 import pApi from "@autobe/playground-api";
+import { AutoBeListener } from "@autobe/ui";
 import { ErrorOutline, ReplayOutlined } from "@mui/icons-material";
 import {
   Alert,
@@ -21,7 +22,6 @@ import {
 } from "@mui/material";
 import { useEffect, useState } from "react";
 
-import { AutoBePlaygroundListener } from "../../structures/AutoBePlaygroundListener";
 import { AutoBePlaygroundChatMovie } from "../chat/AutoBePlaygroundChatMovie";
 
 export const AutoBePlaygroundReplayGetMovie = () => {
@@ -48,7 +48,7 @@ export const AutoBePlaygroundReplayGetMovie = () => {
     }, 300);
 
     const connect = async () => {
-      const listener: AutoBePlaygroundListener = new AutoBePlaygroundListener();
+      const listener: AutoBeListener = new AutoBeListener();
       const { driver } = await pApi.functional.autobe.playground.replay.get(
         {
           host: "http://localhost:5890",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,3 +9,4 @@ export type {
 export { AutoBeFileUploader } from "./utils";
 export * from "./upload";
 export * from "./banner";
+export * from "./structure";

--- a/packages/ui/src/structure/AutoBeListener.ts
+++ b/packages/ui/src/structure/AutoBeListener.ts
@@ -1,25 +1,23 @@
 import { AutoBeEvent, IAutoBeRpcListener } from "@autobe/interface";
 import { List } from "tstl";
 
-import { AutoBePlaygroundState } from "./AutoBePlaygroundState";
-import { IAutoBePlaygroundEventGroup } from "./IAutoBePlaygroundEventGroup";
+import { AutoBeListenerState } from "./AutoBeListenerState";
+import { IAutoBeEventGroup } from "./IAutoBeEventGroup";
 
-export class AutoBePlaygroundListener {
+export class AutoBeListener {
   private callback_:
-    | ((eventGroups: IAutoBePlaygroundEventGroup[]) => Promise<void>)
+    | ((eventGroups: IAutoBeEventGroup[]) => Promise<void>)
     | null;
   private listener_: Required<IAutoBeRpcListener>;
-  private events_: List<IAutoBePlaygroundEventGroup> = new List();
-  private dict_: Map<
-    AutoBeEvent.Type,
-    List.Iterator<IAutoBePlaygroundEventGroup>
-  > = new Map();
-  private readonly state_: AutoBePlaygroundState;
+  private events_: List<IAutoBeEventGroup> = new List();
+  private dict_: Map<AutoBeEvent.Type, List.Iterator<IAutoBeEventGroup>> =
+    new Map();
+  private readonly state_: AutoBeListenerState;
 
   public constructor() {
     this.callback_ = null;
 
-    this.state_ = new AutoBePlaygroundState();
+    this.state_ = new AutoBeListenerState();
     this.listener_ = {
       assistantMessage: async (event) => {
         this.insert(event);
@@ -223,9 +221,7 @@ export class AutoBePlaygroundListener {
     };
   }
 
-  public on(
-    callback: (eventGroups: IAutoBePlaygroundEventGroup[]) => Promise<void>,
-  ) {
+  public on(callback: (eventGroups: IAutoBeEventGroup[]) => Promise<void>) {
     this.callback_ = callback;
   }
 
@@ -233,13 +229,14 @@ export class AutoBePlaygroundListener {
     return this.listener_;
   }
 
-  public getState(): AutoBePlaygroundState {
+  public getState(): AutoBeListenerState {
     return this.state_;
   }
 
   private accumulate(event: AutoBeEvent) {
-    const it: List.Iterator<IAutoBePlaygroundEventGroup> | undefined =
-      this.dict_.get(event.type);
+    const it: List.Iterator<IAutoBeEventGroup> | undefined = this.dict_.get(
+      event.type,
+    );
     if (it === undefined)
       this.dict_.set(
         event.type,

--- a/packages/ui/src/structure/AutoBeListenerState.ts
+++ b/packages/ui/src/structure/AutoBeListenerState.ts
@@ -6,7 +6,7 @@ import {
   AutoBeTestCompleteEvent,
 } from "@autobe/interface";
 
-export class AutoBePlaygroundState {
+export class AutoBeListenerState {
   public analyze: AutoBeAnalyzeCompleteEvent | null;
   public prisma: AutoBePrismaCompleteEvent | null;
   public interface: AutoBeInterfaceCompleteEvent | null;

--- a/packages/ui/src/structure/IAutoBeEventGroup.ts
+++ b/packages/ui/src/structure/IAutoBeEventGroup.ts
@@ -1,8 +1,6 @@
 import { AutoBeEvent } from "@autobe/interface";
 
-export interface IAutoBePlaygroundEventGroup<
-  Event extends AutoBeEvent = AutoBeEvent,
-> {
+export interface IAutoBeEventGroup<Event extends AutoBeEvent = AutoBeEvent> {
   type: Event["type"];
   events: Array<Event>;
 }

--- a/packages/ui/src/structure/index.ts
+++ b/packages/ui/src/structure/index.ts
@@ -1,0 +1,3 @@
+export * from "./AutoBeListener";
+export * from "./AutoBeListenerState";
+export * from "./IAutoBeEventGroup";


### PR DESCRIPTION
- Updated AutoBePlaygroundChatMovie, AutoBePlaygroundChatBodyMovie, and AutoBePlaygroundChatSideMovie to replace AutoBePlaygroundListener with AutoBeListener.
- Changed eventGroups state type from IAutoBePlaygroundEventGroup to IAutoBeEventGroup for better type consistency.
- Introduced AutoBeListener and AutoBeListenerState classes to manage event handling and state management.
- Updated imports and removed unused structures for cleaner code organization.