### PR TITLE
feat(website): new domain `autobe.dev`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,5 +263,5 @@ What improvements this brings
 - **License**: AGPL 3.0
 - **Maintainer**: Wrtn Technologies
 - **Repository**: https://github.com/wrtnlabs/autobe
-- **Documentation**: https://wrtnlabs.io/autobe/docs/
+- **Documentation**: https://autobe.dev/docs/
 - **Main Branch**: main

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 [![NPM Version](https://img.shields.io/npm/v/@autobe/agent.svg)](https://www.npmjs.com/package/@autobe/agent)
 [![NPM Downloads](https://img.shields.io/npm/dm/@autobe/agent.svg)](https://www.npmjs.com/package/@autobe/agent)
 [![Build Status](https://github.com/wrtnlabs/autobe/workflows/build/badge.svg)](https://github.com/wrtnlabs/autobe/actions?query=workflow%3Abuild)
-[![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://wrtnlabs.io/autobe/docs/)
+[![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://autobe.dev/docs/)
 [![Discord Badge](https://dcbadge.limes.pink/api/server/https://discord.gg/aMhRmzkqCx?style=flat)](https://discord.gg/aMhRmzkqCx)
 
 [![Fund Raising News](https://wrtnlabs.io/agentica/images/badges/fund-raising-news-202503.svg)](https://www.bloomberg.com/news/videos/2025-03-31/wtrn-on-series-b-funding-growth-strategy-video)
@@ -83,42 +83,42 @@ pnpm run playground
 
 ## Documentation Resources
 
-Find comprehensive resources at our [official website](https://wrtnlabs.io/autobe).
+Find comprehensive resources at our [official website](https://autobe.dev).
 
 ### 🏠 Home
 
-- 🙋🏻‍♂️ [Introduction](https://wrtnlabs.io/autobe/docs)
-- 📦 [Setup](https://wrtnlabs.io/autobe/docs/setup)
+- 🙋🏻‍♂️ [Introduction](https://autobe.dev/docs)
+- 📦 [Setup](https://autobe.dev/docs/setup)
 - 🔍 Concepts
-  - [Waterfall Model](https://wrtnlabs.io/autobe/docs/concepts/waterfall)
-  - [Compiler Strategy](https://wrtnlabs.io/autobe/docs/concepts/compiler)
-  - [AI Function Calling](https://wrtnlabs.io/autobe/docs/concepts/function-calling)
+  - [Waterfall Model](https://autobe.dev/docs/concepts/waterfall)
+  - [Compiler Strategy](https://autobe.dev/docs/concepts/compiler)
+  - [AI Function Calling](https://autobe.dev/docs/concepts/function-calling)
 
 ### 📖 Features
 
 - 🤖 Agent Library
-  - [Facade Controller](https://wrtnlabs.io/autobe/docs/agent/facade)
-  - [Configuration](https://wrtnlabs.io/autobe/docs/agent/config)
-  - [Event Handling](https://wrtnlabs.io/autobe/docs/agent/event)
-  - [Prompt Histories](https://wrtnlabs.io/autobe/docs/agent/history)
+  - [Facade Controller](https://autobe.dev/docs/agent/facade)
+  - [Configuration](https://autobe.dev/docs/agent/config)
+  - [Event Handling](https://autobe.dev/docs/agent/event)
+  - [Prompt Histories](https://autobe.dev/docs/agent/history)
 - 📡 WebSocket Protocol
-  - [Remote Procedure Call](https://wrtnlabs.io/autobe/docs/websocket/rpc)
-  - [NestJS Server](https://wrtnlabs.io/autobe/docs/websocket/nestjs)
-  - [NodeJS Server](https://wrtnlabs.io/autobe/docs/websocket/nodejs)
-  - [Client Application](https://wrtnlabs.io/autobe/docs/websocket/client)
+  - [Remote Procedure Call](https://autobe.dev/docs/websocket/rpc)
+  - [NestJS Server](https://autobe.dev/docs/websocket/nestjs)
+  - [NodeJS Server](https://autobe.dev/docs/websocket/nodejs)
+  - [Client Application](https://autobe.dev/docs/websocket/client)
 - 🛠️ Backend Stack
-  - [TypeScript](https://wrtnlabs.io/autobe/docs/stack/typescript)
-  - [Prisma ORM](https://wrtnlabs.io/autobe/docs/stack/prisma)
-  - [NestJS Framework](https://wrtnlabs.io/autobe/docs/stack/nestjs)
+  - [TypeScript](https://autobe.dev/docs/stack/typescript)
+  - [Prisma ORM](https://autobe.dev/docs/stack/prisma)
+  - [NestJS Framework](https://autobe.dev/docs/stack/nestjs)
 
 ### 🔗 Appendix
 
-- 🌐 [No-Code Ecosystem](https://wrtnlabs.io/autobe/docs/ecosystem)
+- 🌐 [No-Code Ecosystem](https://autobe.dev/docs/ecosystem)
 - 📅 Roadmap
-  - [Alpha Release (completed)](https://wrtnlabs.io/autobe/docs/roadmap/alpha)
-  - [Beta Release (in progress)](https://wrtnlabs.io/autobe/docs/roadmap/beta)
-  - [v1.0 Official Release (planned)](https://wrtnlabs.io/autobe/docs/roadmap/v1.0)
-- 🔧 [API Documentation](https://wrtnlabs.io/autobe/api)
+  - [Alpha Release (completed)](https://autobe.dev/docs/roadmap/alpha)
+  - [Beta Release (in progress)](https://autobe.dev/docs/roadmap/beta)
+  - [v1.0 Official Release (planned)](https://autobe.dev/docs/roadmap/v1.0)
+- 🔧 [API Documentation](https://autobe.dev/api)
 
 ## No-Code Ecosystem
 

--- a/apps/playground-server/README.md
+++ b/apps/playground-server/README.md
@@ -27,7 +27,7 @@ end
 [![NPM Version](https://img.shields.io/npm/v/@autobe/agent.svg)](https://www.npmjs.com/package/@autobe/agent)
 [![NPM Downloads](https://img.shields.io/npm/dm/@autobe/agent.svg)](https://www.npmjs.com/package/@autobe/agent)
 [![Build Status](https://github.com/wrtnlabs/autobe/workflows/build/badge.svg)](https://github.com/wrtnlabs/autobe/actions?query=workflow%3Abuild)
-[![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://wrtnlabs.io/autobe/docs/)
+[![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://autobe.dev/docs/)
 [![Discord Badge](https://dcbadge.limes.pink/api/server/https://discord.gg/aMhRmzkqCx?style=flat)](https://discord.gg/aMhRmzkqCx)
 
 [![Fund Raising News](https://wrtnlabs.io/agentica/images/badges/fund-raising-news-202503.svg)](https://www.bloomberg.com/news/videos/2025-03-31/wtrn-on-series-b-funding-growth-strategy-video)
@@ -85,42 +85,42 @@ pnpm run playground
 
 ## Documentation Resources
 
-Find comprehensive resources at our [official website](https://wrtnlabs.io/autobe).
+Find comprehensive resources at our [official website](https://autobe.dev).
 
 ### 🏠 Home
 
-- 🙋🏻‍♂️ [Introduction](https://wrtnlabs.io/autobe/docs)
-- 📦 [Setup](https://wrtnlabs.io/autobe/docs/setup)
+- 🙋🏻‍♂️ [Introduction](https://autobe.dev/docs)
+- 📦 [Setup](https://autobe.dev/docs/setup)
 - 🔍 Concepts
-  - [Waterfall Model](https://wrtnlabs.io/autobe/docs/concepts/waterfall)
-  - [Compiler Strategy](https://wrtnlabs.io/autobe/docs/concepts/compiler)
-  - [AI Function Calling](https://wrtnlabs.io/autobe/docs/concepts/function-calling)
+  - [Waterfall Model](https://autobe.dev/docs/concepts/waterfall)
+  - [Compiler Strategy](https://autobe.dev/docs/concepts/compiler)
+  - [AI Function Calling](https://autobe.dev/docs/concepts/function-calling)
 
 ### 📖 Features
 
 - 🤖 Agent Library
-  - [Facade Controller](https://wrtnlabs.io/autobe/docs/agent/facade)
-  - [Configuration](https://wrtnlabs.io/autobe/docs/agent/config)
-  - [Event Handling](https://wrtnlabs.io/autobe/docs/agent/event)
-  - [Prompt Histories](https://wrtnlabs.io/autobe/docs/agent/history)
+  - [Facade Controller](https://autobe.dev/docs/agent/facade)
+  - [Configuration](https://autobe.dev/docs/agent/config)
+  - [Event Handling](https://autobe.dev/docs/agent/event)
+  - [Prompt Histories](https://autobe.dev/docs/agent/history)
 - 📡 WebSocket Protocol
-  - [Remote Procedure Call](https://wrtnlabs.io/autobe/docs/websocket/rpc)
-  - [NestJS Server](https://wrtnlabs.io/autobe/docs/websocket/nestjs)
-  - [NodeJS Server](https://wrtnlabs.io/autobe/docs/websocket/nodejs)
-  - [Client Application](https://wrtnlabs.io/autobe/docs/websocket/client)
+  - [Remote Procedure Call](https://autobe.dev/docs/websocket/rpc)
+  - [NestJS Server](https://autobe.dev/docs/websocket/nestjs)
+  - [NodeJS Server](https://autobe.dev/docs/websocket/nodejs)
+  - [Client Application](https://autobe.dev/docs/websocket/client)
 - 🛠️ Backend Stack
-  - [TypeScript](https://wrtnlabs.io/autobe/docs/stack/typescript)
-  - [Prisma ORM](https://wrtnlabs.io/autobe/docs/stack/prisma)
-  - [NestJS Framework](https://wrtnlabs.io/autobe/docs/stack/nestjs)
+  - [TypeScript](https://autobe.dev/docs/stack/typescript)
+  - [Prisma ORM](https://autobe.dev/docs/stack/prisma)
+  - [NestJS Framework](https://autobe.dev/docs/stack/nestjs)
 
 ### 🔗 Appendix
 
-- 🌐 [No-Code Ecosystem](https://wrtnlabs.io/autobe/docs/ecosystem)
+- 🌐 [No-Code Ecosystem](https://autobe.dev/docs/ecosystem)
 - 📅 Roadmap
-  - [Alpha Release (completed)](https://wrtnlabs.io/autobe/docs/roadmap/alpha)
-  - [Beta Release (in progress)](https://wrtnlabs.io/autobe/docs/roadmap/beta)
-  - [v1.0 Official Release (planned)](https://wrtnlabs.io/autobe/docs/roadmap/v1.0)
-- 🔧 [API Documentation](https://wrtnlabs.io/autobe/api)
+  - [Alpha Release (completed)](https://autobe.dev/docs/roadmap/alpha)
+  - [Beta Release (in progress)](https://autobe.dev/docs/roadmap/beta)
+  - [v1.0 Official Release (planned)](https://autobe.dev/docs/roadmap/v1.0)
+- 🔧 [API Documentation](https://autobe.dev/api)
 
 ## No-Code Ecosystem
 

--- a/apps/playground-ui/README.md
+++ b/apps/playground-ui/README.md
@@ -27,7 +27,7 @@ end
 [![NPM Version](https://img.shields.io/npm/v/@autobe/agent.svg)](https://www.npmjs.com/package/@autobe/agent)
 [![NPM Downloads](https://img.shields.io/npm/dm/@autobe/agent.svg)](https://www.npmjs.com/package/@autobe/agent)
 [![Build Status](https://github.com/wrtnlabs/autobe/workflows/build/badge.svg)](https://github.com/wrtnlabs/autobe/actions?query=workflow%3Abuild)
-[![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://wrtnlabs.io/autobe/docs/)
+[![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://autobe.dev/docs/)
 [![Discord Badge](https://dcbadge.limes.pink/api/server/https://discord.gg/aMhRmzkqCx?style=flat)](https://discord.gg/aMhRmzkqCx)
 
 [![Fund Raising News](https://wrtnlabs.io/agentica/images/badges/fund-raising-news-202503.svg)](https://www.bloomberg.com/news/videos/2025-03-31/wtrn-on-series-b-funding-growth-strategy-video)
@@ -85,42 +85,42 @@ pnpm run playground
 
 ## Documentation Resources
 
-Find comprehensive resources at our [official website](https://wrtnlabs.io/autobe).
+Find comprehensive resources at our [official website](https://autobe.dev).
 
 ### 🏠 Home
 
-- 🙋🏻‍♂️ [Introduction](https://wrtnlabs.io/autobe/docs)
-- 📦 [Setup](https://wrtnlabs.io/autobe/docs/setup)
+- 🙋🏻‍♂️ [Introduction](https://autobe.dev/docs)
+- 📦 [Setup](https://autobe.dev/docs/setup)
 - 🔍 Concepts
-  - [Waterfall Model](https://wrtnlabs.io/autobe/docs/concepts/waterfall)
-  - [Compiler Strategy](https://wrtnlabs.io/autobe/docs/concepts/compiler)
-  - [AI Function Calling](https://wrtnlabs.io/autobe/docs/concepts/function-calling)
+  - [Waterfall Model](https://autobe.dev/docs/concepts/waterfall)
+  - [Compiler Strategy](https://autobe.dev/docs/concepts/compiler)
+  - [AI Function Calling](https://autobe.dev/docs/concepts/function-calling)
 
 ### 📖 Features
 
 - 🤖 Agent Library
-  - [Facade Controller](https://wrtnlabs.io/autobe/docs/agent/facade)
-  - [Configuration](https://wrtnlabs.io/autobe/docs/agent/config)
-  - [Event Handling](https://wrtnlabs.io/autobe/docs/agent/event)
-  - [Prompt Histories](https://wrtnlabs.io/autobe/docs/agent/history)
+  - [Facade Controller](https://autobe.dev/docs/agent/facade)
+  - [Configuration](https://autobe.dev/docs/agent/config)
+  - [Event Handling](https://autobe.dev/docs/agent/event)
+  - [Prompt Histories](https://autobe.dev/docs/agent/history)
 - 📡 WebSocket Protocol
-  - [Remote Procedure Call](https://wrtnlabs.io/autobe/docs/websocket/rpc)
-  - [NestJS Server](https://wrtnlabs.io/autobe/docs/websocket/nestjs)
-  - [NodeJS Server](https://wrtnlabs.io/autobe/docs/websocket/nodejs)
-  - [Client Application](https://wrtnlabs.io/autobe/docs/websocket/client)
+  - [Remote Procedure Call](https://autobe.dev/docs/websocket/rpc)
+  - [NestJS Server](https://autobe.dev/docs/websocket/nestjs)
+  - [NodeJS Server](https://autobe.dev/docs/websocket/nodejs)
+  - [Client Application](https://autobe.dev/docs/websocket/client)
 - 🛠️ Backend Stack
-  - [TypeScript](https://wrtnlabs.io/autobe/docs/stack/typescript)
-  - [Prisma ORM](https://wrtnlabs.io/autobe/docs/stack/prisma)
-  - [NestJS Framework](https://wrtnlabs.io/autobe/docs/stack/nestjs)
+  - [TypeScript](https://autobe.dev/docs/stack/typescript)
+  - [Prisma ORM](https://autobe.dev/docs/stack/prisma)
+  - [NestJS Framework](https://autobe.dev/docs/stack/nestjs)
 
 ### 🔗 Appendix
 
-- 🌐 [No-Code Ecosystem](https://wrtnlabs.io/autobe/docs/ecosystem)
+- 🌐 [No-Code Ecosystem](https://autobe.dev/docs/ecosystem)
 - 📅 Roadmap
-  - [Alpha Release (completed)](https://wrtnlabs.io/autobe/docs/roadmap/alpha)
-  - [Beta Release (in progress)](https://wrtnlabs.io/autobe/docs/roadmap/beta)
-  - [v1.0 Official Release (planned)](https://wrtnlabs.io/autobe/docs/roadmap/v1.0)
-- 🔧 [API Documentation](https://wrtnlabs.io/autobe/api)
+  - [Alpha Release (completed)](https://autobe.dev/docs/roadmap/alpha)
+  - [Beta Release (in progress)](https://autobe.dev/docs/roadmap/beta)
+  - [v1.0 Official Release (planned)](https://autobe.dev/docs/roadmap/v1.0)
+- 🔧 [API Documentation](https://autobe.dev/api)
 
 ## No-Code Ecosystem
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,7 +4,7 @@
   "version": "0.21.0",
   "description": "AutoBE UI",
   "author": "Wrtn Technologies",
-  "homepage": "https://wrtnlabs.io/autobe",
+  "homepage": "https://autobe.dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/wrtnlabs/autobe.git"

--- a/website/next-sitemap.config.js
+++ b/website/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import("next-sitemap").IConfig} */
 module.exports = {
-  siteUrl: "https://wrtnlabs.io/autobe",
+  siteUrl: "https://autobe.dev",
   generateRobotsTxt: true,
   outDir: "./out",
 };

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -7,7 +7,6 @@ const withNextra = nextra({
 // You can include other Next.js configuration options here, in addition to Nextra settings:
 export default withNextra({
   // ... Other Next.js config options
-  basePath: "/autobe",
   output: "export",
   trailingSlash: true,
   images: {

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/wrtnlabs/autobe/issues"
   },
-  "homepage": "https://wrtnlabs.io/autobe",
+  "homepage": "https://autobe.dev",
   "dependencies": {
     "next": "^15.1.0",
     "nextra": "^4.2.17",

--- a/website/src/app/layout.jsx
+++ b/website/src/app/layout.jsx
@@ -40,11 +40,11 @@ export default async function RootLayout(props) {
         // }}
       >
         {/* ICONS */}
-        <link rel="manifest" href="/autobe/favicon/site.webmanifest" />
+        <link rel="manifest" href="/favicon/site.webmanifest" />
         <link
           rel="apple-touch-icon"
           sizes="180x180"
-          href="/autobe/favicon/apple-touch-icon.png"
+          href="/favicon/apple-touch-icon.png"
         />
         {[16, 32].map((size) => (
           <link
@@ -52,14 +52,14 @@ export default async function RootLayout(props) {
             rel="icon"
             type="image/png"
             sizes={`${size}x${size}`}
-            href={`/autobe/favicon/favicon-${size}x${size}.png`}
+            href={`/favicon/favicon-${size}x${size}.png`}
           />
         ))}
         {/* OG */}
         <meta name="og:type" content="object" />
         <meta name="og:site_name" content="AutoBE Guide Documents" />
-        <meta name="og:url" content="https://wrtnlabs.io/autobe" />
-        <meta name="og:image" content="https://wrtnlabs.io/autobe/og.jpg" />
+        <meta name="og:url" content="https://autobe.dev" />
+        <meta name="og:image" content="https://autobe.dev/og.jpg" />
         <meta name="og:title" content="AutoBE Guide Documents" />
         <meta
           name="og:description"
@@ -70,7 +70,7 @@ export default async function RootLayout(props) {
         <meta name="twitter:site" content="@SamchonGithub" />
         <meta
           name="twitter:image"
-          content="https://wrtnlabs.io/autobe/og.jpg"
+          content="https://autobe.dev/og.jpg"
         />
         <meta name="twitter:title" content="AutoBE Guide Documents" />
         <meta

--- a/website/src/content/docs/agent/event.mdx
+++ b/website/src/content/docs/agent/event.mdx
@@ -106,15 +106,15 @@ These events are essential for building interactive interfaces, logging conversa
 
 ```mermaid
 flowchart LR
-  start[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeAnalyzeStartEvent.html" target="_blank"><u>Start</u></a>] --"draft"--> write[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeAnalyzeWriteEvent.html" target="_blank"><u>Write</u></a>]
-  write --"amends"--> review[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeAnalyzeReviewEvent.html" target="_blank"><u>Review</u></a>]
-  review --"finalize"--> complete[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeAnalyzeCompleteEvent.html" target="_blank"><u>Complete</u></a>]
+  start[<a href="/api/interfaces/_autobe_interface.AutoBeAnalyzeStartEvent.html" target="_blank"><u>Start</u></a>] --"draft"--> write[<a href="/api/interfaces/_autobe_interface.AutoBeAnalyzeWriteEvent.html" target="_blank"><u>Write</u></a>]
+  write --"amends"--> review[<a href="/api/interfaces/_autobe_interface.AutoBeAnalyzeReviewEvent.html" target="_blank"><u>Review</u></a>]
+  review --"finalize"--> complete[<a href="/api/interfaces/_autobe_interface.AutoBeAnalyzeCompleteEvent.html" target="_blank"><u>Complete</u></a>]
   complete --"publishes" --> report(Report)
 ```
 
 Analyze events track the requirements analysis process, which follows a structured workflow from initial drafting to final completion. 
 
-The [`AutoBeAnalyzeStartEvent`](/autobe/api/interfaces/_autobe_interface.AutoBeAnalyzeStartEvent.html) event is fired when the agent begins drafting the requirements analysis. The [`AutoBeAnalyzeWriteEvent`](/autobe/api/interfaces/_autobe_interface.AutoBeAnalyzeWriteEvent.html) event occurs during the writing phase, followed by [`AutoBeAnalyzeReviewEvent`](/autobe/api/interfaces/_autobe_interface.AutoBeAnalyzeReviewEvent.html) during the review and amendment process. Finally, [`AutoBeAnalyzeCompleteEvent`](/autobe/api/interfaces/_autobe_interface.AutoBeAnalyzeCompleteEvent.html) is fired when the requirements analysis report is finalized.
+The [`AutoBeAnalyzeStartEvent`](/api/interfaces/_autobe_interface.AutoBeAnalyzeStartEvent.html) event is fired when the agent begins drafting the requirements analysis. The [`AutoBeAnalyzeWriteEvent`](/api/interfaces/_autobe_interface.AutoBeAnalyzeWriteEvent.html) event occurs during the writing phase, followed by [`AutoBeAnalyzeReviewEvent`](/api/interfaces/_autobe_interface.AutoBeAnalyzeReviewEvent.html) during the review and amendment process. Finally, [`AutoBeAnalyzeCompleteEvent`](/api/interfaces/_autobe_interface.AutoBeAnalyzeCompleteEvent.html) is fired when the requirements analysis report is finalized.
 
 [`AutoBeAnalyzeCompleteEvent`](/api/interfaces/_autobe_interface.AutoBeAnalyzeCompleteEvent.html) is generated when the `@autobe` agent and user have completed all discussions regarding requirements, and a report has been issued. The report consists of multiple markdown documents, which are stored in the `files` property.
 
@@ -163,11 +163,11 @@ The `step` property indicates which iteration of the requirements analysis repor
 
 ```mermaid
 flowchart LR
-  start[<a href="/autobe/api/interfaces/_autobe_interface.AutoBePrismaStartEvent.html" target="_blank"><u>Start</u></a>] --"lists"--> components[<a href="/autobe/api/interfaces/_autobe_interface.AutoBePrismaComponentsEvent.html" target="_blank"><u>Components</u></a>]
-  components --"designs"--> schemas[<a href="/autobe/api/interfaces/_autobe_interface.AutoBePrismaSchemasEvent.html" target="_blank"><u>Schemas</u></a>]
-  components --"compiles"--> validate[<a href="/autobe/api/interfaces/_autobe_interface.AutoBePrismaValidateEvent.html" target="_blank"><u>Validate</u></a>]
-  validate --"failure"--> correct[<a href="/autobe/api/interfaces/_autobe_interface.AutoBePrismaCorrectEvent.html" target="_blank"><u>Correct</u></a>]
-  validate --"success" --> complete[<a href="/autobe/api/interfaces/_autobe_interface.AutoBePrismaCompleteEvent.html" target="_blank"><u>Complete</u></a>]
+  start[<a href="/api/interfaces/_autobe_interface.AutoBePrismaStartEvent.html" target="_blank"><u>Start</u></a>] --"lists"--> components[<a href="/api/interfaces/_autobe_interface.AutoBePrismaComponentsEvent.html" target="_blank"><u>Components</u></a>]
+  components --"designs"--> schemas[<a href="/api/interfaces/_autobe_interface.AutoBePrismaSchemasEvent.html" target="_blank"><u>Schemas</u></a>]
+  components --"compiles"--> validate[<a href="/api/interfaces/_autobe_interface.AutoBePrismaValidateEvent.html" target="_blank"><u>Validate</u></a>]
+  validate --"failure"--> correct[<a href="/api/interfaces/_autobe_interface.AutoBePrismaCorrectEvent.html" target="_blank"><u>Correct</u></a>]
+  validate --"success" --> complete[<a href="/api/interfaces/_autobe_interface.AutoBePrismaCompleteEvent.html" target="_blank"><u>Complete</u></a>]
   complete --"generates"--> prisma(Prisma Schema)
 ```
 
@@ -221,12 +221,12 @@ The `step` property indicates which requirements analysis report iteration the d
 
 ```mermaid
 flowchart LR
-  start[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeInterfaceStartEvent.html" target="_blank"><u>Start</u></a>] --"lists"--> endpoints[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeInterfaceEndpointsEvent.html" target="_blank"><u>Endpoints</u></a>]
-  endpoints --"designs"--> operations[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeInterfaceOperationsEvent.html" target="_blank"><u>Operations</u></a>]
-  endpoints --"schemas"--> components[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeInterfaceSchemasEvent.html" target="_blank"><u>Components</u></a>]
-  endpoints --"fills"--> complement[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeInterfaceComplementEvent.html" target="_blank"><u>Complement</u></a>]
-  endpoints --"compiles"--> complete[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeInterfaceCompleteEvent.html" target="_blank"><u>Complete</u></a>]
-  complete --"composes"--> document(<a href="/autobe/api/interfaces/_autobe_interface.AutoBeOpenApi.IDocument.html" target="_blank"><u>OpenAPI</u></a>)
+  start[<a href="/api/interfaces/_autobe_interface.AutoBeInterfaceStartEvent.html" target="_blank"><u>Start</u></a>] --"lists"--> endpoints[<a href="/api/interfaces/_autobe_interface.AutoBeInterfaceEndpointsEvent.html" target="_blank"><u>Endpoints</u></a>]
+  endpoints --"designs"--> operations[<a href="/api/interfaces/_autobe_interface.AutoBeInterfaceOperationsEvent.html" target="_blank"><u>Operations</u></a>]
+  endpoints --"schemas"--> components[<a href="/api/interfaces/_autobe_interface.AutoBeInterfaceSchemasEvent.html" target="_blank"><u>Components</u></a>]
+  endpoints --"fills"--> complement[<a href="/api/interfaces/_autobe_interface.AutoBeInterfaceComplementEvent.html" target="_blank"><u>Complement</u></a>]
+  endpoints --"compiles"--> complete[<a href="/api/interfaces/_autobe_interface.AutoBeInterfaceCompleteEvent.html" target="_blank"><u>Complete</u></a>]
+  complete --"composes"--> document(<a href="/api/interfaces/_autobe_interface.AutoBeOpenApi.IDocument.html" target="_blank"><u>OpenAPI</u></a>)
   document --"generates"--> nestjs(NestJS Project)
 ```
 
@@ -271,11 +271,11 @@ The `step` property indicates which requirements analysis report iteration the A
 
 ```mermaid
 flowchart LR
-  start[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeTestStartEvent.html" target="_blank"><u>Start</u></a>] --"plans"--> scenarios[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeTestScenariosEvent.html" target="_blank"><u>Scenarios</u></a>]
-  scenarios --"coding"--> progress[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeTestWriteEvent.html" target="_blank"><u>Progress</u></a>]
-  scenarios --"compiles"--> validate[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeTestValidateEvent.html" target="_blank"><u>Validate</u></a>]
-  validate --"failure"--> correct[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeTestCorrectEvent.html" target="_blank"><u>Correct</u></a>]
-  validate --"success"--> complete[<a href="/autobe/api/interfaces/_autobe_interface.AutoBeTestCompleteEvent.html" target="_blank"><u>Complete</u></a>]
+  start[<a href="/api/interfaces/_autobe_interface.AutoBeTestStartEvent.html" target="_blank"><u>Start</u></a>] --"plans"--> scenarios[<a href="/api/interfaces/_autobe_interface.AutoBeTestScenariosEvent.html" target="_blank"><u>Scenarios</u></a>]
+  scenarios --"coding"--> progress[<a href="/api/interfaces/_autobe_interface.AutoBeTestWriteEvent.html" target="_blank"><u>Progress</u></a>]
+  scenarios --"compiles"--> validate[<a href="/api/interfaces/_autobe_interface.AutoBeTestValidateEvent.html" target="_blank"><u>Validate</u></a>]
+  validate --"failure"--> correct[<a href="/api/interfaces/_autobe_interface.AutoBeTestCorrectEvent.html" target="_blank"><u>Correct</u></a>]
+  validate --"success"--> complete[<a href="/api/interfaces/_autobe_interface.AutoBeTestCompleteEvent.html" target="_blank"><u>Complete</u></a>]
 ```
 
 Test events monitor the e2e test code generation process.

--- a/website/src/content/docs/hackathon/index.mdx
+++ b/website/src/content/docs/hackathon/index.mdx
@@ -308,7 +308,7 @@ AI-assisted review writing is not allowed. The core purpose of this hackathon is
 
 ### 8.5. Judging and Announcement
 
-Judging will proceed for 2 weeks after submission deadline, with results announced via individual email and official website (https://wrtnlabs.io/autobe). Judging will be conducted jointly by the AutoBE development team and external experts, comprehensively evaluating review professionalism, specificity, practicality, and balance.
+Judging will proceed for 2 weeks after submission deadline, with results announced via individual email and official website (https://autobe.dev). Judging will be conducted jointly by the AutoBE development team and external experts, comprehensively evaluating review professionalism, specificity, practicality, and balance.
 
 Prizes will be paid within one week after results announcement, and you must submit account information capable of international transfers. Tax issues must be handled directly by recipients, and we'll provide necessary documents.
 


### PR DESCRIPTION
This pull request updates all references to the project's documentation and website URLs to use the new `autobe.dev` domain instead of the previous `wrtnlabs.io/autobe` domain. The changes ensure consistency across documentation, badges, configuration files, and in-app links, improving the user experience and avoiding broken or outdated links.

**Website and Documentation URL Updates:**

* Updated all documentation, guide, and resource links in `README.md`, `apps/playground-server/README.md`, and `apps/playground-ui/README.md` to point to `https://autobe.dev` and its subpages instead of `https://wrtnlabs.io/autobe`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R121) [[3]](diffhunk://#diff-3caab2f66b04569920f1c4e23afb34ee0c1147efb00b6126ae468526194883a6L30-R30) [[4]](diffhunk://#diff-3caab2f66b04569920f1c4e23afb34ee0c1147efb00b6126ae468526194883a6L88-R123)
* Changed the homepage field in `packages/ui/package.json` and `website/package.json` to `https://autobe.dev`. [[1]](diffhunk://#diff-1ae5a5e8c23bd3bc31ea590a9cbe48eb9ad3bbddc0fb5732d08c04a53c8ad51dL7-R7) [[2]](diffhunk://#diff-fae242fbf77a8a9d52625664bc36ea12316586f8a716b41137d897a2b7e3df76L26-R26)
* Updated the `siteUrl` in `website/next-sitemap.config.js` to `https://autobe.dev`.
* Removed the `basePath` setting in `website/next.config.ts` to reflect the new root path.

**Meta Tags and Icons:**

* Modified favicon and Open Graph meta tag URLs in `website/src/app/layout.jsx` to use the new domain and root-relative paths. [[1]](diffhunk://#diff-e09713bbee82aaea6510ccf903e3f1c2fcbb27ecb0d56ad5c6478f214d39409bL43-R62) [[2]](diffhunk://#diff-e09713bbee82aaea6510ccf903e3f1c2fcbb27ecb0d56ad5c6478f214d39409bL73-R73)

**In-Documentation Internal Links:**

* Updated all in-content API and documentation links in `website/src/content/docs/agent/event.mdx` to use the new `/api/` path, removing the `/autobe` prefix. [[1]](diffhunk://#diff-7a20ed4f6a3bb3acb934f7d0c2a8809ab77a948f835fd40aa21cf04faf5412bfL109-R117) [[2]](diffhunk://#diff-7a20ed4f6a3bb3acb934f7d0c2a8809ab77a948f835fd40aa21cf04faf5412bfL166-R170)

**Other Documentation:**

* Updated the documentation link in `CLAUDE.md` to the new domain.