### PR TITLE
feat(hackathon): replay flag feature for websocket connect

### DIFF
--- a/apps/hackathon-server/src/controllers/participants/AutoBeHackathonParticipantSessionSocketController.ts
+++ b/apps/hackathon-server/src/controllers/participants/AutoBeHackathonParticipantSessionSocketController.ts
@@ -22,12 +22,14 @@ export class AutoBeHackathonParticipantSessionSocketController {
     >,
     @WebSocketRoute.Param("hackathonCode") hackathonCode: string,
     @WebSocketRoute.Param("id") id: string & tags.Format<"uuid">,
+    @WebSocketRoute.Query() query: IAutoBeHackathonSession.IQuery,
   ): Promise<void> {
     try {
       await AutoBeHackathonSessionSocketProvider.connect({
         hackathonCode,
         id,
         acceptor,
+        query,
       });
     } catch {}
   }

--- a/apps/hackathon-server/src/providers/sessions/AutoBeHackathonSessionSocketProvider.ts
+++ b/apps/hackathon-server/src/providers/sessions/AutoBeHackathonSessionSocketProvider.ts
@@ -26,6 +26,7 @@ export namespace AutoBeHackathonSessionSocketProvider {
       IAutoBeRpcService,
       IAutoBeRpcListener
     >;
+    query: IAutoBeHackathonSession.IQuery;
   }): Promise<void> => {
     // PREPARE RELATED ENTITIES
     const hackathon: IAutoBeHackathon = await findHackathon(props);
@@ -52,6 +53,7 @@ export namespace AutoBeHackathonSessionSocketProvider {
       session,
       connection,
       acceptor: props.acceptor,
+      query: props.query,
     });
   };
 

--- a/apps/hackathon-server/src/providers/sessions/acceptors/AutoBeHackathonSessionSocketAcceptor.ts
+++ b/apps/hackathon-server/src/providers/sessions/acceptors/AutoBeHackathonSessionSocketAcceptor.ts
@@ -30,8 +30,12 @@ export namespace AutoBeHackathonSessionSocketAcceptor {
     session: IAutoBeHackathonSession.ISummary;
     connection: IEntity;
     acceptor: WebSocketAcceptor<unknown, IAutoBeRpcService, IAutoBeRpcListener>;
+    query: IAutoBeHackathonSession.IQuery;
   }): Promise<void> => {
-    const { histories, snapshots } = await startReplay(props);
+    const { histories, snapshots } = await startReplay({
+      ...props,
+      replay: !props.query?.noReplay,
+    });
     const listener: Driver<IAutoBeRpcListener> = props.acceptor.getDriver();
     if (histories.length !== 0)
       while (true) {
@@ -65,7 +69,10 @@ export namespace AutoBeHackathonSessionSocketAcceptor {
     connection: IEntity;
     acceptor: WebSocketAcceptor<unknown, IAutoBeRpcService, IAutoBeRpcListener>;
   }): Promise<void> => {
-    await startReplay(props);
+    await startReplay({
+      ...props,
+      replay: true,
+    });
   };
 
   export const simulate = async (props: {
@@ -88,6 +95,7 @@ export namespace AutoBeHackathonSessionSocketAcceptor {
     session: IAutoBeHackathonSession.ISummary;
     connection: IEntity;
     acceptor: WebSocketAcceptor<unknown, IAutoBeRpcService, IAutoBeRpcListener>;
+    replay: boolean;
   }) => {
     const histories: AutoBeHistory[] =
       await AutoBeHackathonSessionHistoryProvider.getAll({

--- a/packages/interface/src/hackathon/IAutoBeHackathonSession.ts
+++ b/packages/interface/src/hackathon/IAutoBeHackathonSession.ts
@@ -41,4 +41,7 @@ export namespace IAutoBeHackathonSession {
   export interface IHeader {
     Authorization: string;
   }
+  export interface IQuery {
+    noReplay?: boolean | undefined;
+  }
 }


### PR DESCRIPTION
This pull request adds support for passing query parameters to hackathon participant session WebSocket connections, specifically enabling clients to control replay behavior via the new `noReplay` query parameter. The changes propagate this query parameter through the API, server controller, provider, and acceptor layers, and update the connection path construction to include query parameters.

**Support for query parameters in session connections:**

* Added a new `IQuery` type to `IAutoBeHackathonSession` to define allowed query parameters, including the `noReplay` boolean for controlling replay.
* Updated the `connect` API and related types to accept a `query` parameter, and modified the connection path builder to append query parameters to the URL. [[1]](diffhunk://#diff-6844bab10561706ac57e63d0ab7a1e182cc498e50c64c9896ded26e1274b301bR304) [[2]](diffhunk://#diff-6844bab10561706ac57e63d0ab7a1e182cc498e50c64c9896ded26e1274b301bR329-R346) [[3]](diffhunk://#diff-6844bab10561706ac57e63d0ab7a1e182cc498e50c64c9896ded26e1274b301bL312-R313)

**Propagation and handling of the query parameter in the backend:**

* Modified the server-side controller and provider to accept and forward the `query` parameter when establishing a session connection. [[1]](diffhunk://#diff-4a24e3fab49658a2fb9439ab3107a3d74bbee712f038a00182cdf2c218c5adb4R25-R32) [[2]](diffhunk://#diff-17ea997bd272a770e2c1e25fcee8fb5b78cf86e1f5ec903180f1c6df31ea813fR29) [[3]](diffhunk://#diff-17ea997bd272a770e2c1e25fcee8fb5b78cf86e1f5ec903180f1c6df31ea813fR56)
* Updated the session acceptor logic to use the `noReplay` value from the query parameter to control whether replay is performed for the session, and refactored related function signatures to support this. [[1]](diffhunk://#diff-dc176e465211555f56089aa23f94c75a26b7993bd3b8890adf7757d72e0b6f8eR33-R38) [[2]](diffhunk://#diff-dc176e465211555f56089aa23f94c75a26b7993bd3b8890adf7757d72e0b6f8eL68-R75) [[3]](diffhunk://#diff-dc176e465211555f56089aa23f94c75a26b7993bd3b8890adf7757d72e0b6f8eR98)