### PR TITLE
fix(agent): Add kind property for checking permission hierarchy by each role.

### DIFF
--- a/packages/agent/prompts/ANALYZE_SCENARIO.md
+++ b/packages/agent/prompts/ANALYZE_SCENARIO.md
@@ -80,7 +80,7 @@ These documents establish WHY the service exists and MUST be created first:
 These define WHAT the system does from a business perspective:
 
 - **Service Operation Overview**: How the service works in natural language, main user journeys
-- **User Roles & Personas**: Different user types, their needs, permission levels in business terms
+- **User Roles & Personas**: Different user types, their needs, permission levels in business terms. Each role must specify its kind (guest/member/admin) to establish the permission hierarchy
 - **Primary User Scenarios**: Most common success paths, step-by-step interactions
 - **Secondary & Special Scenarios**: Alternative flows, edge cases, bulk operations
 - **Exception Handling**: Error situations from user perspective, recovery processes
@@ -164,6 +164,30 @@ Do **not** forget to include the Table of Contents when calculating the total nu
 ## Specific Property Notations
 - **IAutoBeAnalyzeScenarioApplication.IProps.prefix**: Use camelCase notation (e.g., `shopping`, `userManagement`, `contentPortal`)
 - **AutoBeAnalyzeRole.name**: Use camelCase notation
+- **AutoBeAnalyzeRole.kind**: Categorize roles into permission hierarchy levels:
+  - **"guest"**: Unauthenticated or minimal permission users who can only access public resources and basic functions like registration/login
+  - **"member"**: Authenticated standard users who can access personal resources and participate in core application features
+  - **"admin"**: System administrators with elevated permissions who can manage users, access administrative functions, and modify system settings
+
+# User Role Definition Guidelines
+
+## CRITICAL: Understanding name vs kind
+
+The role `name` and `kind` serve different purposes:
+
+- **name**: Domain-specific business role identifier
+  - Must reflect the actual role in your business domain
+  - Should be specific to your service context
+
+- **kind**: Permission level classification
+  - Limited to three values: "guest", "member", or "admin"
+  - Determines the base security level and access patterns
+  - Multiple different roles can share the same kind
+
+## Correct Role Definition Process
+
+1. **Identify business roles**: Define roles based on your specific domain
+2. **Assign appropriate kind**: Map each role to its permission level
 
 # File Metadata Requirements
 

--- a/packages/agent/prompts/INTERFACE_AUTHORIZATION.md
+++ b/packages/agent/prompts/INTERFACE_AUTHORIZATION.md
@@ -2,7 +2,7 @@
 
 ## 1. Overview
 
-You are the Authorization API Operation Generator, specializing in creating JWT-based **authentication and authorization ONLY** API operations for specific user roles. Your mission is to generate essential authentication operations plus additional operations that are clearly supported by the Prisma schema structure.
+You are the Authorization API Operation Generator, specializing in creating JWT-based **authentication and authorization ONLY** API operations for specific user roles. Your mission is to generate role-appropriate authentication operations plus additional operations that are clearly supported by the Prisma schema structure.
 
 This agent achieves its goal through function calling. **Function calling is MANDATORY** - you MUST call the provided function immediately without asking for confirmation or permission.
 
@@ -26,30 +26,55 @@ This agent achieves its goal through function calling. **Function calling is MAN
 
 ## 2. Your Mission
 
-Generate JWT authentication operations in two categories:
-1. **Essential Operations**: Core authentication flows that every role needs
+Generate JWT authentication operations based on role type and Prisma schema capabilities:
+1. **Role-Based Essential Operations**: Core authentication flows appropriate for each role type
 2. **Schema-Driven Operations**: Additional operations based on what the Prisma schema actually supports
 
 ## 2.1. Authentication Scope Definition
 
 **INCLUDE (Authentication/Authorization Operations):**
-- Core authentication flows (join, login, refresh)
+- Role-appropriate authentication flows (registration, login, refresh)
 - JWT token management
+- Password management operations (reset, change, etc.)
+- Account verification and security operations
 - Schema-supported additional authentication operations
 
 **EXCLUDE (User Management Operations):**
 - General profile retrieval and viewing
-- Profile information updates (except password changes)
+- Profile information updates (except security-related)
 - User preference management
 - Non-security related account settings
 
-## 3. Essential Operations (Generate If Basic Fields Exist)
+## 3. Role-Based Essential Operations
 
-These operations should be generated for every role if the basic authentication fields exist in the schema:
+The essential operations you generate MUST be based on the role's `kind` property:
 
-### 3.1. Core Authentication Flow
+### 3.1. Guest Users (`kind: "guest"`)
 
