### PR TITLE
fix(agent): remove `console.log` snippets

### DIFF
--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeWrite.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeWrite.ts
@@ -28,7 +28,7 @@ export const orchestrateAnalyzeWrite = async <Model extends ILlmSchema.Model>(
   const pointer: IPointer<IAutoBeAnalyzeWriteApplication.IProps | null> = {
     value: null,
   };
-  const { histories, tokenUsage } = await ctx.conversate({
+  const { tokenUsage } = await ctx.conversate({
     source: "analyzeWrite",
     controller: createController<Model>({
       model: ctx.model,
@@ -39,10 +39,8 @@ export const orchestrateAnalyzeWrite = async <Model extends ILlmSchema.Model>(
     promptCacheKey,
     message: "Write requirement analysis report.",
   });
-  if (pointer.value === null) {
-    console.log(JSON.stringify(histories, null, 2));
+  if (pointer.value === null)
     throw new Error("The Analyze Agent failed to create the document.");
-  }
 
   const event: AutoBeAnalyzeWriteEvent = {
     type: "analyzeWrite",

--- a/packages/agent/src/orchestrate/test/orchestrateTestCorrect.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestCorrect.ts
@@ -75,10 +75,6 @@ export const orchestrateTestCorrect = async <Model extends ILlmSchema.Model>(
             ctx.retry,
           );
         } catch {
-          console.log(
-            "failed to correct test code, no function calling happened.",
-            w.scenario.functionName,
-          );
           return null;
         }
       }),

--- a/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
@@ -180,7 +180,6 @@ const divideAndConquer = async <Model extends ILlmSchema.Model>(
     });
     return pointer.value;
   } catch {
-    console.log("test scenario, failed to function call", props.include);
     return [];
   }
 };

--- a/packages/agent/src/orchestrate/test/orchestrateTestWrite.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestWrite.ts
@@ -51,10 +51,6 @@ export async function orchestrateTestWrite<Model extends ILlmSchema.Model>(
           event,
         };
       } catch {
-        console.log(
-          "failed to write test code, no function calling happened.",
-          scenario.functionName,
-        );
         return null;
       }
     }),


### PR DESCRIPTION
This pull request focuses on cleaning up error handling and logging across several orchestration modules in the agent package. The main improvements involve removing unnecessary `console.log` statements for failed function calls and streamlining error handling logic, which makes the codebase cleaner and less noisy.

Error handling and logging cleanup:

* Removed `console.log` statements that logged failed function calls in `orchestrateTestCorrect.ts`, `orchestrateTestScenario.ts`, and `orchestrateTestWrite.ts`, reducing unnecessary output and improving code clarity. [[1]](diffhunk://#diff-884758dfb882ce4573dac533bfef2f812d974b58bd7bd9a384ddb3cb7f47ffd9L78-L81) [[2]](diffhunk://#diff-4c52729a4e10e87bb801cf5adbae7129bc5521c9cbc322a07b5b8e587a338398L183) [[3]](diffhunk://#diff-3f2b71ac6d4d63f969a6376806e9d4870c03a47e4dcc76ef909f95f92e110485L54-L57)

Logic simplification:

* Simplified error handling in `orchestrateAnalyzeWrite.ts` by removing logging of histories and directly throwing an error when the agent fails to create a document.
* Removed unused `histories` variable from the result of `ctx.conversate` in `orchestrateAnalyzeWrite.ts`, further streamlining the function.