### PR TITLE
fix(hackathon): fix `getFiles()`

### DIFF
--- a/apps/hackathon-server/src/providers/sessions/acceptors/AutoBeHackathonSessionCompiler.ts
+++ b/apps/hackathon-server/src/providers/sessions/acceptors/AutoBeHackathonSessionCompiler.ts
@@ -25,7 +25,7 @@ const compiler = new Singleton(async (): Promise<IAutoBeCompiler> => {
     "process",
   );
   await compiler.connect(
-    `${__dirname}/../../executable/compiler${path.extname(__filename)}`,
+    `${__dirname}/../../../executable/compiler${path.extname(__filename)}`,
   );
   return compiler.getDriver();
 });


### PR DESCRIPTION
This pull request updates the path used to connect to the compiler executable in the `AutoBeHackathonSessionCompiler` provider. The change ensures the correct relative path is used to locate the compiler binary.

* Updated the compiler connection path in `AutoBeHackathonSessionCompiler.ts` to use `../../../executable/compiler` instead of `../../executable/compiler`, ensuring the executable is correctly located.