### PR TITLE
fix(agent): enforce `IPage<T>` type

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
@@ -15,9 +15,8 @@ import { AutoBeContext } from "../../context/AutoBeContext";
 import { assertSchemaModel } from "../../context/assertSchemaModel";
 import { transformInterfaceComplementHistories } from "./histories/transformInterfaceComplementHistories";
 import { IAutoBeInterfaceComplementApplication } from "./structures/IAutoBeInterfaceComplementApplication";
-import { eraseVulnerableSchemas } from "./utils/eraseVulnerableSchemas";
+import { fixPageSchemas } from "./utils/fixPageSchemas";
 import { validateAuthorizationSchema } from "./utils/validateAuthorizationSchema";
-import { validateOpenApiPageSchema } from "./utils/validateOpenApiPageSchema";
 
 export function orchestrateInterfaceComplement<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
@@ -131,7 +130,7 @@ function createController<Model extends ILlmSchema.Model>(props: {
   const validate = (
     next: unknown,
   ): IValidation<IAutoBeInterfaceComplementApplication.IProps> => {
-    eraseVulnerableSchemas(next, "schemas");
+    fixPageSchemas(next, "schemas");
 
     const result: IValidation<IAutoBeInterfaceComplementApplication.IProps> =
       typia.validate<IAutoBeInterfaceComplementApplication.IProps>(next);
@@ -142,14 +141,6 @@ function createController<Model extends ILlmSchema.Model>(props: {
       errors,
       schemas: result.data.schemas,
       path: "$input.schemas",
-    });
-    Object.entries(result.data.schemas).forEach(([key, schema]) => {
-      validateOpenApiPageSchema({
-        path: "$input.schemas",
-        errors,
-        key,
-        schema,
-      });
     });
     if (errors.length !== 0)
       return {

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
@@ -17,9 +17,8 @@ import { divideArray } from "../../utils/divideArray";
 import { executeCachedBatch } from "../../utils/executeCachedBatch";
 import { transformInterfaceSchemaHistories } from "./histories/transformInterfaceSchemaHistories";
 import { IAutoBeInterfaceSchemaApplication } from "./structures/IAutoBeInterfaceSchemaApplication";
-import { eraseVulnerableSchemas } from "./utils/eraseVulnerableSchemas";
+import { fixPageSchemas } from "./utils/fixPageSchemas";
 import { validateAuthorizationSchema } from "./utils/validateAuthorizationSchema";
-import { validateOpenApiPageSchema } from "./utils/validateOpenApiPageSchema";
 
 export async function orchestrateInterfaceSchemas<
   Model extends ILlmSchema.Model,
@@ -170,7 +169,7 @@ function createController<Model extends ILlmSchema.Model>(props: {
   const validate = (
     next: unknown,
   ): IValidation<IAutoBeInterfaceSchemaApplication.IProps> => {
-    eraseVulnerableSchemas(next, "schemas");
+    fixPageSchemas(next, "schemas");
 
     const result: IValidation<IAutoBeInterfaceSchemaApplication.IProps> =
       typia.validate<IAutoBeInterfaceSchemaApplication.IProps>(next);
@@ -182,14 +181,6 @@ function createController<Model extends ILlmSchema.Model>(props: {
       errors,
       schemas: result.data.schemas,
       path: "$input.schemas",
-    });
-    Object.entries(result.data.schemas).forEach(([key, schema]) => {
-      validateOpenApiPageSchema({
-        path: "$input.schemas",
-        errors,
-        key,
-        schema,
-      });
     });
     if (errors.length !== 0)
       return {

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
@@ -17,9 +17,8 @@ import { executeCachedBatch } from "../../utils/executeCachedBatch";
 import { transformInterfaceSchemasReviewHistories } from "./histories/transformInterfaceSchemasReviewHistories";
 import { IAutoBeInterfaceSchemasReviewApplication } from "./structures/IAutobeInterfaceSchemasReviewApplication";
 import { authTokenSchema } from "./structures/authTokenSchema";
-import { eraseVulnerableSchemas } from "./utils/eraseVulnerableSchemas";
+import { fixPageSchemas } from "./utils/fixPageSchemas";
 import { validateAuthorizationSchema } from "./utils/validateAuthorizationSchema";
-import { validateOpenApiPageSchema } from "./utils/validateOpenApiPageSchema";
 
 export async function orchestrateInterfaceSchemasReview<
   Model extends ILlmSchema.Model,
@@ -150,7 +149,7 @@ function createController<Model extends ILlmSchema.Model>(props: {
   const validate = (
     next: unknown,
   ): IValidation<IAutoBeInterfaceSchemasReviewApplication.IProps> => {
-    eraseVulnerableSchemas(next, "content");
+    fixPageSchemas(next, "content");
 
     const result: IValidation<IAutoBeInterfaceSchemasReviewApplication.IProps> =
       typia.validate<IAutoBeInterfaceSchemasReviewApplication.IProps>(next);
@@ -161,15 +160,6 @@ function createController<Model extends ILlmSchema.Model>(props: {
       errors,
       schemas: result.data.content,
       path: "$input.content",
-    });
-
-    Object.entries(result.data.content).forEach(([key, schema]) => {
-      validateOpenApiPageSchema({
-        path: "$input.content",
-        errors,
-        key,
-        schema,
-      });
     });
     if (errors.length !== 0)
       return {

--- a/packages/agent/src/orchestrate/interface/utils/eraseVulnerableSchemas.ts
+++ b/packages/agent/src/orchestrate/interface/utils/eraseVulnerableSchemas.ts
@@ -1,9 +1,0 @@
-export const eraseVulnerableSchemas = (input: unknown, path: string): void => {
-  if (isObject(input) === false || isObject(input[path]) === false) return;
-
-  if (input[path].description) delete input[path].description;
-  if (input[path].required) delete input[path].required;
-};
-
-const isObject = (input: unknown): input is Record<string, unknown> =>
-  typeof input === "object" && input !== null;

--- a/packages/agent/src/orchestrate/interface/utils/fixPageSchemas.ts
+++ b/packages/agent/src/orchestrate/interface/utils/fixPageSchemas.ts
@@ -1,0 +1,47 @@
+import { AutoBeOpenApi } from "@autobe/interface";
+import { StringUtil } from "@autobe/utils";
+
+export const fixPageSchemas = (input: unknown, path: string): void => {
+  if (isObject(input) === false || isObject(input[path]) === false) return;
+
+  if (input[path].description) delete input[path].description;
+  if (input[path].required) delete input[path].required;
+  for (const key of Object.keys(input[path])) {
+    if (
+      key.startsWith("IPage") === false ||
+      key.startsWith("IPage.") === true ||
+      key === "IPage"
+    )
+      continue;
+    const data: string = key.substring("IPage".length);
+    input[path][key] = getPageSchema(data);
+  }
+};
+
+const isObject = (input: unknown): input is Record<string, unknown> =>
+  typeof input === "object" && input !== null;
+
+const getPageSchema = (
+  key: string,
+): AutoBeOpenApi.IJsonSchemaDescriptive.IObject => ({
+  type: "object",
+  properties: {
+    pagination: {
+      $ref: "#/components/schemas/IPage.IPagination",
+      description: "Page information.",
+    },
+    data: {
+      type: "array",
+      items: {
+        $ref: `#/components/schemas/${key}`,
+      },
+      description: "List of records.",
+    },
+  },
+  required: ["pagination", "data"],
+  description: StringUtil.trim`
+    A page.
+
+    Collection of records with pagination information.
+  `,
+});

--- a/packages/agent/src/orchestrate/interface/utils/validateOpenApiPageSchema.ts
+++ b/packages/agent/src/orchestrate/interface/utils/validateOpenApiPageSchema.ts
@@ -1,247 +1,247 @@
-import { AutoBeOpenApi } from "@autobe/interface";
-import { AutoBeOpenApiTypeChecker, StringUtil } from "@autobe/utils";
-import { IValidation } from "typia";
+// import { AutoBeOpenApi } from "@autobe/interface";
+// import { AutoBeOpenApiTypeChecker, StringUtil } from "@autobe/utils";
+// import { IValidation } from "typia";
 
-export const validateOpenApiPageSchema = (props: {
-  errors: IValidation.IError[];
-  path: string;
-  key: string;
-  schema: AutoBeOpenApi.IJsonSchemaDescriptive;
-}): void => {
-  if (
-    props.key.startsWith("IPage") === false ||
-    props.key === "IPage" ||
-    props.key.startsWith("IPage.")
-  )
-    return;
+// export const validateOpenApiPageSchema = (props: {
+//   errors: IValidation.IError[];
+//   path: string;
+//   key: string;
+//   schema: AutoBeOpenApi.IJsonSchemaDescriptive;
+// }): void => {
+//   if (
+//     props.key.startsWith("IPage") === false ||
+//     props.key === "IPage" ||
+//     props.key.startsWith("IPage.")
+//   )
+//     return;
 
-  const childName: string = props.key.substring("IPage".length);
-  if (AutoBeOpenApiTypeChecker.isObject(props.schema) === false) {
-    props.errors.push({
-      path: `${props.path}[${JSON.stringify(props.key)}]`,
-      value: props.schema,
-      expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IObject",
-      description: StringUtil.trim`
-          Following the system prompt, "${props.key}" type must be constructed like below.
-          
-          However, you have not defined the below like object type.
-          At the next trial, please ensure to follow the structure exactly as shown.
+//   const childName: string = props.key.substring("IPage".length);
+//   if (AutoBeOpenApiTypeChecker.isObject(props.schema) === false) {
+//     props.errors.push({
+//       path: `${props.path}[${JSON.stringify(props.key)}]`,
+//       value: props.schema,
+//       expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IObject",
+//       description: StringUtil.trim`
+//           Following the system prompt, "${props.key}" type must be constructed like below.
 
-          ${getExampleJsonSchema(childName)}
-        `,
-    });
-    return;
-  }
+//           However, you have not defined the below like object type.
+//           At the next trial, please ensure to follow the structure exactly as shown.
 
-  const properties: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
-    props.schema.properties;
-  const required: string[] = props.schema.required;
+//           ${getExampleJsonSchema(childName)}
+//         `,
+//     });
+//     return;
+//   }
 
-  //----
-  // CHILDREN DATA
-  //----
-  if (properties.data === undefined)
-    props.errors.push({
-      path: `${props.path}[${JSON.stringify(props.key)}].properties.data`,
-      value: undefined,
-      expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IArray",
-      description: StringUtil.trim`
-        Following the system prompt, "${props.key}" type must have a property 
-        "data" as an array type like below. 
-        
-        However, you have not defined the "data" property at all.
-        Please ensure to follow the structure exactly as shown.
+//   const properties: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
+//     props.schema.properties;
+//   const required: string[] = props.schema.required;
 
-        ${getExampleJsonSchema(childName, (o) => o.properties.data)}
-      `,
-    });
-  else {
-    if (AutoBeOpenApiTypeChecker.isArray(properties.data) === false)
-      props.errors.push({
-        path: `${props.path}[${JSON.stringify(props.key)}].properties.data`,
-        value: properties.data,
-        expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IArray",
-        description: StringUtil.trim`
-          Following the system prompt, "${props.key}" type must have an array typed 
-          property "data" like below.
+//   //----
+//   // CHILDREN DATA
+//   //----
+//   if (properties.data === undefined)
+//     props.errors.push({
+//       path: `${props.path}[${JSON.stringify(props.key)}].properties.data`,
+//       value: undefined,
+//       expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IArray",
+//       description: StringUtil.trim`
+//         Following the system prompt, "${props.key}" type must have a property
+//         "data" as an array type like below.
 
-          However, you have not defined the "data" property as an array type.
-          Please ensure to follow the structure exactly as shown.
+//         However, you have not defined the "data" property at all.
+//         Please ensure to follow the structure exactly as shown.
 
-          ${getExampleJsonSchema(childName, (o) => o.properties.data)}
-        `,
-      });
-    else if (
-      AutoBeOpenApiTypeChecker.isReference(properties.data.items) === false
-    )
-      props.errors.push({
-        path: `${props.path}[${JSON.stringify(props.key)}].properties.data.items`,
-        value: properties.data.items,
-        expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IReference",
-        description: StringUtil.trim`
-          Following the system prompt, "${props.key}" type must have an array 
-          typed property "data", and its items must be an reference type like below.
+//         ${getExampleJsonSchema(childName, (o) => o.properties.data)}
+//       `,
+//     });
+//   else {
+//     if (AutoBeOpenApiTypeChecker.isArray(properties.data) === false)
+//       props.errors.push({
+//         path: `${props.path}[${JSON.stringify(props.key)}].properties.data`,
+//         value: properties.data,
+//         expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IArray",
+//         description: StringUtil.trim`
+//           Following the system prompt, "${props.key}" type must have an array typed
+//           property "data" like below.
 
-          However, you have not defined the "data.items" property as an reference type.
-          Please ensure to follow the structure exactly as shown.
+//           However, you have not defined the "data" property as an array type.
+//           Please ensure to follow the structure exactly as shown.
 
-          ${getExampleJsonSchema(childName, (o) => o.properties.data.items)}
-        `,
-      });
-    else if (properties.data.items.$ref !== `#/components/schemas/${childName}`)
-      props.errors.push({
-        path: `${props.path}[${JSON.stringify(props.key)}].properties.data.items.$ref`,
-        value: properties.data.items.$ref,
-        expected: JSON.stringify(`#/components/schemas/${childName}`),
-        description: StringUtil.trim`
-          Following the system prompt, "${props.key}" type must have an array
-          typed property "data", and its items must be an reference type pointing
-          the "${childName}" type.
+//           ${getExampleJsonSchema(childName, (o) => o.properties.data)}
+//         `,
+//       });
+//     else if (
+//       AutoBeOpenApiTypeChecker.isReference(properties.data.items) === false
+//     )
+//       props.errors.push({
+//         path: `${props.path}[${JSON.stringify(props.key)}].properties.data.items`,
+//         value: properties.data.items,
+//         expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IReference",
+//         description: StringUtil.trim`
+//           Following the system prompt, "${props.key}" type must have an array
+//           typed property "data", and its items must be an reference type like below.
 
-          However, you have not defined the "data.items" property as an reference 
-          type pointing the "${childName}" type. Please ensure to follow the 
-          structure exactly as shown.
+//           However, you have not defined the "data.items" property as an reference type.
+//           Please ensure to follow the structure exactly as shown.
 
-          ${getExampleJsonSchema(childName, (o) => o.properties.data.items.$ref)}
-        `,
-      });
-    if (required.includes("data") === false)
-      props.errors.push({
-        path: `${props.path}[${JSON.stringify(props.key)}].required`,
-        value: required,
-        expected: `"data" must be included in the required array.`,
-        description: StringUtil.trim`
-          Following the system prompt, "${props.key}" type must have a property
-          "data" as a required field like below.
+//           ${getExampleJsonSchema(childName, (o) => o.properties.data.items)}
+//         `,
+//       });
+//     else if (properties.data.items.$ref !== `#/components/schemas/${childName}`)
+//       props.errors.push({
+//         path: `${props.path}[${JSON.stringify(props.key)}].properties.data.items.$ref`,
+//         value: properties.data.items.$ref,
+//         expected: JSON.stringify(`#/components/schemas/${childName}`),
+//         description: StringUtil.trim`
+//           Following the system prompt, "${props.key}" type must have an array
+//           typed property "data", and its items must be an reference type pointing
+//           the "${childName}" type.
 
-          However, you have not defined the "data" property as a required field.
-          Please ensure to follow the structure exactly as shown.
+//           However, you have not defined the "data.items" property as an reference
+//           type pointing the "${childName}" type. Please ensure to follow the
+//           structure exactly as shown.
 
-          ${getExampleJsonSchema(childName, (o) => o.required)}
-        `,
-      });
-  }
+//           ${getExampleJsonSchema(childName, (o) => o.properties.data.items.$ref)}
+//         `,
+//       });
+//     if (required.includes("data") === false)
+//       props.errors.push({
+//         path: `${props.path}[${JSON.stringify(props.key)}].required`,
+//         value: required,
+//         expected: `"data" must be included in the required array.`,
+//         description: StringUtil.trim`
+//           Following the system prompt, "${props.key}" type must have a property
+//           "data" as a required field like below.
 
-  // PAGINATION
-  if (properties.pagination === undefined) {
-    props.errors.push({
-      path: `${props.path}[${JSON.stringify(props.key)}].properties.pagination`,
-      value: undefined,
-      expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IReference",
-      description: StringUtil.trim`
-        Following the system prompt, "${props.key}" type must have a property
-        "pagination" as a reference type like below.
+//           However, you have not defined the "data" property as a required field.
+//           Please ensure to follow the structure exactly as shown.
 
-        However, you have not defined the "pagination" property at all.
-        Please ensure to follow the structure exactly as shown.
+//           ${getExampleJsonSchema(childName, (o) => o.required)}
+//         `,
+//       });
+//   }
 
-        ${getExampleJsonSchema(childName, (o) => o.properties.pagination)}
-      `,
-    });
-  } else {
-    if (AutoBeOpenApiTypeChecker.isReference(properties.pagination) === false) {
-      props.errors.push({
-        path: `${props.path}[${JSON.stringify(props.key)}].properties.pagination`,
-        value: undefined,
-        expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IReference",
-        description: StringUtil.trim`
-          Following the system prompt, "${props.key}" type must have a property
-          "pagination" as a reference type like below.
+//   // PAGINATION
+//   if (properties.pagination === undefined) {
+//     props.errors.push({
+//       path: `${props.path}[${JSON.stringify(props.key)}].properties.pagination`,
+//       value: undefined,
+//       expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IReference",
+//       description: StringUtil.trim`
+//         Following the system prompt, "${props.key}" type must have a property
+//         "pagination" as a reference type like below.
 
-          However, you have not defined the "pagination" property as a reference type.
-          Please ensure to follow the structure exactly as shown.
+//         However, you have not defined the "pagination" property at all.
+//         Please ensure to follow the structure exactly as shown.
 
-          ${getExampleJsonSchema(childName, (o) => o.properties.pagination)}
-        `,
-      });
-    } else if (
-      properties.pagination.$ref !== "#/components/schemas/IPage.IPagination"
-    ) {
-      props.errors.push({
-        path: `${props.path}[${JSON.stringify(props.key)}].properties.pagination.$ref`,
-        value: properties.pagination.$ref,
-        expected: JSON.stringify("#/components/schemas/IPage.IPagination"),
-        description: StringUtil.trim`
-          Following the system prompt, "${props.key}" type must have a property
-          "pagination" as a reference type pointing the "IPage.IPagination" type 
-          like below.
+//         ${getExampleJsonSchema(childName, (o) => o.properties.pagination)}
+//       `,
+//     });
+//   } else {
+//     if (AutoBeOpenApiTypeChecker.isReference(properties.pagination) === false) {
+//       props.errors.push({
+//         path: `${props.path}[${JSON.stringify(props.key)}].properties.pagination`,
+//         value: undefined,
+//         expected: "AutoBeOpenApi.IJsonSchemaDescriptive.IReference",
+//         description: StringUtil.trim`
+//           Following the system prompt, "${props.key}" type must have a property
+//           "pagination" as a reference type like below.
 
-          However, you have not defined the "pagination" property as a reference 
-          type pointing the "IPage.IPagination" type. Please ensure to follow the 
-          structure exactly as shown.
-          
-          ${getExampleJsonSchema(childName, (o) => o.properties.pagination.$ref)}
-        `,
-      });
-    }
-    if (required.includes("pagination") === false)
-      props.errors.push({
-        path: `${props.path}[${JSON.stringify(props.key)}].required`,
-        value: props.schema.required,
-        expected: `"pagination" must be included in the required array.`,
-        description: StringUtil.trim`
-          Following the system prompt, "${props.key}" type must have a property
-          "pagination" as a required field like below.
+//           However, you have not defined the "pagination" property as a reference type.
+//           Please ensure to follow the structure exactly as shown.
 
-          However, you have not defined the "pagination" property as a required 
-          field. Please ensure to follow the structure exactly as shown.
+//           ${getExampleJsonSchema(childName, (o) => o.properties.pagination)}
+//         `,
+//       });
+//     } else if (
+//       properties.pagination.$ref !== "#/components/schemas/IPage.IPagination"
+//     ) {
+//       props.errors.push({
+//         path: `${props.path}[${JSON.stringify(props.key)}].properties.pagination.$ref`,
+//         value: properties.pagination.$ref,
+//         expected: JSON.stringify("#/components/schemas/IPage.IPagination"),
+//         description: StringUtil.trim`
+//           Following the system prompt, "${props.key}" type must have a property
+//           "pagination" as a reference type pointing the "IPage.IPagination" type
+//           like below.
 
-          ${getExampleJsonSchema(childName, (o) => o.required)}
-        `,
-      });
-  }
-};
+//           However, you have not defined the "pagination" property as a reference
+//           type pointing the "IPage.IPagination" type. Please ensure to follow the
+//           structure exactly as shown.
 
-const getExampleJsonSchema = (
-  childName: string,
-  closure?: (value: ReturnType<typeof getExampleValue>) => any,
-): string => {
-  const value = {
-    type: "object",
-    properties: {
-      data: {
-        type: "array",
-        items: {
-          $ref: `#/components/schemas/${childName}`,
-        },
-        description: "<SOME_DESCRIPTION>",
-      },
-      pagination: {
-        $ref: "#/components/schemas/IPage.IPagination",
-        description: "<SOME_DESCRIPTION>",
-      },
-    },
-    required: ["data", "pagination"],
-    description: "<SOME_DESCRIPTION>",
-  } satisfies AutoBeOpenApi.IJsonSchemaDescriptive.IObject;
-  return StringUtil.trim`
-    > Change the value as below.
-    >
-    > \`\`\`json
-    ${JSON.stringify((closure ?? ((v) => v))(value), null, 2)
-      .split("\n")
-      .map((s) => `> ${s}`)
-      .join("\n")}
-    > \`\`\`
-  `;
-};
+//           ${getExampleJsonSchema(childName, (o) => o.properties.pagination.$ref)}
+//         `,
+//       });
+//     }
+//     if (required.includes("pagination") === false)
+//       props.errors.push({
+//         path: `${props.path}[${JSON.stringify(props.key)}].required`,
+//         value: props.schema.required,
+//         expected: `"pagination" must be included in the required array.`,
+//         description: StringUtil.trim`
+//           Following the system prompt, "${props.key}" type must have a property
+//           "pagination" as a required field like below.
 
-const getExampleValue = (childName: string) =>
-  ({
-    type: "object",
-    properties: {
-      data: {
-        type: "array",
-        items: {
-          $ref: `#/components/schemas/${childName}`,
-        },
-        description: "<SOME_DESCRIPTION>",
-      },
-      pagination: {
-        $ref: "#/components/schemas/IPage.IPagination",
-        description: "<SOME_DESCRIPTION>",
-      },
-    },
-    required: ["data", "pagination"],
-    description: "<SOME_DESCRIPTION>",
-  }) satisfies AutoBeOpenApi.IJsonSchemaDescriptive.IObject;
+//           However, you have not defined the "pagination" property as a required
+//           field. Please ensure to follow the structure exactly as shown.
+
+//           ${getExampleJsonSchema(childName, (o) => o.required)}
+//         `,
+//       });
+//   }
+// };
+
+// const getExampleJsonSchema = (
+//   childName: string,
+//   closure?: (value: ReturnType<typeof getExampleValue>) => any,
+// ): string => {
+//   const value = {
+//     type: "object",
+//     properties: {
+//       data: {
+//         type: "array",
+//         items: {
+//           $ref: `#/components/schemas/${childName}`,
+//         },
+//         description: "<SOME_DESCRIPTION>",
+//       },
+//       pagination: {
+//         $ref: "#/components/schemas/IPage.IPagination",
+//         description: "<SOME_DESCRIPTION>",
+//       },
+//     },
+//     required: ["data", "pagination"],
+//     description: "<SOME_DESCRIPTION>",
+//   } satisfies AutoBeOpenApi.IJsonSchemaDescriptive.IObject;
+//   return StringUtil.trim`
+//     > Change the value as below.
+//     >
+//     > \`\`\`json
+//     ${JSON.stringify((closure ?? ((v) => v))(value), null, 2)
+//       .split("\n")
+//       .map((s) => `> ${s}`)
+//       .join("\n")}
+//     > \`\`\`
+//   `;
+// };
+
+// const getExampleValue = (childName: string) =>
+//   ({
+//     type: "object",
+//     properties: {
+//       data: {
+//         type: "array",
+//         items: {
+//           $ref: `#/components/schemas/${childName}`,
+//         },
+//         description: "<SOME_DESCRIPTION>",
+//       },
+//       pagination: {
+//         $ref: "#/components/schemas/IPage.IPagination",
+//         description: "<SOME_DESCRIPTION>",
+//       },
+//     },
+//     required: ["data", "pagination"],
+//     description: "<SOME_DESCRIPTION>",
+//   }) satisfies AutoBeOpenApi.IJsonSchemaDescriptive.IObject;


### PR DESCRIPTION
This pull request refactors schema validation and transformation logic in the orchestrate interface modules. The main change is the replacement of the old `eraseVulnerableSchemas` utility with a new, more comprehensive `fixPageSchemas` utility. Additionally, redundant per-schema validation logic has been removed, and the new utility is introduced across all relevant modules. This improves consistency and maintainability of schema handling.

**Schema transformation improvements:**

* Replaced `eraseVulnerableSchemas` with the new `fixPageSchemas` utility in `orchestrateInterfaceComplement.ts`, `orchestrateInterfaceSchemas.ts`, and `orchestrateInterfaceSchemasReview.ts`, ensuring more robust and consistent schema normalization. [[1]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L18-L20) [[2]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dL20-L22) [[3]](diffhunk://#diff-149e865311d6c8b3ffbd019c94ce0745effd5d68a52d0183b2e998d7b002c066L20-L22)
* Removed the old `eraseVulnerableSchemas` utility file.
* Added the new `fixPageSchemas` utility, which not only removes vulnerable fields but also standardizes schemas starting with `IPage`, ensuring they follow a consistent structure.

**Validation logic simplification:**

* Removed redundant per-schema validation using `validateOpenApiPageSchema` in all three orchestrate interface modules, reducing unnecessary complexity in the validation process. [[1]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L146-L153) [[2]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dL186-L193) [[3]](diffhunk://#diff-149e865311d6c8b3ffbd019c94ce0745effd5d68a52d0183b2e998d7b002c066L165-L173)
* Updated the validation flow in controller functions to use `fixPageSchemas` instead of the previous approach. [[1]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L134-R133) [[2]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dL173-R172) [[3]](diffhunk://#diff-149e865311d6c8b3ffbd019c94ce0745effd5d68a52d0183b2e998d7b002c066L153-R152)