### PR TITLE
feat(hackathon): report generator

### DIFF
--- a/apps/hackathon-server/.gitignore
+++ b/apps/hackathon-server/.gitignore
@@ -1,3 +1,4 @@
 assets/participants.csv
 prisma/migrations
 prisma/schema/migrations
+results/

--- a/apps/hackathon-server/src/executable/report.ts
+++ b/apps/hackathon-server/src/executable/report.ts
@@ -1,0 +1,17 @@
+import { FileSystemIterator } from "@autobe/filesystem";
+
+import { AutoBeHackathonConfiguration } from "../AutoBeHackathonConfiguration";
+import { AutoBeHackathonSessionReporter } from "../providers/reports/AutoBeHackathonSessionReporter";
+
+const main = async (): Promise<void> => {
+  const files: Record<string, string> =
+    await AutoBeHackathonSessionReporter.report();
+  await FileSystemIterator.save({
+    root: `${AutoBeHackathonConfiguration.ROOT}/results/20250912`,
+    files,
+  });
+};
+main().catch((error) => {
+  console.log(error);
+  process.exit(-1);
+});

--- a/apps/hackathon-server/src/providers/reports/AutoBeHackathonSessionReporter.ts
+++ b/apps/hackathon-server/src/providers/reports/AutoBeHackathonSessionReporter.ts
@@ -1,0 +1,217 @@
+import { AutoBeAgent } from "@autobe/agent";
+import { AutoBeCompiler } from "@autobe/compiler";
+import { AutoBeHistory, IAutoBeHackathonSession } from "@autobe/interface";
+import { ArrayUtil } from "@nestia/e2e";
+import OpenAI from "openai";
+
+import { StringUtil } from "../../../../../packages/utils/src";
+import { AutoBeHackathonGlobal } from "../../AutoBeHackathonGlobal";
+import { AutoBeHackathonSessionProvider } from "../sessions/AutoBeHackathonSessionProvider";
+
+export namespace AutoBeHackathonSessionReporter {
+  export const report = async (): Promise<Record<string, string>> => {
+    const records =
+      await AutoBeHackathonGlobal.prisma.autobe_hackathon_sessions.findMany({
+        where: {
+          review_article_url: {
+            not: null,
+          },
+          deleted_at: null,
+        },
+        orderBy: [
+          {
+            participant: { email: "asc" },
+          },
+          { model: "asc" },
+          { created_at: "asc" },
+        ],
+        ...AutoBeHackathonSessionProvider.summarize.select(),
+      });
+    const summaries: IAutoBeHackathonSession.ISummary[] = records.map(
+      AutoBeHackathonSessionProvider.summarize.transform,
+    );
+
+    const output: Record<string, string> = {
+      "README.md": index(summaries),
+    };
+    await ArrayUtil.asyncForEach(summaries, async (s, i) => {
+      console.log(`Processing session: ${i + 1} of ${records.length}`);
+      const detailed: IAutoBeHackathonSession =
+        AutoBeHackathonSessionProvider.json.transform(
+          await AutoBeHackathonGlobal.prisma.autobe_hackathon_sessions.findFirstOrThrow(
+            {
+              where: {
+                id: s.id,
+              },
+              ...AutoBeHackathonSessionProvider.json.select(),
+            },
+          ),
+        );
+      const agent: AutoBeAgent<"chatgpt"> = new AutoBeAgent({
+        model: "chatgpt",
+        vendor: {
+          api: new OpenAI({ apiKey: "********" }),
+          model: s.model,
+        },
+        compiler: (listener) => new AutoBeCompiler(listener),
+        histories: detailed.histories,
+      });
+      const files: Record<string, string> = await agent.getFiles({
+        dbms: "sqlite",
+      });
+      for (const [key, value] of Object.entries(files))
+        output[`${s.id}/${key}`] = value;
+      output[`${s.id}/README.md`] = at(detailed);
+    });
+    return output;
+  };
+
+  const index = (sessions: IAutoBeHackathonSession.ISummary[]): string => {
+    const row = (s: IAutoBeHackathonSession.ISummary, i: number): string =>
+      [
+        `[${i + 1}](./${s.id})`,
+        `[${s.participant.name}](./${s.id})`,
+        `[\`${s.model}\`](./${s.id})`,
+        `[\`${s.phase}\`](./${s.id})`,
+        `[wrtnlabs/autobe/discussions/${s.review_article_url?.split("https://github.com/wrtnlabs/autobe/discussions/")[1]?.split("#")[0]}](${s.review_article_url})`,
+      ].join(" | ");
+    return StringUtil.trim`
+      # AutoBe Hackathon 2025
+
+      > https://autobe.dev/docs/hackathon/
+
+      Generation results of AutoBe Hackathon 2025 participants.
+      
+       No | Participant | Model | Phase | Review Article 
+      ----|-------------|-------|-------|----------------
+      ${sessions.map(row).join("\n")},
+    `;
+  };
+
+  const at = (session: IAutoBeHackathonSession): string => {
+    const history = (h: AutoBeHistory, i: number): string => {
+      const title = (str: string): string => `## ${i + 1}. ${str}`;
+      if (h.type === "userMessage")
+        return StringUtil.trim`
+          ${title("User Message")}
+
+          ${h.contents
+            .map((c) => {
+              if (c.type === "file")
+                return c.file.type === "base64"
+                  ? "BASE 64 FILE"
+                  : "OPENAI STORE FILE: " + c.file.id;
+              else if (c.type === "image")
+                return c.image.type === "base64"
+                  ? "BASE 64 IMAGE"
+                  : c.image.url;
+              else if (c.type === "audio") return "AUDIO FILE";
+              return c.text
+                .split("\n")
+                .map((s) => `> ${s}`)
+                .join("\n");
+            })
+            .join("\n\n")}
+        `;
+      else if (h.type === "assistantMessage")
+        return StringUtil.trim`
+          ${title("Assistant Message")}
+
+          ${h.text
+            .split("\n")
+            .map((s) => `> ${s}`)
+            .join("\n")}
+        `;
+      else if (h.type === "analyze")
+        return StringUtil.trim`
+          ${title("Analyze")}
+
+          ### Roles
+
+          Name | Kind | Description
+          -----|------|--------------
+          ${h.roles.map((r) => `${r.name} | ${r.kind} | ${r.description} `).join("\n")}
+
+          ### Documents
+
+          ${h.files.map((f) => `- [\`docs/analysis/${f.filename}\`](./docs/analysis/${f.filename})`).join("\n")}
+        `;
+      else if (h.type === "prisma") {
+        let value: string = StringUtil.trim`
+          ${title("Prisma")}
+
+          - document: [\`ERD.md\`](./docs/ERD.md)
+          - namespaces: ${h.result.data.files.length.toLocaleString()}
+          - tables: ${h.result.data.files
+            .map((f) => f.models)
+            .flat()
+            .length.toLocaleString()}
+          - success: ${h.result.success}
+        `;
+        if (h.result.success === false)
+          value +=
+            "\n\n" +
+            StringUtil.trim`
+              \`\`\`json
+              ${JSON.stringify(h.result.errors, null, 2)}
+              \`\`\`
+            `;
+        return value;
+      } else if (h.type === "interface")
+        return StringUtil.trim`
+          ${title("Interface")}
+
+          - operations: ${h.document.operations.length.toLocaleString()}
+          - schemas: ${Object.keys(h.document.components.schemas).length.toLocaleString()}
+        `;
+      else if (h.type === "test") {
+        let value: string = StringUtil.trim`
+          ${title("Test")}
+
+          - functions: ${h.files.length.toLocaleString()}
+          - success: ${h.compiled.type === "success"}
+        `;
+        if (h.compiled.type === "failure")
+          value +=
+            "\n\n" +
+            StringUtil.trim`
+              \`\`\`json
+              ${JSON.stringify(h.compiled.diagnostics, null, 2)}
+              \`\`\`
+            `;
+        return value;
+      } else if (h.type === "realize") {
+        let value: string = StringUtil.trim`
+          ${title("Realize")}
+
+          - functions: ${h.functions.length.toLocaleString()}
+          - success: ${h.compiled.type === "success"}
+        `;
+        if (h.compiled.type === "failure")
+          value +=
+            "\n\n" +
+            StringUtil.trim`
+              \`\`\`json
+              ${JSON.stringify(h.compiled.diagnostics, null, 2)}
+              \`\`\`
+            `;
+        return value;
+      }
+      h satisfies never;
+      throw new Error("Unknown history type");
+    };
+    const outline: string = StringUtil.trim`
+      # AutoBe Hackathon 2025 Session
+
+      Generation Result of AutoBe Hackathon 2025 participant.
+      
+      - id: [${session.id}](./${session.id})
+      - participant: ${session.participant.name} (${session.participant.email})
+      - model: \`${session.model}\`
+      - phase: \`${session.phase}\`
+      - title: ${session.title}
+      - review: ${session.review_article_url}
+    `;
+    return [outline, ...session.histories.map(history)].join("\n\n");
+  };
+}

