### PR TITLE
feat(agent): check related prisma db schema

### DIFF
--- a/packages/agent/prompts/COMMON_CORRECT_CASTING.md
+++ b/packages/agent/prompts/COMMON_CORRECT_CASTING.md
@@ -16,6 +16,14 @@ Your purpose is to identify and fix TypeScript compilation errors related to typ
 
 Other compilation errors (such as missing imports, syntax errors, or undefined variables) are **NOT your responsibility** and will be handled by subsequent agents.
 
+**🚨 ABSOLUTE COMPILER AUTHORITY 🚨**
+The TypeScript compiler is the ULTIMATE AUTHORITY on code correctness. You MUST:
+- NEVER ignore compiler errors thinking you've "solved" them
+- NEVER assume your fix is correct if the compiler still reports errors
+- NEVER argue that your interpretation is correct over the compiler's
+- ALWAYS trust the compiler's judgment - it is NEVER wrong
+- If the compiler reports an error, the code IS broken, period
+
 This agent achieves its goal through function calling. **Function calling is MANDATORY** - you MUST call the provided function immediately without asking for confirmation or permission.
 
 **REQUIRED ACTIONS:**
@@ -398,6 +406,51 @@ If previous correction attempts failed, you may receive multiple sections showin
 ```
 
 This history helps you understand what corrections were already tried and avoid repeating unsuccessful approaches.
+
+## 🚨 2.5. CRITICAL: Compiler Authority and Error Resolution 🚨
+
+**THE COMPILER IS ALWAYS RIGHT - NO EXCEPTIONS**
+
+This section addresses a critical anti-pattern where AI agents mistakenly believe they've "solved" errors despite persistent compiler complaints. This MUST NEVER happen.
+
+### Absolute Rules:
+
+1. **If the compiler reports an error, the code IS BROKEN**
+   - No amount of reasoning or explanation changes this fact
+   - Your personal belief that the code "should work" is IRRELEVANT
+   - The compiler's judgment is FINAL and ABSOLUTE
+
+2. **NEVER dismiss compiler errors**
+   - ❌ WRONG: "I've fixed the issue, the compiler must be confused"
+   - ❌ WRONG: "This should work, the compiler is being overly strict"
+   - ❌ WRONG: "My solution is correct, ignore the compiler warning"
+   - ✅ CORRECT: "The compiler shows errors, so my fix is incomplete"
+
+3. **When compiler errors persist after your fix:**
+   - Your fix is WRONG, period
+   - Do NOT argue or rationalize
+   - Do NOT claim the compiler is mistaken
+   - Try a different approach immediately
+
+4. **The ONLY acceptable outcome:**
+   - Zero compilation errors
+   - Clean TypeScript compilation
+   - No warnings related to type casting
+
+### Example of FORBIDDEN behavior:
+```typescript
+// Compiler error: Type 'string' is not assignable to type 'number'
+const value: number = "123"; // My fix
+
+// ❌ FORBIDDEN RESPONSE: "I've converted the string to a number conceptually"
+// ❌ FORBIDDEN RESPONSE: "This should work because '123' represents a number"
+// ❌ FORBIDDEN RESPONSE: "The compiler doesn't understand my intention"
+
+// ✅ REQUIRED RESPONSE: "The compiler still shows an error. I need to use parseInt or Number()"
+const value: number = parseInt("123", 10); // Correct fix that satisfies compiler
+```
+
+**REMEMBER**: You are a servant to the compiler, not its master. The compiler's word is LAW.
 
 ## 3. Type Casting Error Patterns and Solutions
 
@@ -1259,6 +1312,15 @@ Before submitting your correction, verify:
 - [ ] If review finds no further issues requiring changes → set `revise.final` to `null`
 - [ ] If review identifies additional problems → provide corrected code in `revise.final`
 - [ ] A `null` value indicates the draft corrections were already optimal
+
+### 4.7. Compiler Authority Verification
+- [ ] NO compiler errors remain after my fix
+- [ ] I have NOT dismissed or ignored any compiler warnings
+- [ ] I have NOT argued that my solution is correct despite compiler errors
+- [ ] I acknowledge the compiler's judgment is FINAL
+- [ ] If errors persist, I admit my fix is WRONG and try alternatives
+
+**CRITICAL REMINDER**: The TypeScript compiler is the ABSOLUTE AUTHORITY. If it reports errors, your code is BROKEN - no exceptions, no excuses, no arguments.
 
 Remember: Your mission is precise correction of type casting and assignment errors. Other agents handle all other types of errors. Stay focused on your specific responsibility.
 

--- a/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
@@ -136,9 +136,9 @@ export const orchestrateInterface =
     );
     if (missedOpenApiSchemas(document).length !== 0) await complement();
 
-    JsonSchemaFactory.removeUnused({
-      operations: document.operations,
-      schemas: document.components.schemas,
+    JsonSchemaFactory.finalize({
+      document,
+      application: ctx.state().prisma!.result.data,
     });
 
     // CONNECT PRE-REQUISITES

--- a/packages/agent/src/orchestrate/realize/histories/transformRealizeCorrectCastingHistories.ts
+++ b/packages/agent/src/orchestrate/realize/histories/transformRealizeCorrectCastingHistories.ts
@@ -32,7 +32,8 @@ export const transformRealizeCorrectCastingHistories = (
           text: StringUtil.trim`
           # Errors
 
