### PR TITLE
fix(compiler): wrong template import

### DIFF
--- a/internals/template/realize-of-sqlite/src/executable/schema.ts
+++ b/internals/template/realize-of-sqlite/src/executable/schema.ts
@@ -1,4 +1,4 @@
-import { MyGlobal } from "../../../realize-of-postgres/src/MyGlobal";
+import { MyGlobal } from "../MyGlobal";
 import { MySetupWizard } from "../setup/MySetupWizard";
 
 const main = async (): Promise<void> => {


### PR DESCRIPTION
This pull request updates an import path in the `schema.ts` file to reference the local `MyGlobal` module instead of the one from the Postgres implementation. This ensures the correct, SQLite-specific global configuration is used.

- Changed the import path for `MyGlobal` in `schema.ts` to use the local SQLite version, improving module isolation and preventing cross-database dependencies.