--- a/test/src/executable/trim.ts
+++ b/test/src/executable/trim.ts
@@ -1,0 +1,37 @@
+import { StringUtil } from "@autobe/utils";
+import { RandomGenerator } from "@nestia/e2e";
+import typia, { tags } from "typia";
+import { v7 } from "uuid";
+
+const session = {
+  id: v7(),
+  participant: {
+    name: RandomGenerator.name(),
+    email: typia.random<string & tags.Format<"email">>(),
+  },
+  model: "openai/gpt-4.1",
+  phase: "realize",
+  title: "Some title",
+  review_article_url: "https://example.com",
+};
+
+export namespace A {
+  export namespace B {
+    export const value: string = StringUtil.trim`
+        ${"The Title"}
+
+      # AutoBe Hackathon 2025 Session
+
+      Generation Result of AutoBe Hackathon 2025 participant.
+      
+      - id: [${session.id}](./${session.id})
+      - participant: ${session.participant.name} (${session.participant.email})
+      - model: \`${session.model}\`
+      - phase: \`${session.phase}\`
+      - title: ${session.title}
+      - review: ${session.review_article_url}
+      ${[1, 2, 3, 4].map((i) => `  - ${i}`).join("\n")}
+    `;
+  }
+}
+console.log(A.B.value);


### PR DESCRIPTION
This pull request introduces an automated reporting feature for the AutoBe Hackathon server, enabling the generation and export of detailed participant session reports. The changes include a new executable script for report generation, a comprehensive session reporter that fetches, summarizes, and exports session data, and improvements to the string formatting utility to ensure consistent and readable output. Additionally, a new test verifies the updated string trimming logic.

### Reporting and Export Functionality

* Added a new executable script `report.ts` that generates hackathon session reports and saves them to a structured results directory.
* Implemented `AutoBeHackathonSessionReporter`, which retrieves session data from the database, summarizes it, generates detailed participant reports, and exports all relevant files for each session.

### Utility Improvements

* Refactored `StringUtil.trim` to more reliably remove leading/trailing empty lines and dedent multiline template strings, even when interpolated values are present. This ensures consistent formatting in generated markdown and reports.

### Test Coverage

* Added a test in `test/src/executable/trim.ts` to verify the new string trimming and formatting logic, ensuring correct output for multiline markdown with interpolations.

### Project Structure

* Updated `.gitignore` to exclude the new `results/` directory, preventing generated reports from being committed to source control.