-          This is a past code and an error with the code. Please refer to the annotation for the location of the error.
+          This is a past code and an error with the code. 
+          Please refer to the annotation for the location of the error.
 
           ${printErrorHints(f.script, f.diagnostics)}          
           \`\`\`

--- a/packages/agent/src/orchestrate/realize/orchestRateRealizeCorrectCasting.ts
+++ b/packages/agent/src/orchestrate/realize/orchestRateRealizeCorrectCasting.ts
@@ -161,6 +161,7 @@ const correct = async <Model extends ILlmSchema.Model>(
           When modifying, modify the entire code, but not the import statement.
 
           Below is template code you wrote:
+
           ${getRealizeWriteCodeTemplate({
             scenario,
             schemas: ctx.state().interface!.document.components.schemas,
@@ -169,9 +170,21 @@ const correct = async <Model extends ILlmSchema.Model>(
           })}
 
           Current code is as follows:
+
           \`\`\`typescript
           ${func.content}
           \`\`\`
+
+          Also, never use typia.assert and typia.assertGuard like functions
+          to the Prisma types. Your mission is to fixing the casting problem of
+          primitive types like string or number. Prisma type is not your scope.
+          
+          If you take a mistake that casting the Prisma type with the typia.assert
+          function, it would be fallen into the infinite compliation due to extremely
+          complicated Prisma type. Note that, the typia.assert function is allowed 
+          only in the individual property level string or literal type.
+
+          I repeat that, never assert the Prisma type. It's not your mission.
         `,
       });
       ++progress.completed;

--- a/packages/interface/src/openapi/AutoBeOpenApi.ts
+++ b/packages/interface/src/openapi/AutoBeOpenApi.ts
@@ -1483,7 +1483,20 @@ export namespace AutoBeOpenApi {
     export interface IArray extends IJsonSchema.IArray, IDescriptive {}
 
     /** Object type info. */
-    export interface IObject extends IJsonSchema.IObject, IDescriptive {}
+    export interface IObject extends IJsonSchema.IObject, IDescriptive {
+      /**
+       * Related Prisma schema.
+       *
+       * If the type is directly related to a specific Prisma schema model,
+       * include the exact model name here to establish a clear link between the
+       * OpenAPI schema and the Prisma model.
+       *
+       * This field is optional and should only be included when there is a
+       * direct correspondence to a Prisma model. If there's not any Prisma
+       * model association, this field can be omitted.
+       */
+      "x-samchon-prisma-schema"?: string;
+    }
 
     /** Reference type directing named schema. */
     export interface IReference extends IJsonSchema.IReference, IDescriptive {}


### PR DESCRIPTION
This pull request introduces significant improvements to the TypeScript casting correction and OpenAPI/Prisma schema validation prompts, focusing on enforcing strict compiler authority and database schema accuracy. The changes clarify agent responsibilities, add new validation mechanisms, and strengthen critical security and correctness requirements for schema generation and review.

**TypeScript Compiler Authority Enhancements:**

* Added explicit instructions that the TypeScript compiler is the ultimate authority—agents must never dismiss compiler errors, must always trust the compiler, and must not argue with its results. This is reinforced throughout the casting correction prompt, including new checklist items and examples of forbidden behaviors. [[1]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32R19-R26) [[2]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32R410-R454) [[3]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32R1316-R1324)

**OpenAPI/Prisma Schema Validation Improvements:**

* Introduced and documented the `x-samchon-prisma-schema` field, which links OpenAPI schemas to their corresponding Prisma models. This enables automatic validation that every property in the schema exists in the referenced Prisma model, especially timestamp fields. Detailed usage, validation steps, and examples are provided. [[1]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958R150-R179) [[2]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958R612-R621) [[3]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958R781-R789) [[4]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L785-L792)
* Updated schema generation and review checklists to require verification of all fields (especially timestamps) against the actual Prisma schema, and to use the new linkage field for validation. [[1]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958R950-R952) [[2]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958R996-R1004)

**Critical Security and Correction Instructions:**

* Strengthened agent instructions to immediately DELETE forbidden properties (phantom timestamps, password/hash fields, system-managed fields, properties not in Prisma) without leaving comments or deferring fixes. This is now the highest-priority action in schema review and correction. [[1]](diffhunk://#diff-60a344c41adcdefac30efeaf9315461028904b39572abf9a77fff494203a3d38R7-R12) [[2]](diffhunk://#diff-60a344c41adcdefac30efeaf9315461028904b39572abf9a77fff494203a3d38R211-R215) [[3]](diffhunk://#diff-60a344c41adcdefac30efeaf9315461028904b39572abf9a77fff494203a3d38R315-R319) [[4]](diffhunk://#diff-60a344c41adcdefac30efeaf9315461028904b39572abf9a77fff494203a3d38L316-R374) [[5]](diffhunk://#diff-60a344c41adcdefac30efeaf9315461028904b39572abf9a77fff494203a3d38L359-R444) [[6]](diffhunk://#diff-60a344c41adcdefac30efeaf9315461028904b39572abf9a77fff494203a3d38R505-R527)

**Schema Factory Finalization:**

* Changed the schema factory cleanup method from `removeUnused` to `finalize`, now passing the full document and Prisma application data for more robust schema validation and finalization.