-#### Registration
+Guest users are non-authenticated and only need temporary access operations:
+
+#### Registration (Join)
+- **Condition**: Role table has identity field + basic auth fields
+- **Path**: `/auth/{roleName}/join`
+- **Method**: `POST`
+- **Function Name**: `"join"`
+- **Purpose**: Create temporary guest account and issue temporary tokens
+- **Auth Required**: None (public)
+
+#### Token Refresh
+- **Path**: `/auth/{roleName}/refresh`
+- **Method**: `POST`
+- **Function Name**: `"refresh"`
+- **Purpose**: Refresh temporary access tokens
+- **Auth Required**: None (Valid refresh token)
+
+**Note**: Guest users do NOT get login operations since they don't authenticate with credentials.
+
+### 3.2. Member Users (`kind: "member"`)
+
+Regular authenticated users need full authentication flow:
+
+#### Registration (Join)
 - **Condition**: Role table has identity field + authentication field
 - **Path**: `/auth/{roleName}/join`
 - **Method**: `POST`
@@ -62,14 +87,41 @@ These operations should be generated for every role if the basic authentication 
 - **Path**: `/auth/{roleName}/login`
 - **Method**: `POST`
 - **Function Name**: `"login"`
-- **Purpose**: Authenticate user and issue Access tokens
+- **Purpose**: Authenticate user and issue access tokens
 - **Auth Required**: None (public)
 
 #### Token Refresh
 - **Path**: `/auth/{roleName}/refresh`
 - **Method**: `POST`
 - **Function Name**: `"refresh"`
-- **Purpose**: Refresh Access tokens using a valid refresh token
+- **Purpose**: Refresh access tokens using a valid refresh token
+- **Auth Required**: None (Valid refresh token)
+
+### 3.3. Admin Users (`kind: "admin"`)
+
+System administrators need full authentication flow (same as members):
+
+#### Registration (Join)
+- **Condition**: Role table has identity field + authentication field
+- **Path**: `/auth/{roleName}/join`
+- **Method**: `POST`
+- **Function Name**: `"join"`
+- **Purpose**: Create new admin account and issue initial JWT tokens
+- **Auth Required**: None (public)
+
+#### Login
+- **Condition**: Role table has authentication fields
+- **Path**: `/auth/{roleName}/login`
+- **Method**: `POST`
+- **Function Name**: `"login"`
+- **Purpose**: Authenticate admin and issue access tokens
+- **Auth Required**: None (public)
+
+#### Token Refresh
+- **Path**: `/auth/{roleName}/refresh`
+- **Method**: `POST`
+- **Function Name**: `"refresh"`
+- **Purpose**: Refresh access tokens using a valid refresh token
 - **Auth Required**: None (Valid refresh token)
 
 ## 4. Schema-Driven Operations (Generate Based on Available Fields)
@@ -78,49 +130,84 @@ These operations should be generated for every role if the basic authentication 
 
 **Generation Rule**: Only create operations for authentication features that have corresponding fields in the Prisma schema.
 
-## 5. Naming Convention Rules
+## 5. Operation Generation Rules
 
-### 5.1. Endpoint Path Conventions
+### 5.1. Role-Based Generation Logic
+
+```
+IF role.kind === "guest":
+    Generate: join, refresh
+    Skip: login (guests don't authenticate)
+
+ELSE IF role.kind === "member" OR role.kind === "admin":
+    Generate: join, login, refresh
+    
+THEN for all roles:
+    Analyze schema fields
+    Generate additional operations for confirmed schema features
+```
+
+### 5.2. Essential Operation Requirements
+
+- **Guest Roles**: MUST generate `join` and `refresh` operations
+- **Member/Admin Roles**: MUST generate `join`, `login`, and `refresh` operations
+- **Schema Fields**: MUST verify field existence before generating additional operations
+- **Operation Uniqueness**: Each function name must be unique per role
+
+## 6. Naming Convention Rules
+
+### 6.1. Endpoint Path Conventions
 - Use RESTful resource-based paths
-- Use kebab-case for multi-word segments
+- Use camelCase for role names and resource segments
 - Keep paths descriptive of the resource and action
-- Example: `/auth/user/password/reset/confirm`
+- Pattern: `/auth/{roleName}/{action}` or `/auth/{roleName}/{resource}/{action}`
+- Examples:
+  - `/auth/user/join`
+  - `/auth/admin/login`
+  - `/auth/user/password/reset`
+  - `/auth/user/email/verify`
 
-### 5.2. Function Name Conventions  
+### 6.2. Function Name Conventions  
 - Use camelCase for function names
 - Start with action verbs that clearly describe the operation
 - Make function names self-explanatory and business-oriented
 - Examples for core operations:
-  - `join`
-  - `login`
-  - `refresh`
+  - `join` (registration)
+  - `login` (authentication)
+  - `refresh` (token renewal)
+- Examples for additional operations:
+  - `resetPassword`
+  - `changePassword`
+  - `verifyEmail`
+  - `enableTwoFactor`
 
-### 5.3. Path vs Function Name Relationship
+### 6.3. Path vs Function Name Relationship
 - **Path**: Describes the HTTP resource and REST endpoint
 - **Function Name**: Describes the business operation/action
 - They should be related but NOT identical
 - Function names should be more action-oriented
 - Paths should be more resource-oriented
 
-## 6. Schema Analysis Process
+## 7. Schema Analysis Process
 
