### PR TITLE
fix(playground): restore replay feature

### DIFF
--- a/apps/playground-ui/src/movies/replay/AutoBePlaygroundReplayGetMovie.tsx
+++ b/apps/playground-ui/src/movies/replay/AutoBePlaygroundReplayGetMovie.tsx
@@ -261,7 +261,7 @@ export const AutoBePlaygroundReplayGetMovie = () => {
                   color: theme.palette.text.secondary,
                 }}
               >
-                {props.vendor} • {props.project} • {props.step}
+                {props.vendor} • {props.project} • {props.phase}
               </Typography>
             </Stack>
 
@@ -312,12 +312,12 @@ const getProps = (): IAutoBePlaygroundReplay.IProps | null => {
   const query: URLSearchParams = new URLSearchParams(window.location.search);
   const vendor: string | null = query.get("vendor");
   const project: string | null = query.get("project");
-  const step: string | null = query.get("step");
-  if (vendor === null || project === null || step === null) return null;
+  const phase: string | null = query.get("phase");
+  if (vendor === null || project === null || phase === null) return null;
 
   return {
     vendor,
     project,
-    step: step as "analyze",
+    phase: phase as "analyze",
   };
 };

--- a/apps/playground-ui/src/movies/replay/AutoBePlaygroundReplayProjectMovie.tsx
+++ b/apps/playground-ui/src/movies/replay/AutoBePlaygroundReplayProjectMovie.tsx
@@ -1,4 +1,4 @@
-import { IAutoBePlaygroundReplay } from "@autobe/interface";
+import { AutoBePhase, IAutoBePlaygroundReplay } from "@autobe/interface";
 import {
   AccessTime,
   ArrowForwardIos,
@@ -52,7 +52,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
     return count.toString();
   };
 
-  const getStepColor = (step: string) => {
+  const getPhaseColor = (p: AutoBePhase | null) => {
     const colors = {
       analyze: theme.palette.info.main,
       prisma: theme.palette.secondary.main,
@@ -60,7 +60,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
       test: theme.palette.warning.main,
       realize: theme.palette.success.main,
     };
-    return colors[step as keyof typeof colors] || theme.palette.grey[500];
+    return colors[p as keyof typeof colors] ?? theme.palette.grey[500];
   };
 
   const getVendorColor = (vendor: string) => {
@@ -72,10 +72,9 @@ export const AutoBePlaygroundReplayProjectMovie = ({
     return colors[vendor as keyof typeof colors] || theme.palette.grey[500];
   };
 
-  const steps = ["analyze", "prisma", "interface", "test", "realize"];
-  const getStepIndex = (step: string) => steps.indexOf(step);
-
-  const stepColor = getStepColor(replay.step);
+  const phases = ["analyze", "prisma", "interface", "test", "realize"];
+  const getPhaseIndex = (p: AutoBePhase | null) => phases.indexOf(p ?? "null");
+  const phaseColor = getPhaseColor(replay.phase);
   const vendorColor = getVendorColor(replay.vendor);
 
   return (
@@ -83,17 +82,17 @@ export const AutoBePlaygroundReplayProjectMovie = ({
       sx={{
         height: "100%",
         transition: "all 0.3s ease-in-out",
-        border: `1px solid ${alpha(stepColor, 0.2)}`,
+        border: `1px solid ${alpha(phaseColor, 0.2)}`,
         "&:hover": {
           transform: "translateY(-4px)",
-          boxShadow: `0 8px 24px ${alpha(stepColor, 0.2)}`,
-          borderColor: stepColor,
+          boxShadow: `0 8px 24px ${alpha(phaseColor, 0.2)}`,
+          borderColor: phaseColor,
         },
       }}
     >
       <CardActionArea
         component="a"
-        href={`/replay/get?vendor=${replay.vendor}&project=${replay.project}&step=${replay.step}`}
+        href={`/replay/get?vendor=${replay.vendor}&project=${replay.project}&phase=${replay.phase}`}
         target="_blank"
         sx={{ height: "100%" }}
       >
@@ -148,7 +147,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
           {/* Stepper */}
           <Box sx={{ mb: 2 }}>
             <Stepper
-              activeStep={getStepIndex(replay.step)}
+              activeStep={getPhaseIndex(replay.phase)}
               orientation="vertical"
               sx={{
                 "& .MuiStepConnector-line": {
@@ -174,7 +173,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
                 },
               }}
             >
-              {steps.map((label) => {
+              {phases.map((label) => {
                 const stepData =
                   replay[
                     label as keyof Pick<
@@ -182,7 +181,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
                       "analyze" | "prisma" | "interface" | "test" | "realize"
                     >
                   ];
-                const isCurrentStep = label === replay.step;
+                const isCurrentStep = label === replay.phase;
                 const stepElapsed = stepData?.elapsed || 0;
 
                 let stepIcon;
@@ -201,7 +200,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
                 } else {
                   // Currently executing (success is null but has stepData)
                   stepIcon = undefined;
-                  stepColor = getStepColor(label); // Use step's own color
+                  stepColor = getPhaseColor(label as AutoBePhase | null); // Use step's own color
                 }
 
                 return (
@@ -337,7 +336,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
                 variant="h6"
                 sx={{
                   fontWeight: 600,
-                  color: stepColor,
+                  color: phaseColor,
                   fontSize: {
                     xs: "1rem",
                     sm: "1.1rem",


### PR DESCRIPTION
This pull request refactors the terminology in the replay movie components from "step" to "phase" for improved clarity and consistency. The changes update both the logic and UI to use `phase` instead of `step`, and leverage the `AutoBePhase` type for better type safety. The most important changes are grouped below:

**Terminology and Type Refactoring**

* Replaced all uses of `step` with `phase` in both props and function logic, including query parameter handling, component props, and UI display (`AutoBePlaygroundReplayGetMovie.tsx`, `AutoBePlaygroundReplayProjectMovie.tsx`). [[1]](diffhunk://#diff-d5f2d884d959a77feddd0c2bebcfd9832593e0dc97fb6b0f75729ea5f129f4b4L264-R264) [[2]](diffhunk://#diff-d5f2d884d959a77feddd0c2bebcfd9832593e0dc97fb6b0f75729ea5f129f4b4L315-R321) [[3]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL55-R63) [[4]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL75-R95) [[5]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL151-R150) [[6]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL177-R184) [[7]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL204-R203) [[8]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL340-R339)
* Updated imports to use the `AutoBePhase` type for stricter typing and improved code maintainability (`AutoBePlaygroundReplayProjectMovie.tsx`).

**UI and Logic Updates**

* Changed color logic and stepper logic to use `phase` and `AutoBePhase`, ensuring that UI elements like colors, active step, and navigation correctly reflect the new terminology (`AutoBePlaygroundReplayProjectMovie.tsx`). [[1]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL55-R63) [[2]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL75-R95) [[3]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL151-R150) [[4]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL177-R184) [[5]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL204-R203) [[6]](diffhunk://#diff-b6ec8a3ec0466ad4b9a3720b8d74e243d24863e12780a1fa071307cd70f9c00cL340-R339)
* Updated URLs and navigation to use the `phase` parameter instead of `step` for replay links, ensuring correct routing (`AutoBePlaygroundReplayProjectMovie.tsx`).

These changes improve code clarity, type safety, and ensure the UI matches the updated terminology.