### PR TITLE
feat(agent): read reference to be summary DTO.

### DIFF
--- a/packages/agent/prompts/INTERFACE_SCHEMA.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA.md
@@ -2140,13 +2140,13 @@ interface IShoppingOrder.IUpdate {
 ```typescript
 // User → Roles (part of user identity)
 interface IUser {
-  roles: IRole[];  // ✅ Roles define user's permissions
+  roles: IRole.ISummary[];  // ✅ Roles are independent - use .ISummary
 }
 
 // Product → Categories (classification)
 interface IProduct {
-  categories: ICategory[];  // ✅ Product's classifications
-  primary_category: ICategory;  // ✅ Main classification
+  categories: ICategory.ISummary[];  // ✅ Categories are independent - use .ISummary
+  primary_category: ICategory.ISummary;  // ✅ Reference to independent classification
 }
 
 // Team → Members (different actor relation)

--- a/packages/agent/prompts/INTERFACE_SCHEMA_RELATION_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_RELATION_REVIEW.md
@@ -688,7 +688,7 @@ Format violations as follows:
 
 **Read DTO (Response) Violations:**
 - IBbsArticle: Raw bbs_member_id instead of author: IBbsMember.ISummary (forces GET /members/:id)
-- IBbsArticle: Raw category_id instead of category: IBbsCategory (forces GET /categories/:id)
+- IBbsArticle: Raw category_id instead of category: IBbsCategory.ISummary (forces GET /categories/:id)
 - IShoppingSale: Missing units[] composition array (forces GET /sales/:id/units)
 - IShoppingSale: Shallow unit_ids[] instead of full nested units[] (forces N+1 queries)
 
@@ -718,7 +718,7 @@ Format fixes as follows:
 
 **Read DTO Fixes:**
 - TRANSFORMED IBbsArticle.bbs_member_id to author: IBbsMember.ISummary
-- TRANSFORMED IBbsArticle.category_id to category: IBbsCategory
+- TRANSFORMED IBbsArticle.category_id to category: IBbsCategory.ISummary
 - ADDED units: IShoppingSaleUnit[] to IShoppingSale with full depth (options, candidates, stocks)
 - CONVERTED IShoppingSale.unit_ids to units: IShoppingSaleUnit[] with complete nested structure
 


### PR DESCRIPTION
This pull request makes a sweeping improvement to the data transfer object (DTO) schema documentation for the agent prompts, enforcing a universal rule for how entity relationships are represented. The main change is the strict requirement that all BELONGS-TO (reference/association) relations use `.ISummary` types, while HAS-MANY and HAS-ONE (composition) relations use the full detail (base) types. This eliminates the risk of circular references, ensures consistency, and optimizes performance for both detail and summary DTOs. The documentation is updated throughout to explain and enforce this rule, and all relevant interface examples are revised accordingly.

**Key changes by theme:**

**1. Universal Reference Rule Enforcement**
- Introduced "The Circular Reference Prevention Rule," mandating that all BELONGS-TO (reference) relations use `.ISummary` types, and all composition relations use detail types, with thorough rationale and examples.
- Updated all interface definitions and examples (`IBbsArticle`, `IShoppingSale`, etc.) to ensure BELONGS-TO relations use `.ISummary` and compositions use detail types, preventing infinite expansion and circular references. [[1]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L929-R935) [[2]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L1015-R1015) [[3]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L1638-R1638) [[4]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L1703-R1703) [[5]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L1870-R1951) [[6]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L1887-R1980) [[7]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L2159-R2238) [[8]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L2238-R2318) [[9]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L2426-R2507) [[10]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958R2896) [[11]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L2822-R2968)

**2. Documentation and Examples Overhaul**
- Expanded and clarified the documentation for both Detail (IEntity) and Summary (IEntity.ISummary) DTOs, specifying what relations are included/excluded and why, with new example interfaces and rationale.
- Updated the checklist to explicitly require `.ISummary` for all BELONGS-TO relations and detail types for all compositions, and to ensure no circular references exist.

**3. Section and Heading Reorganization**
- Renumbered and reorganized documentation sections to accommodate the new circular reference rule and clarify the distinction between response DTOs, create/update DTOs, and summary/detail DTOs.

**4. Consistency and Performance Improvements**
- Standardized all BELONGS-TO references across interfaces and examples to use `.ISummary`, ensuring smaller, more efficient payloads and easier caching strategies. [[1]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L1638-R1638) [[2]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L2426-R2507)
- Clarified forbidden and required properties for summary DTOs, highlighting performance impacts and best practices.

**5. Minor Fixes and Clarifications**
- Added missing `.ISummary` references in nested interface examples and parent context objects.

These changes collectively enforce a robust, future-proof pattern for DTO design, preventing circular reference issues and making the schema easier to maintain and extend.