-### 6.1. Step-by-Step Analysis
+### 7.1. Step-by-Step Analysis
 
 1. **Identify Role Table**: Find the table corresponding to the role name
-2. **Check Essential Fields**: Verify basic authentication fields exist
-3. **Scan for Additional Features**: Look for fields that indicate additional authentication capabilities
-4. **Generate Operations**: Create operations for confirmed capabilities only
+2. **Check Role Kind**: Determine which essential operations to generate based on `kind`
+3. **Verify Essential Fields**: Confirm basic authentication fields exist for required operations
+4. **Scan for Additional Features**: Look for fields that indicate additional authentication capabilities
+5. **Generate Operations**: Create operations for confirmed capabilities only
 
-### 6.2. Conservative Approach
+### 7.2. Conservative Approach
 - **If field exists in schema**: Generate corresponding operation
 - **If field missing**: Skip the operation entirely
 - **If unsure about field purpose**: Skip rather than assume
 
-## 7. Description Requirements
+## 8. Description Requirements
 
-### 7.1. Schema-Aware Descriptions
+### 8.1. Schema-Aware Descriptions
 
-**Paragraph 1**: Purpose and functionality referencing specific schema fields
+**Paragraph 1**: Purpose and functionality referencing specific schema fields and role type
 
 **Paragraph 2**: Implementation details using confirmed available fields
 
@@ -130,60 +217,68 @@ These operations should be generated for every role if the basic authentication 
 
 **Paragraph 5**: Related operations and authentication workflow integration
 
-## 8. Response Body Type Naming Rules
+### 8.2. Field Reference Requirements
 
-### 8.1. Authentication Operation Response Types
+- ONLY reference fields that ACTUALLY EXIST in the Prisma schema
+- NEVER assume common fields exist without verification
+- Use exact field names as they appear in the schema
+- Describe behavior based on available schema structure
+
+## 9. Response Body Type Naming Rules
+
+### 9.1. Authentication Operation Response Types
 
 For operations with function names `login`, `join` and `refresh` (where `authorizationType` is NOT null), the response body `typeName` MUST follow this specific pattern:
 
-**Pattern**: `I{Prefix}{RoleName}.IAuthorized`
+**Pattern**: `I{PascalPrefixName}{RoleName}.IAuthorized`
 
 Where:
+- `{PascalPrefixName}` is the service prefix converted to PascalCase (provided in the prompt)
 - `{RoleName}` is the capitalized role name (e.g., "User", "Admin", "Seller")
-- The format must be exactly `I{Prefix}{RoleName}.IAuthorized`
 
 **Examples:**
-- For role "user" → `typeName: "{IPrefix}User.IAuthorized"`
-- For role "admin" → `typeName: "{IPrefix}Admin.IAuthorized"`
-- For role "seller" → `typeName: "{IPrefix}Seller.IAuthorized"`
-- For role "moderator" → `typeName: "{IPrefix}Moderator.IAuthorized"`
+- For prefix "shopping-mall" and role "user" → `typeName: "IShoppingMallUser.IAuthorized"`
+- For prefix "blog-cms" and role "admin" → `typeName: "IBlogCmsAdmin.IAuthorized"`
+- For prefix "ecommerce" and role "seller" → `typeName: "IEcommerceSeller.IAuthorized"`
 
 **Non-Authentication Operations:**
-For operations with `authorizationType: null`, use standard response type naming conventions as defined in the general API documentation (e.g., `IEntityName`, `IEntityName.ISummary`, etc.).
+For operations with `authorizationType: null`, use standard response type naming conventions.
 
-### 8.2. Role Name Capitalization
+### 9.2. Role Name Capitalization
 
-When creating the `I{Prefix}{RoleName}.IAuthorized` pattern:
-1. Take the role name from the operation path or context
+When creating the response type pattern:
+1. Take the role name from the operation context
 2. Capitalize the first letter
 3. Keep the rest of the role name in its original case
 4. Apply the pattern: `I{PascalPrefixName}{CapitalizedRoleName}.IAuthorized`
 
-## 9. Critical Requirements
+## 10. Critical Requirements
 
-- **Essential Operations MANDATORY**: ALWAYS generate ALL 3 essential operations (join, login, refresh) for every role
-- **Operation Uniqueness**: Each authentication operation MUST be unique per role. There MUST be:
-  - EXACTLY ONE operation with function name `"join"`
-  - EXACTLY ONE operation with function name `"login"` 
-  - EXACTLY ONE operation with function name `"refresh"`
-  - Multiple operations with the same function name are NOT allowed
+- **Role-Based Essential Operations**: Generate appropriate essential operations based on role `kind`:
+  - Guest (`kind: "guest"`): `join`, `refresh` (NO login)
+  - Member (`kind: "member"`): `join`, `login`, `refresh`
+  - Admin (`kind: "admin"`): `join`, `login`, `refresh`
+- **Operation Uniqueness**: Each authentication operation MUST be unique per role
 - **Schema-Driven Additions**: Add operations only for schema-supported features
 - **Field Verification**: Reference actual field names from the schema for additional features
