### PR TITLE
fix(agent): json schema naming convention.

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
@@ -16,6 +16,7 @@ import { assertSchemaModel } from "../../context/assertSchemaModel";
 import { transformInterfaceComplementHistories } from "./histories/transformInterfaceComplementHistories";
 import { IAutoBeInterfaceComplementApplication } from "./structures/IAutoBeInterfaceComplementApplication";
 import { JsonSchemaFactory } from "./utils/JsonSchemaFactory";
+import { JsonSchemaNamingConvention } from "./utils/JsonSchemaNamingConvention";
 import { fulfillJsonSchemaErrorMessages } from "./utils/fulfillJsonSchemaErrorMessages";
 import { validateAuthorizationSchema } from "./utils/validateAuthorizationSchema";
 
@@ -86,6 +87,7 @@ async function step<Model extends ILlmSchema.Model>(
     ...pointer.value,
     ...document.components.schemas,
   };
+  JsonSchemaNamingConvention.schemas(document.operations, newSchemas);
   return step(
     ctx,
     {

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemasReview.ts
@@ -17,6 +17,7 @@ import { executeCachedBatch } from "../../utils/executeCachedBatch";
 import { transformInterfaceSchemasReviewHistories } from "./histories/transformInterfaceSchemasReviewHistories";
 import { IAutoBeInterfaceSchemasReviewApplication } from "./structures/IAutobeInterfaceSchemasReviewApplication";
 import { JsonSchemaFactory } from "./utils/JsonSchemaFactory";
+import { JsonSchemaNamingConvention } from "./utils/JsonSchemaNamingConvention";
 import { fulfillJsonSchemaErrorMessages } from "./utils/fulfillJsonSchemaErrorMessages";
 import { validateAuthorizationSchema } from "./utils/validateAuthorizationSchema";
 
@@ -48,8 +49,10 @@ export async function orchestrateInterfaceSchemasReview<
         await divideAndConquer(ctx, operations, it, progress, promptCacheKey);
       return row;
     }),
-  ))
+  )) {
+    JsonSchemaNamingConvention.schemas(operations, x, y);
     Object.assign(x, y);
+  }
   return x;
 }
 

--- a/packages/agent/src/orchestrate/interface/utils/JsonSchemaNamingConvention.ts
+++ b/packages/agent/src/orchestrate/interface/utils/JsonSchemaNamingConvention.ts
@@ -1,0 +1,82 @@
+import { AutoBeOpenApi } from "@autobe/interface";
+import { MapUtil } from "@autobe/utils";
+import { OpenApiTypeChecker } from "@samchon/openapi";
+
+export namespace JsonSchemaNamingConvention {
+  export const operations = (operations: AutoBeOpenApi.IOperation[]): void => {
+    const typeNames: Set<string> = new Set();
+    operate(typeNames, operations);
+  };
+
+  export const schemas = (
+    operations: AutoBeOpenApi.IOperation[],
+    ...componentSchemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>[]
+  ): void => {
+    const typeNames: Set<string> = new Set();
+    for (const schemas of componentSchemas)
+      for (const key of Object.keys(schemas)) typeNames.add(key);
+    const answer = operate(typeNames, operations);
+
+    for (const dict of componentSchemas)
+      for (const x of Object.keys(dict)) {
+        const y: string = answer(x);
+        if (x === y) continue;
+        dict[y] = dict[x]!;
+        delete dict[x];
+      }
+    for (const dict of componentSchemas)
+      for (const x of Object.values(dict)) {
+        OpenApiTypeChecker.visit({
+          components: { schemas: dict },
+          schema: x,
+          closure: (s) => {
+            if (OpenApiTypeChecker.isReference(s) === false) return;
+            s.$ref = `#/components/schemas/${answer(s.$ref.split("/").pop()!)}`;
+          },
+        });
+      }
+  };
+
+  const operate = (
+    typeNames: Set<string>,
+    operations: AutoBeOpenApi.IOperation[],
+  ): ((v: string) => string) => {
+    for (const op of operations) {
+      if (op.requestBody) typeNames.add(op.requestBody.typeName);
+      if (op.responseBody) typeNames.add(op.responseBody.typeName);
+    }
+    const answer = prepare(typeNames);
+    for (const op of operations) {
+      if (op.requestBody)
+        op.requestBody.typeName = answer(op.requestBody.typeName);
+      if (op.responseBody)
+        op.responseBody.typeName = answer(op.responseBody.typeName);
+    }
+    return answer;
+  };
+
+  const prepare = (typeNames: Set<string>): ((v: string) => string) => {
+    const similar: Map<string, string[]> = new Map();
+    const getKey = (v: string) => v.split(".")[0]!.toLowerCase();
+    const getValue = (v: string) => v.split(".")[0]!;
+    const emplace = (v: string) =>
+      MapUtil.take(similar, getKey(v), () => []).push(getValue(v));
+    for (const v of typeNames) emplace(v);
+
+    const solution: Map<string, string> = new Map();
+    for (const [key, values] of similar) {
+      if (values.length === 1) continue;
+      const winner: string = values.sort(
+        (a, b) => countCapitalLetters(b) - countCapitalLetters(a),
+      )[0]!;
+      solution.set(key, winner);
+    }
+    return (v: string) => {
+      const key: string = getKey(v);
+      if (solution.has(key) === false) return v;
+      return [solution.get(key), ...v.split(".").slice(1)].join(".");
+    };
+  };
+}
+
+const countCapitalLetters = (str: string) => (str.match(/[A-Z]/g) || []).length;


### PR DESCRIPTION
This pull request introduces a new utility, `JsonSchemaNamingConvention`, to standardize and fix type names in OpenAPI schema operations and components. The changes ensure consistent naming for schema types, improving reliability and maintainability across the orchestration functions. The new convention is integrated into the main schema orchestration flows and reviews, and is applied at key points where schemas are processed and merged.

**Schema naming convention improvements:**

* Added the new `JsonSchemaNamingConvention` utility (`JsonSchemaNamingConvention.ts`) to automatically standardize and fix type names in OpenAPI operations and schema components. This includes logic to resolve naming conflicts by preferring names with more capital letters and updating `$ref` references accordingly.
* Integrated `JsonSchemaNamingConvention.operations` and `JsonSchemaNamingConvention.schemas` into the main orchestration functions (`orchestrateInterfaceSchemas`, `orchestrateInterfaceComplement`, and `orchestrateInterfaceSchemasReview`) to ensure type names are fixed before further processing and merging. [[1]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dR32-R35) [[2]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900R90) [[3]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dL56-R67) [[4]](diffhunk://#diff-149e865311d6c8b3ffbd019c94ce0745effd5d68a52d0183b2e998d7b002c066L51-R55)
* Updated imports to include `JsonSchemaNamingConvention` in relevant files for schema orchestration and review. [[1]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900R19) [[2]](diffhunk://#diff-4116257e896ec9538075562f0bac335c9abf77d1fb2485251410c65d98bb099dR21) [[3]](diffhunk://#diff-149e865311d6c8b3ffbd019c94ce0745effd5d68a52d0183b2e998d7b002c066R20)

**Process and code structure enhancements:**

* Added comments and restructured code in `orchestrateInterfaceSchemas` to clarify the divide-and-conquer approach and the sequence of naming convention application.

These changes collectively improve schema type name consistency and prevent issues from duplicate or ambiguous type names in OpenAPI workflows.