### PR TITLE
fix(compiler): revert OpenAPI operation name  of duplicated.

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
@@ -7,7 +7,10 @@ import {
   AutoBeOpenApi,
 } from "@autobe/interface";
 import { AutoBeInterfacePrerequisite } from "@autobe/interface/src/histories/contents/AutoBeInterfacePrerequisite";
-import { AutoBeOpenApiEndpointComparator } from "@autobe/utils";
+import {
+  AutoBeOpenApiEndpointComparator,
+  revertOpenApiAccessor,
+} from "@autobe/utils";
 import { ILlmSchema } from "@samchon/openapi";
 import { HashMap, Pair } from "tstl";
 import { v7 } from "uuid";
@@ -142,6 +145,7 @@ export const orchestrateInterface =
           (p) => p.endpoint.method === op.method && p.endpoint.path === op.path,
         )?.prerequisites ?? [];
     });
+    revertOpenApiAccessor(document);
 
     // DO COMPILE
     return ctx.dispatch({

--- a/packages/utils/src/interface/index.ts
+++ b/packages/utils/src/interface/index.ts
@@ -1,4 +1,5 @@
 export * from "./AutoBeOpenApiEndpointComparator";
 export * from "./AutoBeOpenApiTypeChecker";
 export * from "./invertOpenApiDocument";
+export * from "./revertOpenApiAccessor";
 export * from "./transformOpenApiDocument";

--- a/packages/utils/src/interface/revertOpenApiAccessor.ts
+++ b/packages/utils/src/interface/revertOpenApiAccessor.ts
@@ -1,0 +1,27 @@
+import { AutoBeOpenApi } from "@autobe/interface";
+import {
+  HttpMigration,
+  IHttpMigrateApplication,
+  IHttpMigrateRoute,
+  OpenApi,
+} from "@samchon/openapi";
+
+import { transformOpenApiDocument } from "./transformOpenApiDocument";
+
+export const revertOpenApiAccessor = (
+  document: AutoBeOpenApi.IDocument,
+): void => {
+  const regular: OpenApi.IDocument = transformOpenApiDocument(document);
+  const migrate: IHttpMigrateApplication = HttpMigration.application(regular);
+  for (const op of document.operations) {
+    const route: IHttpMigrateRoute | undefined = migrate.routes.find(
+      (r) => r.method === op.method && r.path === op.path,
+    );
+    if (
+      route !== undefined &&
+      route.accessor.length !== 0 &&
+      route.accessor.at(-1) !== op.name
+    )
+      op.name = route.accessor.at(-1)!;
+  }
+};


### PR DESCRIPTION
This pull request introduces a new utility function to help synchronize OpenAPI operation names with their accessor routes and integrates it into the interface orchestration workflow. The main changes are the addition of the `revertOpenApiAccessor` function and its usage to ensure operation names match their corresponding accessor routes after document transformation.

**New utility function for OpenAPI accessor synchronization:**

* Added `revertOpenApiAccessor` in `packages/utils/src/interface/revertOpenApiAccessor.ts`, which updates operation names in an `AutoBeOpenApi.IDocument` to match the last accessor segment from the migrated OpenAPI routes.
* Exported `revertOpenApiAccessor` from the interface utilities index for broader usage.

**Integration into orchestration workflow:**

* Imported `revertOpenApiAccessor` into `packages/agent/src/orchestrate/interface/orchestrateInterface.ts` and called it after prerequisites are resolved, ensuring operation names are accurate before further compilation steps. [[1]](diffhunk://#diff-9011b0c160648b4ccca5ed6c13b2bff42bfd46562d883e13b90885f3e3dcd84eL10-R13) [[2]](diffhunk://#diff-9011b0c160648b4ccca5ed6c13b2bff42bfd46562d883e13b90885f3e3dcd84eR148)