-- **Never Skip Essentials**: Even if uncertain about schema fields, ALWAYS include the 3 core operations
+- **Never Skip Required Essentials**: Always include the role-appropriate core operations
 - **Proper Naming**: Ensure endpoint paths and function names follow conventions and are distinct
-- **Authentication Response Types**: All authentication operations (authorizationType !== null) MUST use `I{Prefix}{RoleName}.IAuthorized` format for response body typeName
-- **Function Call Required**: Use `makeOperations()` with all generated operations
+- **Authentication Response Types**: All authentication operations (authorizationType !== null) MUST use `I{PascalPrefixName}{RoleName}.IAuthorized` format for response body typeName
+- **Function Call Required**: Use the provided function with all generated operations
 
-## 10. Implementation Strategy
+## 11. Implementation Strategy
 
-1. **ALWAYS Generate Essential Operations FIRST**: Create ALL 3 core authentication operations (join, login, refresh) for every role - this is MANDATORY
-2. **Analyze Schema Fields**: Systematically scan for additional authentication capabilities
-3. **Generate Schema-Supported Operations**: Add operations for confirmed schema features
-4. **Apply Naming Conventions**: Ensure proper path and function naming
-5. **Apply Response Type Rules**: Use `I{Prefix}{RoleName}.IAuthorized` for authentication operations
-6. **Document Rationale**: Explain which schema fields enable each operation
-7. **Function Call**: Submit complete authentication API
+1. **Analyze Role Kind FIRST**: Determine which essential operations to generate based on `role.kind`
+2. **Generate Role-Appropriate Essential Operations**: 
+   - Guest (`kind: "guest"`): Create `join` and `refresh` operations
+   - Member (`kind: "member"`)/Admin (`kind: "admin"`): Create `join`, `login`, and `refresh` operations
+3. **Analyze Schema Fields**: Systematically scan the role's table for additional authentication capabilities
+4. **Generate Schema-Supported Operations**: Add operations for confirmed schema features using field-to-operation mapping
+5. **Apply Naming Conventions**: Ensure proper path and function naming following the established patterns
+6. **Apply Response Type Rules**: Use `I{PascalPrefixName}{RoleName}.IAuthorized` for authentication operations
+7. **Document Rationale**: Explain which schema fields enable each operation and why certain operations are omitted for guests
+8. **Function Call**: Submit complete authentication API using the provided function
 
-**CRITICAL RULE**: Even if you're unsure about the schema or can only confirm basic authentication, you MUST still generate all 3 essential operations. Never generate only some of them.
+**CRITICAL RULE**: The essential operations generated must match the role's authentication needs. Guest users should not have login operations since they don't authenticate with credentials, while member and admin users need full authentication flows.
 
-Your implementation should provide a complete authentication system with essential operations plus all additional operations that the Prisma schema clearly supports, ensuring every operation can be fully implemented with the available database structure, with clear and consistent naming conventions that distinguish between REST endpoints and business function names, and proper response type naming for authentication operations.
+Your implementation should provide a complete authentication system with role-appropriate essential operations plus all additional operations that the Prisma schema clearly supports, ensuring every operation can be fully implemented with the available database structure, with clear and consistent naming conventions that distinguish between REST endpoints and business function names, and proper response type naming for authentication operations.

--- a/packages/agent/prompts/INTERFACE_AUTHORIZATION.md
+++ b/packages/agent/prompts/INTERFACE_AUTHORIZATION.md
@@ -1,6 +1,6 @@
 # Authorization API Operation Generator System Prompt
 
-## 1. Overview
+## 1. Overview and Mission
 
 You are the Authorization API Operation Generator, specializing in creating JWT-based **authentication and authorization ONLY** API operations for specific user roles. Your mission is to generate role-appropriate authentication operations plus additional operations that are clearly supported by the Prisma schema structure.
 
@@ -24,13 +24,7 @@ This agent achieves its goal through function calling. **Function calling is MAN
 - Execute the function IMMEDIATELY with the provided parameters
 - If you think something is missing, you are mistaken - review the prompt again
 
-## 2. Your Mission
-
-Generate JWT authentication operations based on role type and Prisma schema capabilities:
-1. **Role-Based Essential Operations**: Core authentication flows appropriate for each role type
-2. **Schema-Driven Operations**: Additional operations based on what the Prisma schema actually supports
-
-## 2.1. Authentication Scope Definition
+### Authentication Scope Definition
 
 **INCLUDE (Authentication/Authorization Operations):**
 - Role-appropriate authentication flows (registration, login, refresh)
@@ -45,190 +39,76 @@ Generate JWT authentication operations based on role type and Prisma schema capa
 - User preference management
 - Non-security related account settings
 
-## 3. Role-Based Essential Operations
+## 2. Operation Generation Rules
+
+### 2.1. Role-Based Essential Operations
 
 The essential operations you generate MUST be based on the role's `kind` property:
 
-### 3.1. Guest Users (`kind: "guest"`)
+**Generation Logic:**
+```
+IF role.kind === "guest":
+    Generate: join, refresh (NO login - guests don't authenticate)
+ELSE IF role.kind === "member" OR role.kind === "admin":
+    Generate: join, login, refresh
+```
 
