### PR TITLE
fix(agent): `prisma_schemas` does not exist on operation.

### DIFF
--- a/packages/agent/prompts/INTERFACE_OPERATION.md
+++ b/packages/agent/prompts/INTERFACE_OPERATION.md
@@ -54,7 +54,6 @@ Analyze the provided information and generate complete API operations that trans
 - Keys are model names (e.g., "User", "Post", "Customer")
 - Values are the complete Prisma model definitions including all fields and relations
 - This is your AUTHORITATIVE SOURCE for all database structure information
-- When filling the `prisma_schemas` field for each operation, extract relevant models from this source
 
 ## 2.2. Operation Design Philosophy
 
@@ -516,39 +515,6 @@ Use actual role names from the Prisma schema. Common patterns:
   
   path: "/customers",
   method: "patch",
-  
-  prisma_schemas: `
-    model Customer {
-      id            String    @id @default(uuid())
-      email         String    @unique
-      name          String
-      phone         String?
-      address       String?
-      status        String    @default("active") // active, inactive, suspended
-      created_at    DateTime  @default(now())
-      updated_at    DateTime  @updatedAt
-      deleted_at    DateTime? // Soft-delete field for logical deletion
-      
-      orders        Order[]
-      reviews       Review[]
-      cart_items    CartItem[]
-      
-      @@index([email])
-      @@index([created_at])
-      @@index([deleted_at])
-    }
-    
-    model Order {
-      id            String    @id @default(uuid())
-      customer_id   String
-      customer      Customer  @relation(fields: [customer_id], references: [id])
-      total_amount  Float
-      status        String    // pending, confirmed, shipped, delivered, cancelled
-      created_at    DateTime  @default(now())
-      
-      @@index([customer_id])
-    }
-  `,
   
   description: `Retrieve a filtered and paginated list of shopping customer accounts from the system. This operation provides advanced search capabilities for finding customers based on multiple criteria including partial name matching, email domain filtering, registration date ranges, and account status.
 

--- a/packages/agent/prompts/INTERFACE_OPERATION_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_OPERATION_REVIEW.md
@@ -40,8 +40,6 @@ You will receive:
 1. **Original Requirements**: The requirements analysis document
 2. **Prisma Schema**: The database schema definitions
 3. **Generated Operations**: The API operations created by the Interface Agent
-   - Each operation includes a `prisma_schemas` field containing relevant Prisma models
-   - This field shows the exact database structure including soft-delete fields if they exist
 4. **Original Prompt**: The INTERFACE_OPERATION.md guidelines
 5. **Fixed Endpoint List**: The predetermined endpoint list that CANNOT be modified
 
@@ -195,9 +193,9 @@ When you find system-generated data manipulation:
 **⚠️ CRITICAL WARNING**: The most common and dangerous error is DELETE operations mentioning soft delete when the schema doesn't support it!
 
 - [ ] **FIRST PRIORITY - Schema Analysis**: 
-  - **MUST** analyze the `prisma_schemas` field in EACH operation BEFORE reviewing delete operations
+  - **MUST** analyze the Prisma schema BEFORE reviewing delete operations
   - Look for ANY field that could support soft delete (deleted, deleted_at, is_deleted, is_active, archived, removed_at, etc.)
-  - The `prisma_schemas` field contains the EXACT Prisma models - use this as your source of truth
+  - Use the provided Prisma schema as your source of truth
   - If NO such fields exist → The schema ONLY supports hard delete
   
 - [ ] **Delete Operation Description Verification**:
@@ -250,13 +248,12 @@ When you find system-generated data manipulation:
 - [ ] Rate limiting considerations mentioned for expensive operations
 
 ### 5.2. Schema Compliance Checklist
-- [ ] All operation fields reference ONLY actual Prisma schema fields (check `prisma_schemas` field)
+- [ ] All operation fields reference ONLY actual Prisma schema fields
 - [ ] No assumptions about fields not in schema (deleted_at, created_by, etc.)
-- [ ] Delete operations align with actual schema capabilities (verify in `prisma_schemas` field)
+- [ ] Delete operations align with actual schema capabilities
 - [ ] Required fields handled in create operations
 - [ ] Unique constraints respected in operations
 - [ ] Foreign key relationships valid
-- [ ] **Schema Verification**: Used `prisma_schemas` field to validate all field references
 
 ### 5.3. Logical Consistency Checklist
 - [ ] Return types match operation purpose:
@@ -378,7 +375,7 @@ Example: "DELETE /users operation tries to set deleted_at field, but User model 
 
 **Prisma Schema Context**:
 ```prisma
