### PR TITLE
feat(hackathon): unlimit session creation

### DIFF
--- a/apps/hackathon-server/src/providers/sessions/AutoBeHackathonSessionProvider.ts
+++ b/apps/hackathon-server/src/providers/sessions/AutoBeHackathonSessionProvider.ts
@@ -158,6 +158,7 @@ export namespace AutoBeHackathonSessionProvider {
               autobe_hackathon_id: props.hackathon.id,
               autobe_hackathon_participant_id: props.participant.id,
               model: "qwen/qwen3-next-80b-a3b-instruc",
+              deleted_at: null,
             },
           });
         if (count >= 10)
@@ -173,6 +174,7 @@ export namespace AutoBeHackathonSessionProvider {
               autobe_hackathon_id: props.hackathon.id,
               autobe_hackathon_participant_id: props.participant.id,
               model: "openai/gpt-4.1-mini",
+              deleted_at: null,
             },
           });
         if (count >= 3)
@@ -189,6 +191,7 @@ export namespace AutoBeHackathonSessionProvider {
               autobe_hackathon_participant_id: props.participant.id,
               model: "openai/gpt-4.1-mini",
               completed_at: { not: null },
+              deleted_at: null,
             },
           });
         if (completed === 0)
@@ -205,6 +208,7 @@ export namespace AutoBeHackathonSessionProvider {
               autobe_hackathon_id: props.hackathon.id,
               autobe_hackathon_participant_id: props.participant.id,
               model: "openai/gpt-4.1",
+              deleted_at: null,
             },
           });
         if (duplicated !== 0)


### PR DESCRIPTION
This pull request adds an extra filter to several queries in the `AutoBeHackathonSessionProvider` to ensure that only sessions which have not been deleted (i.e., where `deleted_at` is `null`) are considered. This helps prevent accidentally including soft-deleted sessions in logic that counts or checks session records.

**Query filtering improvements:**

* Added `deleted_at: null` to all session queries to exclude soft-deleted records when counting or checking hackathon sessions in `AutoBeHackathonSessionProvider.ts`. [[1]](diffhunk://#diff-4299718e9deef84787955e8eaa3bf23687058f216886cadd8721467f9bccbd3cR161) [[2]](diffhunk://#diff-4299718e9deef84787955e8eaa3bf23687058f216886cadd8721467f9bccbd3cR177) [[3]](diffhunk://#diff-4299718e9deef84787955e8eaa3bf23687058f216886cadd8721467f9bccbd3cR194) [[4]](diffhunk://#diff-4299718e9deef84787955e8eaa3bf23687058f216886cadd8721467f9bccbd3cR211)