### PR TITLE
feat(agent): the concept session and its authorization rule.

### DIFF
--- a/packages/agent/prompts/PRISMA_COMPONENT.md
+++ b/packages/agent/prompts/PRISMA_COMPONENT.md
@@ -61,6 +61,7 @@ Based on enterprise application patterns, organize components into these common 
    - Users, customers, administrators
    - Authentication and authorization
    - User profiles and preferences
+   - Session management for authenticated actors (e.g., `user_sessions`, `administrator_sessions`, `shopping_customer_sessions`)
 
 3. **Business Logic** (`schema-03-{domain}.prisma`)
    - Core business entities specific to the application
@@ -132,6 +133,26 @@ Based on enterprise application patterns, organize components into these common 
    - **Snapshots**: Add `_snapshots` suffix for versioning tables
    - **Junction Tables**: Use both entity names: `user_roles`, `product_categories`
    - **Materialized Views**: Will be handled by the second agent with `mv_` prefix
+   - **Sessions**: For login/token lifecycle, use `*_sessions` per actor type and place them under the Identity/Actors component. Examples: `user_sessions`, `administrator_sessions`, `shopping_customer_sessions`. Ensure snake_case naming and avoid duplicate domain prefixes.
+
+### Sessions for Authenticated Actors (Placement & Naming)
+
+#### Sessions for Authenticated Actors
+
+Authentication session tables must be placed within the Identity/Actors component (`schema-02-actors.prisma`, namespace `Actors`). Each actor class requiring login (e.g., users, administrators, customers) must have a dedicated session table. Table names should follow the `{actor_base}_sessions` pattern in snake_case and plural form (e.g., `user_sessions`, `administrator_sessions`, `shopping_customer_sessions`).
+
+**Key Guidelines:**
+- Each session table references its corresponding actor table via a foreign key (e.g., `user_sessions` → `users.id`).
+- Multiple sessions per actor are allowed; do not use polymorphic or shared session tables.
+- Session tables are strictly for identity and authentication management. Do not place them in business domains such as Orders, Sales, or Commerce.
+
+**Example Table Names:**
+- `user_sessions` (FK → `users.id`)
+- `administrator_sessions` (FK → `administrators.id`)
+- `shopping_customer_sessions` (FK → `shopping_customers.id`)
+
+**Placement Principle:**
+Sessions are an identity/authorization concern and must always reside in the Identity/Actors component for clarity and maintainability.
 
 ### Business Entity Patterns
 

--- a/test/scripts/chat.md
+++ b/test/scripts/chat.md
@@ -443,14 +443,14 @@ model wrtn_enterprise_employees {
 // for audit tracing about individual events
 model wrtn_enterprise_employee_sessions {
   id String @id @uuid
-  wrtn_enterprise_id String @uuid
+  wrtn_enterprise_employee_id String @uuid
   href String
   referrer String
   ip String
   created_at DateTime
   expired_at DateTime?
 
-  @@index([wrtn_enterprise_id, created_at])
+  @@index([wrtn_enterprise_employee_id, created_at])
 }
 
 model wrtn_enterprise_employee_appointments {


### PR DESCRIPTION
This pull request introduces a comprehensive session table pattern for authenticated actors across the Prisma schema documentation and related authorization payloads. The changes standardize how session tables are named, structured, and referenced, and update the JWT payload and TypeScript interfaces to include session identifiers for improved auditability and clarity in authentication flows.

**Session Table Pattern & Schema Guidelines:**

* Added a detailed session table pattern for authenticated actors, specifying exact naming, placement, required fields, and index strategy. Session tables such as `user_sessions`, `administrator_sessions`, and `shopping_customer_sessions` must reside in the Identity/Actors component and follow a strict schema. [[1]](diffhunk://#diff-8edafb48f753cbc0d55a6797a57454bf0920ae0a1f5824e0245fd975031b145bR405-R467) [[2]](diffhunk://#diff-85a1b881b17412dea7440aa323cc512d35268747e18d7151c4035ff3ba467359R136-R155)
* Updated the enterprise component organization guide to explicitly include session management for authenticated actors, clarifying placement and naming conventions.

**Authorization Payload & JWT Structure Updates:**

* Modified the payload interface generation rules to require a `session_id` field alongside the top-level actor ID, ensuring that authorization payloads and JWT tokens always include both identifiers. [[1]](diffhunk://#diff-1b8102596935f0bc672bcf9f70cee518aa1bd03984140be4fff07dd20beeed0eL88-R95) [[2]](diffhunk://#diff-1b8102596935f0bc672bcf9f70cee518aa1bd03984140be4fff07dd20beeed0eR246-R250)
* Revised JWT token structure documentation to reflect the inclusion of `session_id`, and provided example queries for session validation in both extended and standalone actor scenarios.

**Schema Correction:**

* Corrected the session table model in `test/scripts/chat.md` to use the proper foreign key (`wrtn_enterprise_employee_id`) and corresponding index, aligning with the new session table pattern.