### PR TITLE
fix(agent): default timeout to be `null`.

### DIFF
--- a/packages/agent/src/factory/createAutoBeContext.ts
+++ b/packages/agent/src/factory/createAutoBeContext.ts
@@ -57,10 +57,7 @@ export const createAutoBeContext = <Model extends ILlmSchema.Model>(props: {
     {
       retry: props.config.retry ?? AutoBeConfigConstant.RETRY,
       locale: props.config.locale ?? "en-US",
-      timeout:
-        props.config.timeout === null
-          ? null
-          : (props.config.timeout ?? AutoBeConfigConstant.TIMEOUT),
+      timeout: props.config.timeout ?? null,
     };
   const critical: Semaphore = new Semaphore(2);
   return {

--- a/packages/agent/src/structures/IAutoBeConfig.ts
+++ b/packages/agent/src/structures/IAutoBeConfig.ts
@@ -95,7 +95,7 @@ export interface IAutoBeConfig {
    *     timeout: null;
    *   }
    *
-   * @default 1_800_000 (30 minutes)
+   * @default null
    */
   timeout?: number | null;
 


### PR DESCRIPTION
This pull request updates the handling of the `timeout` configuration in the AutoBe agent context to simplify its default behavior and make it more explicit. The most important changes are:

Configuration Defaults:

* Changed the default value for `timeout` in the `IAutoBeConfig` interface from `1_800_000` (30 minutes) to `null`, clarifying that no timeout is set unless explicitly provided.

Context Creation Logic:

* Simplified the logic for setting `timeout` in `createAutoBeContext` so that it defaults to `null` if not specified, removing the previous fallback to a constant value.