### PR TITLE
feat(test): statistics prompt

### DIFF
--- a/test/scripts/chat.md
+++ b/test/scripts/chat.md
@@ -301,7 +301,7 @@ export interface IWrtnChatSession {
 export interface IWrtnEnterpriseEmployee {
   // FK 참조관계 및 has 관계 맵핑
   enterprise: IWrtnEnterprise.ISummary;
-  companions: IWrtnEnterpriseTeamCompanion.ISummary[];
+  companions: IWrtnEnterpriseTeamCompanion[];
 
   // 이후로 자유로이 나머지 속성들을 설계할 것...
   id: string & tags.Format<"uuid">;
@@ -311,6 +311,26 @@ export interface IWrtnEnterpriseEmployee {
   updated_at: string & tags.Format<"date-time">;
   approved_at: string & tags.Format<"date-time"> | null;
 }
+export namespace IWrtnEnterpriseEmployee {
+  export interface ISummary {
+    // FK 참조관계 및 has 관계 맵핑
+  enterprise: IWrtnEnterprise.ISummary;
+
+  // 여기만큼은 예외적으로 1: M has relationship 이지만
+  // 이렇게 소속 팀 정보를 전부 다 보여주어야 함
+  // 이게 은근 중요한 정보라 summary 차원에서도 필히 표기해야하여 그러하다
+  companions: IWrtnEnterpriseTeamCompanion[];
+
+  // 이후로 자유로이 나머지 속성들을 설계할 것...
+  id: string & tags.Format<"uuid">;
+  email: string & tags.Format<"email">;
+  title: "master" | "manager" | "member" | null;
+  created_at: string & tags.Format<"date-time">;
+  updated_at: string & tags.Format<"date-time">;
+  approved_at: string & tags.Format<"date-time"> | null;
+  }
+}
+
 export interface IWrtnEnterpriseEmployeeAppointment {
   id: string & tags.Format<"uuid">;
   employee: IWrtnEnterpriseEmployee.ISummary; // 임명된 사람
@@ -318,6 +338,7 @@ export interface IWrtnEnterpriseEmployeeAppointment {
   title: "master" | "manager" | "member" | null;
   created_at: string & tags.Format<"date-time">;
 }
+
 export interface IWrtnEnterpriseEmployeeInvitation {
   id: string & tags.Format<"uuid">;
   employee: IWrtnEnterpriseEmployee.ISummary; // 초대한 사람


### PR DESCRIPTION
This pull request introduces significant changes to how token usage is tracked and aggregated for chat and procedure sessions, moving from embedded JSON fields to normalized, dedicated tables. It also greatly expands and clarifies the requirements for enterprise-grade statistics, aggregation, and access control, emphasizing their critical importance for B2B customers. Additionally, there are updates to TypeScript interfaces to match these backend changes and stricter implementation checklists.

**Database schema normalization and statistics requirements:**

**Token Usage Tracking and Schema Normalization**
- Removed the `token_usage` JSON field from `wrtn_chat_session_histories`, `wrtn_chat_session_aggregates`, `wrtn_procedure_session_histories`, and `wrtn_procedure_session_aggregates`, replacing them with new normalized 1:1 relationship tables (`wrtn_chat_session_history_token_usages`, `wrtn_chat_session_aggregate_token_usages`, `wrtn_procedure_session_history_token_usages`, and `wrtn_procedure_session_aggregate_token_usages`) to store detailed token usage breakdowns. [[1]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L748-R795) [[2]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L771-R842) [[3]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L998-R1129)
- Updated documentation to clarify that only specific fields (e.g., `data`, `arguments`, `value`) must remain JSON, while token usage is now normalized. [[1]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L771-R842) [[2]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L998-R1129) [[3]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L1577-R1744)

**Enterprise Statistics and Access Control**
- Added strict, detailed requirements for statistical APIs: all metrics, aggregation dimensions (time, organization, model), and permission-based access controls must be implemented exhaustively, with tables and examples for each user role and aggregation type. This is now marked as a non-optional, business-critical feature for B2B SaaS. [[1]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83R1346-R1380) [[2]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83R1389-R1413) [[3]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83R1466-R1477) [[4]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L1331-R1499)
- Expanded the checklist to require full API and DTO coverage for all statistics and aggregation requirements, ensuring no omission of metrics or access control logic.

**API/DTO and TypeScript Interface Updates**
- Updated TypeScript interfaces to reflect the new normalized token usage tables, including documentation for how APIs should handle missing token usage records (returning zeroes). Also, introduced a summary interface for employees to align with backend changes. [[1]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L304-R304) [[2]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83R314-R341) [[3]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83R963-R970)

**Clarifications and Documentation Improvements**
- Improved documentation and comments throughout to clarify the importance of real-time aggregation, the non-negotiable nature of these requirements, and the rationale for normalized schema vs. JSON fields. [[1]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L1040-R1150) [[2]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83L1577-R1744)

Let me know if you want a deeper dive into any of these areas or need help understanding how these changes might affect API implementation or frontend integration!