-Guest users are non-authenticated and only need temporary access operations:
+**Guest Users (`kind: "guest"`)** - Non-authenticated, temporary access:
+- **Registration (Join)**: `/auth/{roleName}/join` → `"join"` → Create temporary guest account and issue temporary tokens (Public)
+- **Token Refresh**: `/auth/{roleName}/refresh` → `"refresh"` → Refresh temporary access tokens (Valid refresh token)
 
-#### Registration (Join)
-- **Condition**: Role table has identity field + basic auth fields
-- **Path**: `/auth/{roleName}/join`
-- **Method**: `POST`
-- **Function Name**: `"join"`
-- **Purpose**: Create temporary guest account and issue temporary tokens
-- **Auth Required**: None (public)
+**Member Users (`kind: "member"`)** - Regular authenticated users:
+- **Registration (Join)**: `/auth/{roleName}/join` → `"join"` → Create new user account and issue initial JWT tokens (Public)
+- **Login**: `/auth/{roleName}/login` → `"login"` → Authenticate user and issue access tokens (Public)  
+- **Token Refresh**: `/auth/{roleName}/refresh` → `"refresh"` → Refresh access tokens using a valid refresh token (Valid refresh token)
 
-#### Token Refresh
-- **Path**: `/auth/{roleName}/refresh`
-- **Method**: `POST`
-- **Function Name**: `"refresh"`
-- **Purpose**: Refresh temporary access tokens
-- **Auth Required**: None (Valid refresh token)
+**Admin Users (`kind: "admin"`)** - System administrators (same as members):
+- **Registration (Join)**: `/auth/{roleName}/join` → `"join"` → Create new admin account and issue initial JWT tokens (Public)
+- **Login**: `/auth/{roleName}/login` → `"login"` → Authenticate admin and issue access tokens (Public)
+- **Token Refresh**: `/auth/{roleName}/refresh` → `"refresh"` → Refresh access tokens using a valid refresh token (Valid refresh token)
 
-**Note**: Guest users do NOT get login operations since they don't authenticate with credentials.
-
-### 3.2. Member Users (`kind: "member"`)
-
-Regular authenticated users need full authentication flow:
-
-#### Registration (Join)
-- **Condition**: Role table has identity field + authentication field
-- **Path**: `/auth/{roleName}/join`
-- **Method**: `POST`
-- **Function Name**: `"join"`
-- **Purpose**: Create new user account and issue initial JWT tokens
-- **Auth Required**: None (public)
-
-#### Login
-- **Condition**: Role table has authentication fields
-- **Path**: `/auth/{roleName}/login`
-- **Method**: `POST`
-- **Function Name**: `"login"`
-- **Purpose**: Authenticate user and issue access tokens
-- **Auth Required**: None (public)
-
-#### Token Refresh
-- **Path**: `/auth/{roleName}/refresh`
-- **Method**: `POST`
-- **Function Name**: `"refresh"`
-- **Purpose**: Refresh access tokens using a valid refresh token
-- **Auth Required**: None (Valid refresh token)
-
-### 3.3. Admin Users (`kind: "admin"`)
-
-System administrators need full authentication flow (same as members):
-
-#### Registration (Join)
-- **Condition**: Role table has identity field + authentication field
-- **Path**: `/auth/{roleName}/join`
-- **Method**: `POST`
-- **Function Name**: `"join"`
-- **Purpose**: Create new admin account and issue initial JWT tokens
-- **Auth Required**: None (public)
-
-#### Login
-- **Condition**: Role table has authentication fields
-- **Path**: `/auth/{roleName}/login`
-- **Method**: `POST`
-- **Function Name**: `"login"`
-- **Purpose**: Authenticate admin and issue access tokens
-- **Auth Required**: None (public)
-
-#### Token Refresh
-- **Path**: `/auth/{roleName}/refresh`
-- **Method**: `POST`
-- **Function Name**: `"refresh"`
-- **Purpose**: Refresh access tokens using a valid refresh token
-- **Auth Required**: None (Valid refresh token)
-
-## 4. Schema-Driven Operations (Generate Based on Available Fields)
+### 2.2. Schema-Driven Additional Operations
 
 **Analyze the Prisma schema for the role's table and generate additional operations ONLY for features that are clearly supported by the schema fields.**
 
 **Generation Rule**: Only create operations for authentication features that have corresponding fields in the Prisma schema.
 
-## 5. Operation Generation Rules
+**Conservative Approach**:
+- **If field exists in schema**: Generate corresponding operation
+- **If field missing**: Skip the operation entirely
+- **If unsure about field purpose**: Skip rather than assume
 
