### PR TITLE
feat(agent): get reference ids from operation.

### DIFF
--- a/packages/agent/src/orchestrate/test/utils/getReferenceIds.ts
+++ b/packages/agent/src/orchestrate/test/utils/getReferenceIds.ts
@@ -1,0 +1,25 @@
+import { AutoBeOpenApi } from "@autobe/interface";
+import { OpenApiTypeChecker } from "@samchon/openapi";
+
+export const getReferenceIds = (props: {
+  document: AutoBeOpenApi.IDocument;
+  operation: AutoBeOpenApi.IOperation;
+}): string[] => {
+  const result: Set<string> = new Set();
+  const emplace = (key: string) => {
+    if (key.endsWith("_id")) result.add(key);
+  };
+
+  props.operation.parameters.forEach((p) => emplace(p.name));
+  if (props.operation.requestBody) {
+    OpenApiTypeChecker.visit({
+      components: props.document.components,
+      schema: { $ref: props.operation.requestBody.typeName },
+      closure: (schema) => {
+        if (OpenApiTypeChecker.isObject(schema) === false) return;
+        for (const key of Object.keys(schema.properties ?? {})) emplace(key);
+      },
+    });
+  }
+  return Array.from(result);
+};


### PR DESCRIPTION
This pull request adds a new utility function to extract reference ID fields from OpenAPI operation definitions. The function identifies parameter and request body fields that end with `_id`, improving support for automated reference handling.

**New utility for extracting reference IDs:**

* Added `getReferenceIds` function in `getReferenceIds.ts` to collect all parameter and request body property names ending with `_id` from an OpenAPI operation, utilizing `OpenApiTypeChecker` for schema traversal.