### PR TITLE
fix(hackathon): rollback pm2

### DIFF
--- a/apps/hackathon-server/ecosystem.config.js
+++ b/apps/hackathon-server/ecosystem.config.js
@@ -2,8 +2,9 @@ module.exports = {
   apps: [
     {
       name: "hackathon-server",
-      script: "pnpm",
-      args: "run start",
+      script: "src/executable/server.ts",
+      interpreter: "pnpm",
+      interpreter_args: "-r ts-node/register",
       instances: 4,
       exec_mode: "cluster",
     },


### PR DESCRIPTION
This pull request updates the configuration for running the `hackathon-server` application in `ecosystem.config.js`. The main change is to start the server directly from the TypeScript entry point using `ts-node`, rather than running the build script via `pnpm`.

Configuration changes for server startup:

* The `script` is now set to `src/executable/server.ts` to run the TypeScript source directly.
* The `interpreter` is set to `pnpm` with `interpreter_args` configured to use `-r ts-node/register`, enabling direct execution of TypeScript files with runtime transpilation.