### PR TITLE
fix(agent): pagination schema composition side-effect

### DIFF
--- a/packages/agent/src/orchestrate/interface/utils/JsonSchemaFactory.ts
+++ b/packages/agent/src/orchestrate/interface/utils/JsonSchemaFactory.ts
@@ -15,6 +15,7 @@ export namespace JsonSchemaFactory {
       if (isPage(key)) {
         schemas[key] = page(key);
         typeNames.delete(key);
+        typeNames.add(getPageName(key));
       }
     return schemas;
   };
@@ -63,6 +64,9 @@ export namespace JsonSchemaFactory {
     key.startsWith("IPage") === true &&
     key.startsWith("IPage.") === false &&
     key !== "IPage";
+
+  export const getPageName = (key: string): string =>
+    key.substring("IPage".length);
 
   const isRecord = (input: unknown): input is Record<string, unknown> =>
     typeof input === "object" && input !== null;


### PR DESCRIPTION
This pull request makes a small update to the `JsonSchemaFactory` utility. The main change is the introduction of a new helper function and a minor adjustment to how type names are managed for page schemas.

- Utilities and schema handling:
  * Added a new `getPageName` function to extract the page name from a schema key and updated the logic to add this extracted name to the `typeNames` set when processing page schemas. [[1]](diffhunk://#diff-6ceb18cf37298df469d7b47f04ebbf953c8149d64d65625df4b70bc0cc39c5b3R18) [[2]](diffhunk://#diff-6ceb18cf37298df469d7b47f04ebbf953c8149d64d65625df4b70bc0cc39c5b3R68-R70)