### PR TITLE
Fix(agent) Issue omitting successful cases in realize correct

### DIFF
--- a/packages/agent/src/orchestrate/realize/orchestRateRealizeCorrectCasting.ts
+++ b/packages/agent/src/orchestrate/realize/orchestRateRealizeCorrectCasting.ts
@@ -94,6 +94,12 @@ const correct = async <Model extends ILlmSchema.Model>(
   const locations: string[] = diagnose(event).filter((l) =>
     functions.map((f) => f.location).includes(l),
   );
+  
+  // If no locations to correct, return original functions
+  if (locations.length === 0) {
+    return functions;
+  }
+  
   progress.total += locations.length;
 
   const converted: CorrectionResult[] = await executeCachedBatch(
@@ -220,7 +226,11 @@ const correct = async <Model extends ILlmSchema.Model>(
     life - 1,
   );
 
-  return [...success, ...ignored, ...retriedFunctions];
+  // Get functions that were not modified (not in converted array)
+  const convertedLocations = converted.map(c => c.func.location);
+  const unchanged = functions.filter(f => !convertedLocations.includes(f.location));
+
+  return [...success, ...ignored, ...retriedFunctions, ...unchanged];
 };
 
 /**

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeCorrect.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeCorrect.ts
@@ -123,7 +123,11 @@ async function correct<Model extends ILlmSchema.Model>(
   failures: IAutoBeRealizeFunctionFailure[],
   progress: AutoBeProgressEventBase,
 ): Promise<AutoBeRealizeFunction[]> {
-  const result: AutoBeRealizeFunction[] = await executeCachedBatch(
+  if (locations.length === 0) {
+    return functions;
+  }
+
+  const corrected: AutoBeRealizeFunction[] = await executeCachedBatch(
     locations.map((location) => async (): Promise<AutoBeRealizeFunction> => {
       const scenario = scenarios.find((el) => el.location === location);
       const func = functions.find((el) => el.location === location);
@@ -162,7 +166,11 @@ async function correct<Model extends ILlmSchema.Model>(
     }),
   );
 
-  return result;
+  // Create a map of corrected functions for efficient lookup
+  const correctedMap = new Map(corrected.map((f) => [f.location, f]));
+
+  // Return all functions, with corrected ones replaced
+  return functions.map((func) => correctedMap.get(func.location) || func);
 }
 
 async function step<Model extends ILlmSchema.Model>(

--- a/packages/agent/src/orchestrate/realize/utils/replaceImportStatements.ts
+++ b/packages/agent/src/orchestrate/realize/utils/replaceImportStatements.ts
@@ -54,6 +54,11 @@ function removeAllImports(
     .replace(
       /import\s*\*\s*as\s+jwt\s+from\s*["']jsonwebtoken["']\s*;?\s*/gm,
       "",
+    )
+    // NestJS HttpException
+    .replace(
+      /import\s*{\s*HttpException\s*}\s*from\s*["']@nestjs\/common["']\s*;?\s*/gm,
+      "",
     );
 
   // Remove API structure imports with wrong paths


### PR DESCRIPTION
This pull request improves the robustness and correctness of the function correction logic in the orchestration layer, and enhances import statement handling. The main changes ensure that all functions are returned (including unchanged ones) after correction attempts, and that unnecessary imports are more thoroughly removed.

### Correction logic improvements

* Both `orchestRateRealizeCorrectCasting.ts` and `orchestrateRealizeCorrect.ts` now immediately return the original functions if there are no locations to correct, preventing unnecessary processing. [[1]](diffhunk://#diff-9ada66cc58bbfcf9444f5c1420e69167461ff162c082406e528704bf3dffb40eR97-R102) [[2]](diffhunk://#diff-57bec35823e19aa25460e714cdcd5de0ee7326294efb8c8e6698626c075e7156L126-R130)
* The correction functions now guarantee that all input functions are returned, with corrected ones replaced and unchanged ones preserved, ensuring no functions are lost during the correction process. [[1]](diffhunk://#diff-9ada66cc58bbfcf9444f5c1420e69167461ff162c082406e528704bf3dffb40eL223-R233) [[2]](diffhunk://#diff-57bec35823e19aa25460e714cdcd5de0ee7326294efb8c8e6698626c075e7156L165-R173)

### Import statement handling

* The `replaceImportStatements.ts` utility now removes `HttpException` imports from `@nestjs/common`, in addition to existing patterns, improving cleanup of unused or unwanted imports.