### PR TITLE
fix(agent): missed schema presets

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
@@ -33,6 +33,9 @@ export async function orchestrateInterfaceSchemas<
     if (op.requestBody !== null) typeNames.add(op.requestBody.typeName);
     if (op.responseBody !== null) typeNames.add(op.responseBody.typeName);
   }
+  const presets: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
+    JsonSchemaFactory.presets(typeNames);
+
   const matrix: string[][] = divideArray({
     array: Array.from(typeNames),
     capacity,
@@ -41,8 +44,6 @@ export async function orchestrateInterfaceSchemas<
     total: typeNames.size,
     completed: 0,
   };
-
-  const presets: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> = {};
   const x: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> = {
     ...presets,
   };

--- a/packages/agent/src/orchestrate/interface/utils/JsonSchemaFactory.ts
+++ b/packages/agent/src/orchestrate/interface/utils/JsonSchemaFactory.ts
@@ -4,14 +4,21 @@ import typia, { tags } from "typia";
 
 export namespace JsonSchemaFactory {
   export const presets = (
-    typeNames: string[],
+    typeNames: Set<string>,
   ): Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> => {
-    return {
+    const schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> = {
       ...DEFAULT_SCHEMAS,
-      ...Object.fromEntries(
-        typeNames.filter(isPage).map((key) => [key, page(key)]),
-      ),
     };
+    for (const [key, value] of Object.entries(DEFAULT_SCHEMAS)) {
+      schemas[key] = value;
+      typeNames.delete(key);
+    }
+    for (const key of typeNames)
+      if (isPage(key)) {
+        schemas[key] = page(key);
+        typeNames.delete(key);
+      }
+    return schemas;
   };
 
   export const page = (

--- a/packages/agent/src/orchestrate/interface/utils/JsonSchemaFactory.ts
+++ b/packages/agent/src/orchestrate/interface/utils/JsonSchemaFactory.ts
@@ -6,9 +6,7 @@ export namespace JsonSchemaFactory {
   export const presets = (
     typeNames: Set<string>,
   ): Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> => {
-    const schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> = {
-      ...DEFAULT_SCHEMAS,
-    };
+    const schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> = {};
     for (const [key, value] of Object.entries(DEFAULT_SCHEMAS)) {
       schemas[key] = value;
       typeNames.delete(key);

--- a/test/package.json
+++ b/test/package.json
@@ -7,9 +7,10 @@
   "scripts": {
     "prepare": "ts-patch install",
     "build": "tsc --noEmit",
+    "build:prompt": "node build/prompt.js",
     "dev": "tsc --watch --noEmit",
-    "start": "node build/prompt.js && pnpm run start:go",
-    "archive": "node build/prompt.js && pnpm run archive:go",
+    "start": "pnpm run build:prompt && pnpm run start:go",
+    "archive": "pnpm run build:prompt && pnpm run archive:go",
     "start:go": "ts-node src",
     "archive:go": "ts-node src/archive",
     "bench": "ts-node src/benchmarks"


### PR DESCRIPTION
This pull request refactors how schema presets are generated and improves the build process for the test package. The main changes include updating the logic for collecting and generating schema presets, and simplifying the build scripts for more maintainable and reusable commands.

**Schema presets generation improvements:**

* Refactored the `JsonSchemaFactory.presets` function in `JsonSchemaFactory.ts` to accept a `Set<string>` instead of an array, and to more efficiently merge default schemas and page schemas while removing handled keys from the set.
* Updated `orchestrateInterfaceSchemas.ts` to call the new `JsonSchemaFactory.presets` with a `Set<string>`, and to remove the redundant initialization of the `presets` object. [[1]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dR36-R38) [[2]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dL44-L45)

**Build process enhancements:**

* Added a new `build:prompt` script in `test/package.json` and refactored the `start` and `archive` scripts to use this new command, improving script reusability and maintainability.