### PR TITLE
feat(test): reporter of failed archiving

### DIFF
--- a/test/src/executable/failures.ts
+++ b/test/src/executable/failures.ts
@@ -1,0 +1,100 @@
+import { AutoBeAgent } from "@autobe/agent";
+import { AutoBeCompiler } from "@autobe/compiler";
+import { FileSystemIterator } from "@autobe/filesystem";
+import { AutoBeHistory, AutoBePhase } from "@autobe/interface";
+import { StringUtil } from "@autobe/utils";
+import fs from "fs";
+import OpenAI from "openai";
+import path from "path";
+import typia from "typia";
+
+import { TestGlobal } from "../TestGlobal";
+import { TestHistory } from "../internal/TestHistory";
+import { TestProject } from "../structures/TestProject";
+
+const main = async (): Promise<void> => {
+  if (fs.existsSync(`${TestGlobal.ROOT}/results`) === true)
+    await fs.promises.rm(`${TestGlobal.ROOT}/results`, {
+      recursive: true,
+    });
+
+  type VendorModel =
+    | "openai/gpt-4.1"
+    | "openai/gpt-4.1-mini"
+    | "openai/gpt-5"
+    | "qwen/qwen3-next-80b-a3b-instruct";
+  const phaseSequence = [
+    "analyze",
+    "prisma",
+    "interface",
+    "test",
+    "realize",
+  ] as const satisfies AutoBePhase[];
+
+  for (const vendor of typia.misc.literals<VendorModel>())
+    for (const project of typia.misc.literals<TestProject>())
+      for (const phase of phaseSequence) {
+        TestGlobal.vendorModel = vendor;
+        if ((await TestHistory.has(project, phase)) === false) continue;
+
+        const histories: AutoBeHistory[] = await TestHistory.getHistories(
+          project,
+          phase,
+        );
+        const last: AutoBeHistory | undefined = histories.at(-1);
+        if (last === undefined) continue;
+        else if (last.type !== "test" && last.type !== "realize") continue;
+        else if (last.compiled.type !== "failure") continue;
+
+        console.log("=======================================================");
+        console.log(vendor, project, phase);
+        console.log("=======================================================");
+        console.log(StringUtil.trim`
+          \`\`\`bash
+          code results/${vendor}/${project}/${phase}
+          pnpm run archive --vendor ${vendor} --project ${project} --from ${phase} > archive.${vendor}.${project}.log
+          \`\`\`
+        `);
+        console.log("\n");
+        console.log(last.compiled.diagnostics);
+        console.log("\n");
+        console.log(
+          Array.from(
+            new Set(
+              last.compiled.diagnostics
+                .map((d) => d.file)
+                .filter((f) => f !== null),
+            ),
+          ).map((f) =>
+            path.resolve(
+              `${TestGlobal.ROOT}/results/${vendor}/${project}/${phase}/${f}`,
+            ),
+          ),
+        );
+        console.log("-------------------------------------------------------");
+        console.log("\n");
+
+        const agent: AutoBeAgent<"chatgpt"> = new AutoBeAgent({
+          model: "chatgpt",
+          vendor: {
+            api: new OpenAI({
+              apiKey: "",
+            }),
+            model: vendor,
+          },
+          compiler: (listener) => new AutoBeCompiler(listener),
+          histories,
+        });
+        const files: Record<string, string> = await agent.getFiles({
+          dbms: "sqlite",
+        });
+        await FileSystemIterator.save({
+          root: `${TestGlobal.ROOT}/results/${vendor}/${project}/${phase}`,
+          files: {
+            ...files,
+            "pnpm-workspace.yaml": "",
+          },
+        });
+      }
+};
+main().catch(console.error);


### PR DESCRIPTION
This pull request adds a new script to the test suite that analyzes failure cases in the results of previous test runs. The script iterates through combinations of vendor models, projects, and phases, identifies failed test or realization phases, and outputs diagnostic information and relevant file paths. It also reconstructs the project files for each failure case using the `AutoBeAgent` and saves them for further inspection.

Failure analysis and reporting:

* Added a script to `test/src/executable/failures.ts` that iterates over vendor models, projects, and phases to identify failed test or realization phases and outputs detailed diagnostic information, including file paths and logs.

Project reconstruction for failures:

* Uses `AutoBeAgent` to reconstruct and save project files for each failure case, enabling easier debugging and inspection of failed runs.