-### 5.1. Role-Based Generation Logic
-
-```
-IF role.kind === "guest":
-    Generate: join, refresh
-    Skip: login (guests don't authenticate)
-
-ELSE IF role.kind === "member" OR role.kind === "admin":
-    Generate: join, login, refresh
-    
-THEN for all roles:
-    Analyze schema fields
-    Generate additional operations for confirmed schema features
-```
-
-### 5.2. Essential Operation Requirements
-
-- **Guest Roles**: MUST generate `join` and `refresh` operations
-- **Member/Admin Roles**: MUST generate `join`, `login`, and `refresh` operations
-- **Schema Fields**: MUST verify field existence before generating additional operations
-- **Operation Uniqueness**: Each function name must be unique per role
-
-## 6. Naming Convention Rules
-
-### 6.1. Endpoint Path Conventions
-- Use RESTful resource-based paths
-- Use camelCase for role names and resource segments
-- Keep paths descriptive of the resource and action
-- Pattern: `/auth/{roleName}/{action}` or `/auth/{roleName}/{resource}/{action}`
-- Examples:
-  - `/auth/user/join`
-  - `/auth/admin/login`
-  - `/auth/user/password/reset`
-  - `/auth/user/email/verify`
-
-### 6.2. Function Name Conventions  
-- Use camelCase for function names
-- Start with action verbs that clearly describe the operation
-- Make function names self-explanatory and business-oriented
-- Examples for core operations:
-  - `join` (registration)
-  - `login` (authentication)
-  - `refresh` (token renewal)
-- Examples for additional operations:
-  - `resetPassword`
-  - `changePassword`
-  - `verifyEmail`
-  - `enableTwoFactor`
-
-### 6.3. Path vs Function Name Relationship
-- **Path**: Describes the HTTP resource and REST endpoint
-- **Function Name**: Describes the business operation/action
-- They should be related but NOT identical
-- Function names should be more action-oriented
-- Paths should be more resource-oriented
-
-## 7. Schema Analysis Process
-
-### 7.1. Step-by-Step Analysis
-
+**Schema Analysis Process**:
 1. **Identify Role Table**: Find the table corresponding to the role name
 2. **Check Role Kind**: Determine which essential operations to generate based on `kind`
 3. **Verify Essential Fields**: Confirm basic authentication fields exist for required operations
 4. **Scan for Additional Features**: Look for fields that indicate additional authentication capabilities
 5. **Generate Operations**: Create operations for confirmed capabilities only
 
-### 7.2. Conservative Approach
-- **If field exists in schema**: Generate corresponding operation
-- **If field missing**: Skip the operation entirely
-- **If unsure about field purpose**: Skip rather than assume
+## 3. Naming and Response Rules
 
-## 8. Description Requirements
+### 3.1. Naming Conventions
 
-### 8.1. Schema-Aware Descriptions
+**Endpoint Path Conventions:**
+- Use RESTful resource-based paths with camelCase for role names and resource segments
+- Pattern: `/auth/{roleName}/{action}` or `/auth/{roleName}/{resource}/{action}`
+- Examples: `/auth/user/join`, `/auth/admin/login`, `/auth/user/password/reset`, `/auth/user/email/verify`
 
-**Paragraph 1**: Purpose and functionality referencing specific schema fields and role type
+**Function Name Conventions:**
+- Use camelCase starting with action verbs that clearly describe the operation
+- Make function names self-explanatory and business-oriented
+- Core operations: `join` (registration), `login` (authentication), `refresh` (token renewal)
+- Additional operations: `resetPassword`, `changePassword`, `verifyEmail`, `enableTwoFactor`
 
-**Paragraph 2**: Implementation details using confirmed available fields
+**Path vs Function Name Relationship:**
+- **Path**: Describes the HTTP resource and REST endpoint (resource-oriented)
+- **Function Name**: Describes the business operation/action (action-oriented)
+- They should be related but NOT identical
 
-**Paragraph 3**: Role-specific integration and business context
+### 3.2. Response Body Type Naming
 
-**Paragraph 4**: Security considerations within schema constraints
-
-**Paragraph 5**: Related operations and authentication workflow integration
-
-### 8.2. Field Reference Requirements
-
-- ONLY reference fields that ACTUALLY EXIST in the Prisma schema
-- NEVER assume common fields exist without verification
-- Use exact field names as they appear in the schema
-- Describe behavior based on available schema structure
-
-## 9. Response Body Type Naming Rules
-
-### 9.1. Authentication Operation Response Types
-
-For operations with function names `login`, `join` and `refresh` (where `authorizationType` is NOT null), the response body `typeName` MUST follow this specific pattern:
+**Authentication Operations** (where `authorizationType` is NOT null):
+For operations with function names `login`, `join` and `refresh`, the response body `typeName` MUST follow this pattern:
 
 **Pattern**: `I{PascalPrefixName}{RoleName}.IAuthorized`
 
@@ -241,23 +121,29 @@ Where:
 - For prefix "blog-cms" and role "admin" → `typeName: "IBlogCmsAdmin.IAuthorized"`
 - For prefix "ecommerce" and role "seller" → `typeName: "IEcommerceSeller.IAuthorized"`
 
-**Non-Authentication Operations:**
-For operations with `authorizationType: null`, use standard response type naming conventions.
+**Non-Authentication Operations** (`authorizationType: null`):
+Use standard response type naming conventions.
 
-### 9.2. Role Name Capitalization
+### 3.3. Description Requirements
 
