### PR TITLE
Feat(Agent): validate interface agents' schema keys

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
@@ -18,6 +18,7 @@ import { IAutoBeInterfaceComplementApplication } from "./structures/IAutoBeInter
 import { JsonSchemaFactory } from "./utils/JsonSchemaFactory";
 import { fulfillJsonSchemaErrorMessages } from "./utils/fulfillJsonSchemaErrorMessages";
 import { validateAuthorizationSchema } from "./utils/validateAuthorizationSchema";
+import { validateDuplicatedSchemaName } from "./utils/validateDuplicatedSchemaName";
 
 export function orchestrateInterfaceComplement<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
@@ -142,6 +143,11 @@ function createController<Model extends ILlmSchema.Model>(props: {
 
     const errors: IValidation.IError[] = [];
     validateAuthorizationSchema({
+      errors,
+      schemas: result.data.schemas,
+      path: "$input.schemas",
+    });
+    validateDuplicatedSchemaName({
       errors,
       schemas: result.data.schemas,
       path: "$input.schemas",

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemas.ts
@@ -20,6 +20,7 @@ import { IAutoBeInterfaceSchemaApplication } from "./structures/IAutoBeInterface
 import { JsonSchemaFactory } from "./utils/JsonSchemaFactory";
 import { fulfillJsonSchemaErrorMessages } from "./utils/fulfillJsonSchemaErrorMessages";
 import { validateAuthorizationSchema } from "./utils/validateAuthorizationSchema";
+import { validateDuplicatedSchemaName } from "./utils/validateDuplicatedSchemaName";
 
 export async function orchestrateInterfaceSchemas<
   Model extends ILlmSchema.Model,
@@ -187,6 +188,11 @@ function createController<Model extends ILlmSchema.Model>(props: {
     // Check all IAuthorized types
     const errors: IValidation.IError[] = [];
     validateAuthorizationSchema({
+      errors,
+      schemas: result.data.schemas,
+      path: "$input.schemas",
+    });
+    validateDuplicatedSchemaName({
       errors,
       schemas: result.data.schemas,
       path: "$input.schemas",

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
@@ -19,6 +19,7 @@ import { IAutoBeInterfaceSchemasReviewApplication } from "./structures/IAutobeIn
 import { JsonSchemaFactory } from "./utils/JsonSchemaFactory";
 import { fulfillJsonSchemaErrorMessages } from "./utils/fulfillJsonSchemaErrorMessages";
 import { validateAuthorizationSchema } from "./utils/validateAuthorizationSchema";
+import { validateDuplicatedSchemaName } from "./utils/validateDuplicatedSchemaName";
 
 export async function orchestrateInterfaceSchemasReview<
   Model extends ILlmSchema.Model,
@@ -148,6 +149,11 @@ function createController<Model extends ILlmSchema.Model>(props: {
 
     const errors: IValidation.IError[] = [];
     validateAuthorizationSchema({
+      errors,
+      schemas: result.data.content,
+      path: "$input.content",
+    });
+    validateDuplicatedSchemaName({
       errors,
       schemas: result.data.content,
       path: "$input.content",

--- a/packages/agent/src/orchestrate/interface/utils/validateDuplicatedSchemaName.ts
+++ b/packages/agent/src/orchestrate/interface/utils/validateDuplicatedSchemaName.ts
@@ -1,3 +1,4 @@
+import { AutoBeOpenApi } from "@autobe/interface";
 import { IValidation } from "typia";
 
 /**
@@ -12,7 +13,7 @@ import { IValidation } from "typia";
  */
 export const validateDuplicatedSchemaName = (props: {
   errors: IValidation.IError[];
-  keys: string[];
+  schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>;
   path: string;
 }) => {
   // First, determine canonical forms for base namespaces
@@ -20,7 +21,7 @@ export const validateDuplicatedSchemaName = (props: {
   const namespaceCounts = new Map<string, Map<string, number>>();
 
   // Count namespace occurrences
-  for (const key of props.keys) {
+  for (const key of Object.keys(props.schemas)) {
     const parts = key.split(".");
     const namespace = parts[0];
     const lowerNamespace = namespace.toLowerCase();
@@ -54,7 +55,7 @@ export const validateDuplicatedSchemaName = (props: {
   // Now check for duplicates and normalize using canonical namespaces
   const normalizedGroups = new Map<string, Set<string>>();
 
-  for (const key of props.keys) {
+  for (const key of Object.keys(props.schemas)) {
     const parts = key.split(".");
     const namespace = parts[0];
     const lowerNamespace = namespace.toLowerCase();

--- a/packages/agent/src/orchestrate/interface/utils/validateDuplicatedSchemaName.ts
+++ b/packages/agent/src/orchestrate/interface/utils/validateDuplicatedSchemaName.ts
@@ -1,0 +1,164 @@
+import { IValidation } from "typia";
+
+/**
+ * Validates that schema names are unique in a case-insensitive manner. Detects
+ * duplicates like "IUser.IRequest" vs "Iuser.IRequest" which should not
+ * coexist.
+ *
+ * @param props - Validation properties
+ * @param props.errors - Array to collect validation errors
+ * @param props.schemas - Schema definitions to validate
+ * @param props.path - Path context for error reporting
+ */
+export const validateDuplicatedSchemaName = (props: {
+  errors: IValidation.IError[];
+  keys: string[];
+  path: string;
+}) => {
+  // First, determine canonical forms for base namespaces
+  const namespaceCanonicals = new Map<string, string>();
+  const namespaceCounts = new Map<string, Map<string, number>>();
+
+  // Count namespace occurrences
+  for (const key of props.keys) {
+    const parts = key.split(".");
+    const namespace = parts[0];
+    const lowerNamespace = namespace.toLowerCase();
+
+    if (!namespaceCounts.has(lowerNamespace)) {
+      namespaceCounts.set(lowerNamespace, new Map());
+    }
+
+    const variants = namespaceCounts.get(lowerNamespace)!;
+    variants.set(namespace, (variants.get(namespace) || 0) + 1);
+  }
+
+  // Determine canonical form for each namespace
+  for (const [lowerNamespace, variants] of namespaceCounts) {
+    let canonical = "";
+    let maxCount = 0;
+
+    for (const [variant, count] of variants) {
+      if (
+        count > maxCount ||
+        (count === maxCount && shouldPrefer(variant, canonical))
+      ) {
+        canonical = variant;
+        maxCount = count;
+      }
+    }
+
+    namespaceCanonicals.set(lowerNamespace, canonical);
+  }
+
+  // Now check for duplicates and normalize using canonical namespaces
+  const normalizedGroups = new Map<string, Set<string>>();
+
+  for (const key of props.keys) {
+    const parts = key.split(".");
+    const namespace = parts[0];
+    const lowerNamespace = namespace.toLowerCase();
+    const canonicalNamespace =
+      namespaceCanonicals.get(lowerNamespace) || namespace;
+
+    // Build normalized key with canonical namespace
+    const normalizedKey =
+      parts.length > 1
+        ? `${canonicalNamespace}.${parts.slice(1).join(".")}`
+        : canonicalNamespace;
+
+    const lowerNormalizedKey = normalizedKey.toLowerCase();
+
+    if (!normalizedGroups.has(lowerNormalizedKey)) {
+      normalizedGroups.set(lowerNormalizedKey, new Set());
+    }
+
+    normalizedGroups.get(lowerNormalizedKey)!.add(key);
+  }
+
+  // Report all groups with duplicates
+  for (const [, originalKeys] of normalizedGroups) {
+    if (originalKeys.size > 1) {
+      const keyArray = Array.from(originalKeys);
+
+      // Determine the canonical form for this group
+      // First, find the best original key, then normalize it
+      let bestOriginalKey = "";
+      for (const key of keyArray) {
+        if (bestOriginalKey === "" || shouldPrefer(key, bestOriginalKey)) {
+          bestOriginalKey = key;
+        }
+      }
+
+      // Now normalize the best key with canonical namespace
+      const parts = bestOriginalKey.split(".");
+      const namespace = parts[0];
+      const lowerNamespace = namespace.toLowerCase();
+      const canonicalNamespace =
+        namespaceCanonicals.get(lowerNamespace) || namespace;
+
+      const canonical =
+        parts.length > 1
+          ? `${canonicalNamespace}.${parts.slice(1).join(".")}`
+          : canonicalNamespace;
+
+      const nonCanonical = keyArray.filter((k) => {
+        // Compare the original key against the canonical form directly
+        // Don't normalize before comparing
+        return k !== canonical;
+      });
+
+      if (nonCanonical.length > 0) {
+        // Create an error for each non-canonical variant
+        for (const variant of nonCanonical) {
+          props.errors.push({
+            path: `${props.path}.${variant}`,
+            expected: `"${canonical}" (canonical form)`,
+            value: variant,
+            message: `Case-insensitive duplicate schema name detected. Use "${canonical}" instead of "${variant}"`,
+          } as IValidation.IError);
+        }
+      }
+    }
+  }
+
+  return props.errors;
+};
+
+/**
+ * When frequency is tied, determines which key should be preferred. Prefers
+ * PascalCase names (e.g., IRequest over irequest, ISummary over ISUMMARY).
+ */
+function shouldPrefer(newName: string, currentCanonical: string): boolean {
+  // Empty string loses to anything
+  if (currentCanonical === "") return true;
+
+  // Check if names follow PascalCase pattern (starts with uppercase, has lowercase)
+  const newIsPascal = /^[A-Z]/.test(newName) && /[a-z]/.test(newName);
+  const currentIsPascal =
+    /^[A-Z]/.test(currentCanonical) && /[a-z]/.test(currentCanonical);
+
+  // Prefer PascalCase over all-uppercase or all-lowercase
+  if (newIsPascal && !currentIsPascal) return true;
+  if (!newIsPascal && currentIsPascal) return false;
+
+  // If both are PascalCase or both are not, prefer names starting with uppercase
+  const newStartsUpper = /^[A-Z]/.test(newName);
+  const currentStartsUpper = /^[A-Z]/.test(currentCanonical);
+
+  if (newStartsUpper && !currentStartsUpper) return true;
+  if (!newStartsUpper && currentStartsUpper) return false;
+
+  // As a last resort, prefer the one with more uppercase letters (but not all uppercase)
+  const newUpperCount = (newName.match(/[A-Z]/g) || []).length;
+  const currentUpperCount = (currentCanonical.match(/[A-Z]/g) || []).length;
+
+  // Avoid all-uppercase by checking ratio
+  const newAllUpper = newName === newName.toUpperCase();
+  const currentAllUpper = currentCanonical === currentCanonical.toUpperCase();
+
+  if (!newAllUpper && currentAllUpper) return true;
+  if (newAllUpper && !currentAllUpper) return false;
+
+  return newUpperCount > currentUpperCount;
+}


### PR DESCRIPTION
This pull request introduces a new validation utility to ensure schema names are unique in a case-insensitive manner across the orchestrate interface modules. The main goal is to prevent issues caused by duplicate schema names that differ only by letter casing, such as "IUser.IRequest" vs "Iuser.IRequest". The new validation is integrated into the relevant orchestrate controllers, and a new utility file implements the logic for canonicalizing and detecting duplicates.

**Validation Enhancements:**

* Added a new utility function `validateDuplicatedSchemaName` in `utils/validateDuplicatedSchemaName.ts` to detect and report case-insensitive duplicate schema names, preferring PascalCase as the canonical form.
* Integrated `validateDuplicatedSchemaName` into the validation workflow of the following orchestrate controllers to enforce unique schema names:
  - `orchestrateInterfaceComplement.ts` [[1]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900R21) [[2]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900R150-R154)
  - `orchestrateInterfaceSchemas.ts` [[1]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dR23) [[2]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dR195-R199)
  - `orchestrateInterfaceSchemasReview.ts` [[1]](diffhunk://#diff-149e865311d6c8b3ffbd019c94ce0745effd5d68a52d0183b2e998d7b002c066R22) [[2]](diffhunk://#diff-149e865311d6c8b3ffbd019c94ce0745effd5d68a52d0183b2e998d7b002c066R156-R160)