### PR TITLE
fix(hackathon): no more query parameter required

### DIFF
--- a/apps/hackathon-api/src/functional/autobe/hackathon/participants/sessions/index.ts
+++ b/apps/hackathon-api/src/functional/autobe/hackathon/participants/sessions/index.ts
@@ -301,7 +301,6 @@ export async function connect(
   connection: IConnection<connect.Header>,
   hackathonCode: string,
   id: string & tags.Format<"uuid">,
-  query: connect.Query,
   provider: connect.Provider,
 ): Promise<connect.Output> {
   const connector: WebSocketConnector<
@@ -310,7 +309,7 @@ export async function connect(
     connect.Listener
   > = new WebSocketConnector(connection.headers ?? ({} as any), provider);
   await connector.connect(
-    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${connect.path(hackathonCode, id, query)}`,
+    `${connection.host.endsWith("/") ? connection.host.substring(0, connection.host.length - 1) : connection.host}${connect.path(hackathonCode, id)}`,
   );
   const driver: Driver<connect.Listener> = connector.getDriver();
   return {
@@ -326,24 +325,12 @@ export namespace connect {
   export type Header = IAutoBeHackathonSession.IHeader;
   export type Provider = IAutoBeRpcListener;
   export type Listener = IAutoBeRpcService;
-  export type Query = IAutoBeHackathonSession.IQuery;
 
   export const path = (
     hackathonCode: string,
     id: string & tags.Format<"uuid">,
-    query: Query,
-  ) => {
-    const variables: URLSearchParams = new URLSearchParams();
-    for (const [key, value] of Object.entries(query as any))
-      if (undefined === value) continue;
-      else if (Array.isArray(value))
-        value.forEach((elem: any) => variables.append(key, String(elem)));
-      else variables.set(key, String(value));
-    const location: string = `/autobe/hackathon/${encodeURIComponent(hackathonCode?.toString() ?? "null")}/participants/sessions/${encodeURIComponent(id?.toString() ?? "null")}/connect`;
-    return 0 === variables.size
-      ? location
-      : `${location}?${variables.toString()}`;
-  };
+  ) =>
+    `/autobe/hackathon/${encodeURIComponent(hackathonCode?.toString() ?? "null")}/participants/sessions/${encodeURIComponent(id?.toString() ?? "null")}/connect`;
 }
 
 /**

--- a/apps/hackathon-server/src/controllers/participants/AutoBeHackathonParticipantSessionSocketController.ts
+++ b/apps/hackathon-server/src/controllers/participants/AutoBeHackathonParticipantSessionSocketController.ts
@@ -22,14 +22,12 @@ export class AutoBeHackathonParticipantSessionSocketController {
     >,
     @WebSocketRoute.Param("hackathonCode") hackathonCode: string,
     @WebSocketRoute.Param("id") id: string & tags.Format<"uuid">,
-    @WebSocketRoute.Query() query: IAutoBeHackathonSession.IQuery,
   ): Promise<void> {
     try {
       await AutoBeHackathonSessionSocketProvider.connect({
         hackathonCode,
         id,
         acceptor,
-        query,
       });
     } catch {}
   }

--- a/apps/hackathon-server/src/providers/sessions/AutoBeHackathonSessionSocketProvider.ts
+++ b/apps/hackathon-server/src/providers/sessions/AutoBeHackathonSessionSocketProvider.ts
@@ -26,7 +26,6 @@ export namespace AutoBeHackathonSessionSocketProvider {
       IAutoBeRpcService,
       IAutoBeRpcListener
     >;
-    query: IAutoBeHackathonSession.IQuery;
   }): Promise<void> => {
     // PREPARE RELATED ENTITIES
     const hackathon: IAutoBeHackathon = await findHackathon(props);
@@ -53,7 +52,6 @@ export namespace AutoBeHackathonSessionSocketProvider {
       session,
       connection,
       acceptor: props.acceptor,
-      query: props.query,
     });
   };
 

--- a/apps/hackathon-server/src/providers/sessions/acceptors/AutoBeHackathonSessionSocketAcceptor.ts
+++ b/apps/hackathon-server/src/providers/sessions/acceptors/AutoBeHackathonSessionSocketAcceptor.ts
@@ -30,12 +30,8 @@ export namespace AutoBeHackathonSessionSocketAcceptor {
     session: IAutoBeHackathonSession.ISummary;
     connection: IEntity;
     acceptor: WebSocketAcceptor<unknown, IAutoBeRpcService, IAutoBeRpcListener>;
-    query: IAutoBeHackathonSession.IQuery;
   }): Promise<void> => {
-    const { histories, snapshots } = await startReplay({
-      ...props,
-      replay: !props.query?.noReplay,
-    });
+    const { histories, snapshots } = await startReplay(props);
     const listener: Driver<IAutoBeRpcListener> = props.acceptor.getDriver();
     if (histories.length !== 0)
       while (true) {
@@ -69,10 +65,7 @@ export namespace AutoBeHackathonSessionSocketAcceptor {
     connection: IEntity;
     acceptor: WebSocketAcceptor<unknown, IAutoBeRpcService, IAutoBeRpcListener>;
   }): Promise<void> => {
-    await startReplay({
-      ...props,
-      replay: true,
-    });
+    await startReplay(props);
   };
 
   export const simulate = async (props: {
@@ -95,7 +88,6 @@ export namespace AutoBeHackathonSessionSocketAcceptor {
     session: IAutoBeHackathonSession.ISummary;
     connection: IEntity;
     acceptor: WebSocketAcceptor<unknown, IAutoBeRpcService, IAutoBeRpcListener>;
-    replay: boolean;
   }) => {
     const histories: AutoBeHistory[] =
       await AutoBeHackathonSessionHistoryProvider.getAll({

--- a/packages/interface/src/hackathon/IAutoBeHackathonSession.ts
+++ b/packages/interface/src/hackathon/IAutoBeHackathonSession.ts
@@ -41,7 +41,4 @@ export namespace IAutoBeHackathonSession {
   export interface IHeader {
     Authorization: string;
   }
-  export interface IQuery {
-    noReplay?: boolean | undefined;
-  }
 }


### PR DESCRIPTION
This pull request refactors the session connection flow for hackathon participants by removing the use of the `query` parameter (specifically the `noReplay` flag) from the WebSocket connection and related interfaces. The logic for controlling replay behavior is now handled internally rather than being passed through the API, simplifying the interface and reducing unnecessary data propagation.

**API and Interface Simplification**

* Removed the `query` parameter from the `connect` function signature, the `connect.path` method, and related WebSocket connection logic in `apps/hackathon-api/src/functional/autobe/hackathon/participants/sessions/index.ts`. [[1]](diffhunk://#diff-6844bab10561706ac57e63d0ab7a1e182cc498e50c64c9896ded26e1274b301bL304) [[2]](diffhunk://#diff-6844bab10561706ac57e63d0ab7a1e182cc498e50c64c9896ded26e1274b301bL313-R312) [[3]](diffhunk://#diff-6844bab10561706ac57e63d0ab7a1e182cc498e50c64c9896ded26e1274b301bL329-R333)
* Deleted the `IQuery` interface from `IAutoBeHackathonSession` in `packages/interface/src/hackathon/IAutoBeHackathonSession.ts`.

**Server-Side Refactoring**

* Removed the `query` argument from controller and provider methods, including `AutoBeHackathonParticipantSessionSocketController` and `AutoBeHackathonSessionSocketProvider`, as well as the acceptor logic in `apps/hackathon-server/src/controllers/participants/AutoBeHackathonParticipantSessionSocketController.ts` and `apps/hackathon-server/src/providers/sessions/AutoBeHackathonSessionSocketProvider.ts`. [[1]](diffhunk://#diff-4a24e3fab49658a2fb9439ab3107a3d74bbee712f038a00182cdf2c218c5adb4L25-L32) [[2]](diffhunk://#diff-17ea997bd272a770e2c1e25fcee8fb5b78cf86e1f5ec903180f1c6df31ea813fL29) [[3]](diffhunk://#diff-17ea997bd272a770e2c1e25fcee8fb5b78cf86e1f5ec903180f1c6df31ea813fL56)
* Updated `AutoBeHackathonSessionSocketAcceptor` and its usage of `startReplay` to remove dependency on the `query` parameter and the explicit `replay` flag, streamlining replay logic. [[1]](diffhunk://#diff-dc176e465211555f56089aa23f94c75a26b7993bd3b8890adf7757d72e0b6f8eL33-R34) [[2]](diffhunk://#diff-dc176e465211555f56089aa23f94c75a26b7993bd3b8890adf7757d72e0b6f8eL72-R68) [[3]](diffhunk://#diff-dc176e465211555f56089aa23f94c75a26b7993bd3b8890adf7757d72e0b6f8eL98)