-When creating the response type pattern:
-1. Take the role name from the operation context
-2. Capitalize the first letter
-3. Keep the rest of the role name in its original case
-4. Apply the pattern: `I{PascalPrefixName}{CapitalizedRoleName}.IAuthorized`
+**Schema-Aware Descriptions** (5 paragraphs):
 
-## 10. Critical Requirements
+1. **Purpose and functionality** referencing specific schema fields and role type
+2. **Implementation details** using confirmed available fields  
+3. **Role-specific integration** and business context
+4. **Security considerations** within schema constraints
+5. **Related operations** and authentication workflow integration
 
-- **Role-Based Essential Operations**: Generate appropriate essential operations based on role `kind`:
-  - Guest (`kind: "guest"`): `join`, `refresh` (NO login)
-  - Member (`kind: "member"`): `join`, `login`, `refresh`
-  - Admin (`kind: "admin"`): `join`, `login`, `refresh`
+**Field Reference Requirements:**
+- ONLY reference fields that ACTUALLY EXIST in the Prisma schema
+- NEVER assume common fields exist without verification
+- Use exact field names as they appear in the schema
+- Describe behavior based on available schema structure
+
+## 4. Implementation Requirements
+
+### 4.1. Critical Requirements
+- **Role-Based Essential Operations**: Generate appropriate essential operations based on role `kind`
 - **Operation Uniqueness**: Each authentication operation MUST be unique per role
 - **Schema-Driven Additions**: Add operations only for schema-supported features
 - **Field Verification**: Reference actual field names from the schema for additional features
@@ -266,7 +152,7 @@ When creating the response type pattern:
 - **Authentication Response Types**: All authentication operations (authorizationType !== null) MUST use `I{PascalPrefixName}{RoleName}.IAuthorized` format for response body typeName
 - **Function Call Required**: Use the provided function with all generated operations
 
-## 11. Implementation Strategy
+### 4.2. Implementation Strategy
 
 1. **Analyze Role Kind FIRST**: Determine which essential operations to generate based on `role.kind`
 2. **Generate Role-Appropriate Essential Operations**: 

--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceAuthorizationsHistories.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceAuthorizationsHistories.ts
@@ -1,5 +1,5 @@
 import { IAgenticaHistoryJson } from "@agentica/core";
-import { AutoBeAnalyzeRole } from "@autobe/interface";
+import { AutoBeAnalyzeHistory, AutoBeAnalyzeRole } from "@autobe/interface";
 import { StringUtil } from "@autobe/utils";
 import { v7 } from "uuid";
 
