### PR TITLE
feat(agent): realize agent to import every nested types

### DIFF
--- a/packages/agent/src/orchestrate/realize/histories/transformRealizeWriteHistories.ts
+++ b/packages/agent/src/orchestrate/realize/histories/transformRealizeWriteHistories.ts
@@ -100,6 +100,7 @@ export const transformRealizeWriteHistories = (props: {
   const authorizationHistories = operation.authorizationType
     ? transformRealizeWriteAuthorizationsHistories(operation, payloads)
     : [];
+  const document = props.state.interface.document;
 
   return [
     {
@@ -127,11 +128,12 @@ export const transformRealizeWriteHistories = (props: {
       id: v7(),
       type: "systemMessage",
       created_at: new Date().toISOString(),
-      text: getRealizeWriteCodeTemplate(
-        props.scenario,
+      text: getRealizeWriteCodeTemplate({
+        authorization: props.authorization,
+        scenario: props.scenario,
+        schemas: document.components.schemas,
         operation,
-        props.authorization,
-      ),
+      }),
     },
     {
       id: v7(),

--- a/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
@@ -63,6 +63,7 @@ export const orchestrateRealize =
     const scenarios: IAutoBeRealizeScenarioResult[] = operations.map(
       (operation) => generateRealizeScenario(ctx, operation, authorizations),
     );
+    const document: AutoBeOpenApi.IDocument = ctx.state().interface!.document;
 
     const writeProgress: AutoBeProgressEventBase = {
       total: scenarios.length,
@@ -75,10 +76,10 @@ export const orchestrateRealize =
             totalAuthorizations: authorizations,
             authorization: scenario.decoratorEvent ?? null,
             scenario,
+            document,
             progress: writeProgress,
             promptCacheKey,
           };
-
           const code: AutoBeRealizeWriteEvent | null =
             await orchestrateRealizeWrite(ctx, props).catch(() => {
               return orchestrateRealizeWrite(ctx, props).catch(() => null);

--- a/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealize.ts
@@ -29,9 +29,9 @@ export const orchestrateRealize =
     props: IAutoBeApplicationProps,
   ): Promise<AutoBeAssistantMessageHistory | AutoBeRealizeHistory> => {
     // PREDICATION
-    const operations: AutoBeOpenApi.IOperation[] | undefined =
-      ctx.state().interface?.document.operations;
-    if (!operations)
+    const document: AutoBeOpenApi.IDocument | undefined =
+      ctx.state().interface?.document;
+    if (document === undefined)
       throw new Error("Can't do realize agent because operations are nothing.");
 
     const start: Date = new Date();
@@ -60,10 +60,9 @@ export const orchestrateRealize =
       await orchestrateRealizeAuthorization(ctx);
 
     // SCENARIOS
-    const scenarios: IAutoBeRealizeScenarioResult[] = operations.map(
+    const scenarios: IAutoBeRealizeScenarioResult[] = document.operations.map(
       (operation) => generateRealizeScenario(ctx, operation, authorizations),
     );
-    const document: AutoBeOpenApi.IDocument = ctx.state().interface!.document;
 
     const writeProgress: AutoBeProgressEventBase = {
       total: scenarios.length,

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeCorrect.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeCorrect.ts
@@ -220,6 +220,7 @@ async function step<Model extends ILlmSchema.Model>(
 
   pointer.value.revise.final = await replaceImportStatements(ctx, {
     operation: props.scenario.operation,
+    schemas: ctx.state().interface!.document.components.schemas,
     code: pointer.value.revise.final,
     decoratorType: props.authorization?.payload.name,
   });

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeWrite.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeWrite.ts
@@ -1,4 +1,5 @@
 import {
+  AutoBeOpenApi,
   AutoBeProgressEventBase,
   AutoBeRealizeAuthorization,
   AutoBeRealizeWriteEvent,
@@ -20,6 +21,7 @@ import { replaceImportStatements } from "./utils/replaceImportStatements";
 export async function orchestrateRealizeWrite<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   props: {
+    document: AutoBeOpenApi.IDocument;
     totalAuthorizations: AutoBeRealizeAuthorization[];
     authorization: AutoBeRealizeAuthorization | null;
     scenario: IAutoBeRealizeScenarioResult;
@@ -71,6 +73,7 @@ export async function orchestrateRealizeWrite<Model extends ILlmSchema.Model>(
 
   pointer.value.final = await replaceImportStatements(ctx, {
     operation: props.scenario.operation,
+    schemas: props.document.components.schemas,
     code: pointer.value.final,
     decoratorType: props.authorization?.payload.name,
   });

--- a/packages/agent/src/orchestrate/realize/utils/getRealizeWriteCodeTemplate.ts
+++ b/packages/agent/src/orchestrate/realize/utils/getRealizeWriteCodeTemplate.ts
@@ -32,23 +32,24 @@ import { getRealizeWriteImportStatements } from "./getRealizeWriteImportStatemen
  * @param authorization - Authorization context if endpoint is authenticated
  * @returns Complete TypeScript code template as a formatted string
  */
-export function getRealizeWriteCodeTemplate(
-  scenario: IAutoBeRealizeScenarioResult,
-  operation: AutoBeOpenApi.IOperation,
-  authorization: AutoBeRealizeAuthorization | null,
-): string {
+export function getRealizeWriteCodeTemplate(props: {
+  scenario: IAutoBeRealizeScenarioResult;
+  operation: AutoBeOpenApi.IOperation;
+  schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>;
+  authorization: AutoBeRealizeAuthorization | null;
+}): string {
   // Collect all function parameters in order
   const functionParameters: string[] = [];
 
   // Add authentication parameter if needed (e.g., user: IUser, admin: IAdmin)
-  if (authorization && authorization.role.name) {
+  if (props.authorization && props.authorization.role.name) {
     // Debug: Log the values to check what's being used
-    const authParameter = `${authorization.role.name}: ${authorization.payload.name}`;
+    const authParameter = `${props.authorization.role.name}: ${props.authorization.payload.name}`;
     functionParameters.push(authParameter);
   }
 
   // Add path parameters (e.g., id, postId, etc.)
-  const pathParameters = operation.parameters.map((param) => {
+  const pathParameters = props.operation.parameters.map((param) => {
     const paramType = param.schema.type;
     const paramFormat =
       "format" in param.schema
@@ -59,8 +60,8 @@ export function getRealizeWriteCodeTemplate(
   functionParameters.push(...pathParameters);
 
   // Add request body parameter if present
-  if (operation.requestBody?.typeName) {
-    const bodyParameter = `body: ${operation.requestBody.typeName}`;
+  if (props.operation.requestBody?.typeName) {
+    const bodyParameter = `body: ${props.operation.requestBody.typeName}`;
     functionParameters.push(bodyParameter);
   }
 
@@ -79,17 +80,17 @@ export function getRealizeWriteCodeTemplate(
   }
 
   // Determine return type
-  const returnType = operation.responseBody?.typeName ?? "void";
+  const returnType = props.operation.responseBody?.typeName ?? "void";
 
   // Generate the complete template
   return StringUtil.trim`
     Complete the code below, disregard the import part and return only the function part.
 
     \`\`\`typescript
-    ${getRealizeWriteImportStatements(operation).join("\n")} 
+    ${getRealizeWriteImportStatements(props).join("\n")} 
 
     // ONLY YOU HAVE TO WRITE THIS, AND USE IMPORTED.
-    export async function ${scenario.functionName}(${formattedSignature}): Promise<${returnType}> {
+    export async function ${props.scenario.functionName}(${formattedSignature}): Promise<${returnType}> {
       ...
     }
     \`\`\`

--- a/packages/agent/src/orchestrate/realize/utils/replaceImportStatements.ts
+++ b/packages/agent/src/orchestrate/realize/utils/replaceImportStatements.ts
@@ -98,6 +98,7 @@ export async function replaceImportStatements<Model extends ILlmSchema.Model>(
   ctx: AutoBeContext<Model>,
   props: {
     operation: AutoBeOpenApi.IOperation;
+    schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>;
     code: string;
     decoratorType?: string;
   },
@@ -121,7 +122,7 @@ export async function replaceImportStatements<Model extends ILlmSchema.Model>(
   code = removeAllImports(code, typeReferences, decoratorType);
 
   // Build the standard imports
-  const imports = getRealizeWriteImportStatements(operation);
+  const imports = getRealizeWriteImportStatements(props);
 
   // Only add decoratorType import if it exists
   if (decoratorType) {

--- a/test/src/features/realize/internal/validate_agent_realize_write.ts
+++ b/test/src/features/realize/internal/validate_agent_realize_write.ts
@@ -68,6 +68,7 @@ export const validate_agent_realize_write = async (
         const write: AutoBeRealizeWriteEvent = await orchestrateRealizeWrite(
           agent.getContext(),
           {
+            document: agent.getContext().state().interface!.document,
             totalAuthorizations: authorizations,
             authorization: authorization ?? null,
             progress,
@@ -95,6 +96,7 @@ export const validate_agent_realize_write = async (
           agent.getContext(),
           {
             totalAuthorizations: authorizations,
+            document: agent.getContext().state().interface!.document,
             authorization: authorization ?? null,
             progress,
             scenario,


### PR DESCRIPTION
This pull request refactors how OpenAPI document schemas are passed and used throughout the "realize write" orchestration pipeline. The main goal is to ensure that schema information is available wherever code generation and import statement construction are needed, improving type resolution and correctness in generated code.

**Schema propagation and usage improvements:**

* The OpenAPI `document` (specifically, its `components.schemas`) is now passed as a prop throughout the orchestration pipeline, including to `orchestrateRealizeWrite`, `transformRealizeWriteHistories`, and related utilities. This enables more accurate type handling during code generation. [[1]](diffhunk://#diff-f74521d6c5a5a34d8b5390508de3a2898927d3a51783ec2f5451b0d5a4f62aa1R66) [[2]](diffhunk://#diff-f74521d6c5a5a34d8b5390508de3a2898927d3a51783ec2f5451b0d5a4f62aa1R79-L81) [[3]](diffhunk://#diff-86b67cc7427e56ee14766b0e267867b1c42b6dff8ece647f1dc0714a129823a7R103) [[4]](diffhunk://#diff-539abc67bce75f46ea8137bae5fda95dcb07f7068b51d5e6902ac8c09b0f0597R24) [[5]](diffhunk://#diff-27c833571532bf95798b30cd3febf56e92574c35cd055d4c1d7a98c942ef4639R71) [[6]](diffhunk://#diff-27c833571532bf95798b30cd3febf56e92574c35cd055d4c1d7a98c942ef4639R99)

**Code template and import statement generation:**

* The `getRealizeWriteCodeTemplate` function signature now takes a single props object containing `scenario`, `operation`, `schemas`, and `authorization`, and all internal references are updated accordingly. This allows it to pass schema information to import statement generation and parameter construction. [[1]](diffhunk://#diff-86b67cc7427e56ee14766b0e267867b1c42b6dff8ece647f1dc0714a129823a7L130-R136) [[2]](diffhunk://#diff-9f42a70482d047f7815fadfdd98c8b63dcac2da1999e98eecbc644770565e894L35-R52) [[3]](diffhunk://#diff-9f42a70482d047f7815fadfdd98c8b63dcac2da1999e98eecbc644770565e894L62-R64) [[4]](diffhunk://#diff-9f42a70482d047f7815fadfdd98c8b63dcac2da1999e98eecbc644770565e894L82-R93)
* The `getRealizeWriteImportStatements` utility now accepts the full operation and schemas object, and uses `OpenApiTypeChecker` to recursively collect all referenced types from request and response bodies. This results in more complete and accurate import statements in generated code.

**Import replacement and code correction:**

* The `replaceImportStatements` utility now receives schemas and passes them to `getRealizeWriteImportStatements`, ensuring that import statements in generated code are correctly replaced and reflect all necessary types. [[1]](diffhunk://#diff-5283105b77ac3a8b402edc2f840b4946cfaa7fcf5063cd6b30095e5e29ef9ea9R101) [[2]](diffhunk://#diff-5283105b77ac3a8b402edc2f840b4946cfaa7fcf5063cd6b30095e5e29ef9ea9L124-R125) [[3]](diffhunk://#diff-57bec35823e19aa25460e714cdcd5de0ee7326294efb8c8e6698626c075e7156R223) [[4]](diffhunk://#diff-539abc67bce75f46ea8137bae5fda95dcb07f7068b51d5e6902ac8c09b0f0597R76)

**Test updates:**

* Test cases for `orchestrateRealizeWrite` are updated to pass the document schemas, ensuring that tests reflect the new required props and improved code generation. [[1]](diffhunk://#diff-27c833571532bf95798b30cd3febf56e92574c35cd055d4c1d7a98c942ef4639R71) [[2]](diffhunk://#diff-27c833571532bf95798b30cd3febf56e92574c35cd055d4c1d7a98c942ef4639R99)