-[Relevant portion from prisma_schemas field]
+[Relevant portion from provided Prisma schema]
 ```
 
 **Security Review**:
@@ -391,10 +388,10 @@ Example: "DELETE /users operation tries to set deleted_at field, but User model 
 - [ ] Operation Purpose Match: [PASS/FAIL - details]
 - [ ] HTTP Method Semantics: [PASS/FAIL - details]
 
-**Schema Compliance** (Validated against `prisma_schemas` field):
-- [ ] Field References: [PASS/FAIL - details based on prisma_schemas]
-- [ ] Type Accuracy: [PASS/FAIL - details based on prisma_schemas]
-- [ ] Delete Pattern: [PASS/FAIL - verified soft-delete fields in prisma_schemas]
+**Schema Compliance**:
+- [ ] Field References: [PASS/FAIL - details]
+- [ ] Type Accuracy: [PASS/FAIL - details]
+- [ ] Delete Pattern: [PASS/FAIL - verified soft-delete fields in schema]
 
 **Issues Found**:
 1. [CRITICAL/MAJOR/MINOR] - [Issue description]
@@ -533,26 +530,13 @@ const reviewedOperations = [
 
 ## 12. Example Operation Review
 
-Here's an example of how to review an operation with the `prisma_schemas` field:
+Here's an example of how to review an operation:
 
 ### Original Operation
 ```typescript
 {
   path: "/customers",
   method: "delete",
-  
-  prisma_schemas: `
-    model Customer {
-      id            String    @id @default(uuid())
-      email         String    @unique
-      name          String
-      created_at    DateTime  @default(now())
-      updated_at    DateTime  @updatedAt
-      // Note: NO deleted_at field - only hard delete is possible
-      
-      orders        Order[]
-    }
-  `,
   
   description: "Soft delete a customer by marking them as deleted. This operation sets the deleted_at timestamp to the current time, preserving the customer record for audit purposes while excluding them from normal queries.",
   
@@ -572,7 +556,7 @@ Here's an example of how to review an operation with the `prisma_schemas` field:
 **❌ CRITICAL SCHEMA VIOLATION DETECTED**
 
 **Prisma Schema Analysis**:
-- Examined `prisma_schemas` field for Customer model
+- Examined Customer model in provided schema
 - **NO soft-delete fields found** (no deleted_at, is_deleted, archived, etc.)
 - Schema only supports **hard delete** (permanent removal)
 
@@ -602,15 +586,13 @@ Here's an example of how to review an operation with the `prisma_schemas` field:
   path: "/users", 
   method: "delete",
   
-  prisma_schemas: `
-    model User {
-      id            String    @id @default(uuid())
-      email         String    @unique
-      deleted_at    DateTime? // ✅ Soft-delete field EXISTS
-      
-      posts         Post[]
-    }
-  `,
+  // Assume schema has:
+  // model User {
+  //   id            String    @id @default(uuid())
+  //   email         String    @unique
+  //   deleted_at    DateTime? // ✅ Soft-delete field EXISTS
+  //   posts         Post[]
+  // }
   
   description: "Soft delete a user by setting the deleted_at timestamp. The user record is preserved for audit purposes but excluded from normal queries. Users can be restored by clearing the deleted_at field.",
   

--- a/test/src/internal/TestLogger.ts
+++ b/test/src/internal/TestLogger.ts
@@ -19,6 +19,7 @@ export namespace TestLogger {
       );
     else if (event.type === "jsonValidateError")
       content.push(
+        event.source,
         "  - typia.validate<T>()",
         ...event.result.errors.map(
           (v) => `    - ${v.path}: ${v.expected} (${JSON.stringify(v.value)})`,


### PR DESCRIPTION
This pull request updates the documentation for API operation design and review to simplify references to the Prisma schema and remove the `prisma_schemas` field from examples and instructions. The changes clarify that reviewers should use the provided Prisma schema directly as the source of truth, rather than relying on a `prisma_schemas` field embedded in each operation.

**Documentation simplification and schema reference updates:**

* Removed instructions and examples referencing the `prisma_schemas` field in both `INTERFACE_OPERATION.md` and `INTERFACE_OPERATION_REVIEW.md`, shifting guidance to use the provided Prisma schema directly as the authoritative source for model definitions and schema validation. [[1]](diffhunk://#diff-ebb95536e362925acc78f439c515010f5460944a1907e3e411a6261fe3cbc217L57) [[2]](diffhunk://#diff-5d2ac09af1ba2ff45329a4412194ca5cea764580c5dcdeacbb970de0e9d3380aL43-L44) [[3]](diffhunk://#diff-5d2ac09af1ba2ff45329a4412194ca5cea764580c5dcdeacbb970de0e9d3380aL198-R198) [[4]](diffhunk://#diff-5d2ac09af1ba2ff45329a4412194ca5cea764580c5dcdeacbb970de0e9d3380aL253-L259)
* Updated schema analysis and compliance checklists to reference the provided Prisma schema instead of the `prisma_schemas` field, including all relevant verification steps and checklist items. [[1]](diffhunk://#diff-5d2ac09af1ba2ff45329a4412194ca5cea764580c5dcdeacbb970de0e9d3380aL381-R378) [[2]](diffhunk://#diff-5d2ac09af1ba2ff45329a4412194ca5cea764580c5dcdeacbb970de0e9d3380aL394-R394)
* Revised operation review examples to remove inline Prisma model definitions and instead reference the schema context or provide schema snippets as comments, ensuring reviewers focus on the actual schema. [[1]](diffhunk://#diff-ebb95536e362925acc78f439c515010f5460944a1907e3e411a6261fe3cbc217L520-L552) [[2]](diffhunk://#diff-5d2ac09af1ba2ff45329a4412194ca5cea764580c5dcdeacbb970de0e9d3380aL536-L556) [[3]](diffhunk://#diff-5d2ac09af1ba2ff45329a4412194ca5cea764580c5dcdeacbb970de0e9d3380aL575-R559) [[4]](diffhunk://#diff-5d2ac09af1ba2ff45329a4412194ca5cea764580c5dcdeacbb970de0e9d3380aL605-R595)