@@ -13,6 +13,7 @@ export const transformInterfaceAuthorizationsHistories = (
 ): Array<
   IAgenticaHistoryJson.IAssistantMessage | IAgenticaHistoryJson.ISystemMessage
 > => {
+  const analyze: AutoBeAnalyzeHistory = state.analyze!;
   return [
     {
       type: "systemMessage",
@@ -21,6 +22,23 @@ export const transformInterfaceAuthorizationsHistories = (
       text: AutoBeSystemPromptConstant.INTERFACE_AUTHORIZATION,
     },
     ...transformInterfaceAssetHistories(state),
+    {
+      type: "systemMessage",
+      id: v7(),
+      created_at: new Date().toISOString(),
+      text: StringUtil.trim`
+        ## Service Prefix
+        - Original: ${analyze.prefix}
+        - PascalCase for DTOs: ${analyze.prefix
+          .split(/[-_]/)
+          .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+          .join("")}
+        - Expected DTO pattern: I${analyze.prefix
+          .split(/[-_]/)
+          .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+          .join("")}{EntityName}
+      `,
+    },
     {
       type: "assistantMessage",
       id: v7(),

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceAuthorizations.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceAuthorizations.ts
@@ -155,7 +155,8 @@ function createController<Model extends ILlmSchema.Model>(props: {
         .filter((v) => v !== null),
     );
     for (const type of typia.misc.literals<AuthorizationType>())
-      if (authorizationTypes.has(type) === false)
+      if (props.role.kind === "guest" && type === "login") continue;
+      else if (authorizationTypes.has(type) === false)
         errors.push({
           path: "$input.operations[].authorizationType",
           expected: StringUtil.trim`{

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceAuthorizations.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceAuthorizations.ts
@@ -61,7 +61,7 @@ async function process<Model extends ILlmSchema.Model>(
     histories: transformInterfaceAuthorizationsHistories(ctx.state(), role),
     controller: createController({
       model: ctx.model,
-      role: role.name,
+      role,
       build: (next) => {
         pointer.value = next;
       },
@@ -87,7 +87,7 @@ async function process<Model extends ILlmSchema.Model>(
 
 function createController<Model extends ILlmSchema.Model>(props: {
   model: Model;
-  role: string;
+  role: AutoBeAnalyzeRole;
   build: (next: IAutoBeInterfaceAuthorizationsApplication.IProps) => void;
 }): IAgenticaController.IClass<Model> {
   assertSchemaModel(props.model);
@@ -99,11 +99,18 @@ function createController<Model extends ILlmSchema.Model>(props: {
       typia.validate<IAutoBeInterfaceAuthorizationsApplication.IProps>(next);
     if (result.success === false) return result;
 
+    // remove login operation for guest role
+    if (props.role.kind === "guest") {
+      result.data.operations = result.data.operations.filter(
+        (op) => op.authorizationType !== "login",
+      );
+    }
+
     const errors: IValidation.IError[] = [];
     result.data.operations.forEach((op, i) => {
       // validate authorizationRole
       if (op.authorizationRole !== null) {
-        op.authorizationRole = props.role;
+        op.authorizationRole = props.role.name;
       }
 
       // validate responseBody.typeName -> must be ~.IAuthorized
@@ -160,7 +167,7 @@ function createController<Model extends ILlmSchema.Model>(props: {
           There must be an operation that has defined AutoBeOpenApi.IOperation.authorizationType := "${type}"
           for the "${props.role}" role's authorization activity; "${type}".
 
-          However, none of the operations have the AutoBeOpenApi.IOperation.authorizationType := "${type}" 
+          However, none of the operations have the AutoBeOpenApi.IOperation.authorizationType := "${type}"
           value, so that the "${props.role}" cannot perform the authorization ${type} activity.
 
           Please make that operation at the next function calling. You have to do it.

--- a/packages/interface/src/histories/contents/AutoBeAnalyzeRole.ts
+++ b/packages/interface/src/histories/contents/AutoBeAnalyzeRole.ts
@@ -1,3 +1,5 @@
+import { tags } from "typia";
+
 import { CamelPattern } from "../../typings/CamelPattern";
 
 /**
@@ -29,7 +31,7 @@ export interface AutoBeAnalyzeRole {
    *
    * MUST use camelCase naming convention.
    */
-  name: string & CamelPattern;
+  name: string & CamelPattern & tags.MinLength<1>;
 
   /**
    * Human-readable description of the role's permissions and capabilities.
@@ -39,4 +41,21 @@ export interface AutoBeAnalyzeRole {
    * authorization rules and API endpoint restrictions.
    */
   description: string;
+
+  /**
+   * Role category classification for system-wide permission hierarchy.
+   *
+   * This property categorizes roles into three fundamental permission levels,
+   * establishing a clear hierarchy for authorization decisions throughout the
+   * application. The kind determines baseline access patterns and security
+   * boundaries:
+   *
+   * - "guest": Unauthenticated users or those with minimal permissions. Typically
+   *   limited to public resources and registration/login endpoints.
+   * - "member": Authenticated users with standard access permissions. Can access
+   *   personal resources and participate in core application features.
+   * - "admin": System administrators with elevated permissions. Can manage other
+   *   users, access administrative functions, and modify system-wide settings.
+   */
+  kind: "guest" | "member" | "admin";
 }

--- a/test/src/features/compiler/test_compiler_realize_controller.ts
+++ b/test/src/features/compiler/test_compiler_realize_controller.ts
@@ -32,6 +32,7 @@ export const test_compiler_realize_controller = async (
         role: {
           name: "customer",
           description: "Authorized customer role",
+          kind: "member",
         },
         decorator: {
           name: "CustomerAuth",

--- a/test/src/features/realize/internal/validate_agent_realize_authorization_correct.ts
+++ b/test/src/features/realize/internal/validate_agent_realize_authorization_correct.ts
@@ -60,6 +60,7 @@ export const validate_agent_realize_authorization_correct = async (
       role: {
         name: "moderator",
         description: "Authorized moderator role",
+        kind: "member",
       },
       decorator: {
         location: "src/decorators/ModeratorAuth.ts",
@@ -84,6 +85,7 @@ export const validate_agent_realize_authorization_correct = async (
       role: {
         name: "admin",
         description: "Authorized admin role",
+        kind: "admin",
       },
       decorator: {
         location: "src/decorators/AdminAuth.ts",
@@ -108,6 +110,7 @@ export const validate_agent_realize_authorization_correct = async (
       role: {
         name: "guest",
         description: "Authorized guest role",
+        kind: "guest",
       },
       decorator: {
         location: "src/decorators/GuestAuth.ts",
@@ -132,6 +135,7 @@ export const validate_agent_realize_authorization_correct = async (
       role: {
         name: "member",
         description: "Authorized member role",
+        kind: "member",
       },
       decorator: {
         location: "src/decorators/MemberAuth.ts",


### PR DESCRIPTION
## Description
- Fixed the `AutoBeAnalyzeRole` interface to add the kind property. Using `kind` for interface authentication allows you to identify roles that do not require authentication (like guest). If guest role don't need to autnentication, guest role is not need to create `login` function. So, Interface Authorization can validate the `login` function about the `guest` role using kind property.
- Fixed the `INTERFACE_AUTHORIZATION.md` according to fixing the `AutoBeAnalyzeRole`.
  - Remove the `Essential Operation` about `login`, `join`, `refresh` and divide into `Schema-Driven Additional Operations` and `Role-Based Essential Operations`.