### PR TITLE
feat(website): enhance hackathon content

### DIFF
--- a/website/src/content/docs/hackathon/index.mdx
+++ b/website/src/content/docs/hackathon/index.mdx
@@ -7,8 +7,8 @@ Wrtn Technologies is hosting the 1st AutoBE Hackathon.
 - **Participants**: 70 people
 - **Registration Period**: September 5 - 10, 2025
 - **Event Schedule**: September 13 - 14, 2025 (48 hours)
-  - Start: September 13, 00:00:00 (KST)
-  - End: September 14, 23:59:59 (KST)
+  - Start: September 13, 00:00:00 (KST, UTC+9)
+  - End: September 14, 23:59:59 (KST, UTC+9)
 
 We want to ask backend developers: Can AI truly replace the work of backend developers? We seek to hear the answer to this question directly from developers working in the field.
 
@@ -26,7 +26,7 @@ We particularly welcome developers with the following experience and interests: 
 
 Registration runs from September 5 to 10, 2025, and the actual hackathon will take place for exactly 48 hours from midnight on September 13 to just before midnight on September 14. It starts at 00:00:00 on September 13 and ends at 23:59:59 on September 14, Korea Standard Time.
 
-The total prize pool is $5,000: $2,000 for the best review, $1,000 for the second-best review, and $50 participation prizes for all participants who participate sincerely and provide meaningful feedback.
+The total prize pool is $6,400: $2,000 for the best review, $1,000 for the second-best review, and $50 participation prizes for all participants who participate sincerely and provide meaningful feedback.
 
 ### 1.3. Next Hackathon Preview
 
@@ -187,7 +187,7 @@ During generation, please carefully record conversation content with AutoBE, res
 
 ### 5.4. Submission
 
-Within one week after the hackathon ends, by 23:59:59 (KST) on September 21, 2025, you must write and submit detailed review documents. Submission can be done directly within the AutoBE platform, with no separate email submission required.
+Within one week after the hackathon ends, by 23:59:59 (KST, UTC+9) on September 21, 2025, you must write and submit detailed review documents. Submission can be done directly within the AutoBE platform, with no separate email submission required.
 
 Review documents have no specific format requirements but should include sufficiently detailed analysis for each project. Please explain not just "good" or "bad" but specifically what parts were good or bad in what ways and why.
 
@@ -308,7 +308,7 @@ AI-assisted review writing is not allowed. The core purpose of this hackathon is
 
 ### 8.5. Judging and Announcement
 
-Judging will proceed for 2 weeks after submission deadline, with results announced via individual email and official website. Judging will be conducted jointly by the AutoBE development team and external experts, comprehensively evaluating review professionalism, specificity, practicality, and balance.
+Judging will proceed for 2 weeks after submission deadline, with results announced via individual email and official website (https://wrtnlabs.io/autobe). Judging will be conducted jointly by the AutoBE development team and external experts, comprehensively evaluating review professionalism, specificity, practicality, and balance.
 
 Prizes will be paid within one week after results announcement, and you must submit account information capable of international transfers. Tax issues must be handled directly by recipients, and we'll provide necessary documents.
 
@@ -354,16 +354,7 @@ We're preparing the 2nd hackathon targeting Q4 2025. By then, we plan to complet
 - Aim to successfully generate shopping mall-level large applications even with small models like GPT 4.1 mini
 - Optimize to generate same quality backend applications for under $20
 
-### 10.3. Toward Larger Scale Hackathons
-
-Based on these optimizations, we plan to recruit many more participants for the 2nd hackathon:
-
-- **Participant Scale**: Over 500 (7x expansion from current 70)
-- **Prize Pool**: Expanded to $20,000 total
-- **Eligibility**: Relaxed experience requirements to allow more diverse developers to participate
-- **Global Expansion**: Conducted for developers worldwide
-
-### 10.4. Long-term Vision
+### 10.3. Long-term Vision
 
 Our goal is to create a world where anyone can easily create backend applications through AutoBE. Hackathons are an important process for realizing this vision, and we aim to create a platform that grows together with the developer community.
 


### PR DESCRIPTION
This pull request updates the documentation for the 1st AutoBE Hackathon, mainly clarifying time zones, updating prize pool information, and refining event details. The changes improve clarity for participants and update information about future hackathons.

Event and schedule clarifications:

* Added explicit mention of time zone (`KST, UTC+9`) to all event start, end, and submission deadline times for greater clarity. [[1]](diffhunk://#diff-a68feff51cee391d63ee861d2e22b7faaaad3f6c1e7e76a502e634f9a55004f3L10-R11) [[2]](diffhunk://#diff-a68feff51cee391d63ee861d2e22b7faaaad3f6c1e7e76a502e634f9a55004f3L190-R190)

Prize and announcement updates:

* Increased the total prize pool from $5,000 to $6,400, updating the documentation to reflect the new amount.
* Added the official website link (https://wrtnlabs.io/autobe) to the results announcement section for improved communication.

Future hackathon section changes:

* Removed the detailed preview for the 2nd hackathon (participant scale, prize pool, eligibility, and global expansion), and consolidated the focus to long-term vision for the platform.