### PR TITLE
feat(agent): fix DTO type name's duplicated renaming rule.

### DIFF
--- a/test/scripts/chat.md
+++ b/test/scripts/chat.md
@@ -1129,6 +1129,18 @@ value: Record<string, any>  // any 타입 사용 금지
 arguments: object        // object 타입 사용 금지 (any와 동일하게 처리될 수 있음)
 ```
 
+**올바른 JSON Schema 정의**:
+
+빈 오브젝트 타입 `{}`는 JSON Schema로 변환할 때 반드시 다음과 같이 명시해야 한다:
+
+```json
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}
+```
+
 ### 6.3. `IWrtnTokenUsage`
 
 토큰 사용량 타입은 이렇게 정의한다.
@@ -1325,6 +1337,18 @@ arguments: any                    // any 타입 절대 금지
 value: Record<string, any>        // any 타입 절대 금지
 arguments: object                 // object 타입 금지 (any로 처리될 수 있음)
 arguments: Record<string, unknown> // unknown 사용도 권장하지 않음
+```
+
+**올바른 JSON Schema 정의**:
+
+빈 오브젝트 타입 `{}`는 JSON Schema로 변환할 때 반드시 다음과 같이 명시해야 한다:
+
+```json
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}
 ```
 
 뤼튼 엔터프라이즈에서 말하는 AI Procedure 란, 위 [4. AI Chatbot](#4-ai-chatbot) 과 같은 챗봇의 형태가 아닌, 지정된 형태의 인풋을 받아서 약속된 형태의 아웃풋을 반환하는 함수형 서비스이다. 문자 그대로 함수(프로시저) 형태의 AI 서비스로써, Stable Diffusion 으로 이미지를 생성하는게 AI Procedure 의 가장 대표적인 사례이다.

--- a/test/src/features/interface/test_agent_interface_schema_rename.ts
+++ b/test/src/features/interface/test_agent_interface_schema_rename.ts
@@ -1,0 +1,138 @@
+import { orchestrateInterfaceSchemaRename } from "@autobe/agent/src/orchestrate/interface/orchestrateInterfaceSchemaRename";
+import { AutoBeOpenApi } from "@autobe/interface";
+import { missedOpenApiSchemas } from "@autobe/utils";
+import typia, { tags } from "typia";
+
+export const test_agent_interface_schema_rename = (): void => {
+  const document: AutoBeOpenApi.IDocument = {
+    operations: [
+      {
+        ...typia.random<AutoBeOpenApi.IOperation>(),
+        method: "get",
+        path: "/bbs/articles",
+        responseBody: {
+          typeName: "IPageIArticle.ISummary",
+          description: "A paginated list of article summaries",
+        },
+      },
+      {
+        ...typia.random<AutoBeOpenApi.IOperation>(),
+        method: "get",
+        path: "/bbs/articles/:articleId/comments",
+        responseBody: {
+          typeName: "IPageIArticleComment",
+          description: "A paginated list of comments for an article",
+        },
+      },
+      {
+        ...typia.random<AutoBeOpenApi.IOperation>(),
+        method: "post",
+        path: "/bbs/articles",
+        requestBody: {
+          typeName: "IArticle.ICreate",
+          description: "Create a new article",
+        },
+        responseBody: {
+          typeName: "IArticle",
+          description: "The created article",
+        },
+      },
+      {
+        ...typia.random<AutoBeOpenApi.IOperation>(),
+        method: "post",
+        path: "/bbs/articles/:articleId/comments",
+        requestBody: {
+          typeName: "IArticleComment.ICreate",
+          description: "Create a new comment on an article",
+        },
+        responseBody: {
+          typeName: "IArticleComment",
+          description: "The created comment",
+        },
+      },
+    ],
+    components: {
+      schemas: typia.json.schemas<
+        [
+          IPageIArticle.ISummary,
+          IPageIArticleComment,
+          IArticle,
+          IArticle.ICreate,
+          IArticle.ISummary,
+          IArticleComment,
+          IArticleComment.ICreate,
+        ]
+      >().components.schemas as any,
+      authorizations: [],
+    },
+  };
+  orchestrateInterfaceSchemaRename.rename(document, [
+    { from: "IArticle", to: "IBbsArticle" },
+    { from: "IArticleComment", to: "IBbsArticleComment" },
+  ]);
+  console.log(JSON.stringify(document, null, 2));
+  console.log(missedOpenApiSchemas(document));
+};
+
+namespace IPageIArticle {
+  export interface ISummary {
+    data: IArticle.ISummary[];
+  }
+}
+interface IPageIArticleComment {
+  data: IArticleComment[];
+}
+
+/** The article. */
+interface IArticle extends IArticle.ISummary {
+  /** Body content of the article. */
+  body: string;
+  comments: IArticleComment[];
+}
+namespace IArticle {
+  /** Summary information of the article. */
+  export interface ISummary {
+    /** Primary Key. */
+    id: string & tags.Format<"uuid">;
+
+    /** Title of the article. */
+    title: string;
+
+    /** Creation timestamp. */
+    created_at: string & tags.Format<"date-time">;
+
+    /** Last update timestamp. */
+    updated_at: string & tags.Format<"date-time">;
+  }
+
+  /** Interface for creating a new article. */
+  export interface ICreate {
+    /** Title of the article. */
+    title: string;
+
+    /** Body content of the article. */
+    body: string;
+  }
+}
+
+/** Comment on an article. */
+interface IArticleComment {
+  /** Primary Key. */
+  id: string & tags.Format<"uuid">;
+
+  /** Content of the comment. */
+  body: string;
+
+  /** Timestamp when the comment was created. */
+  created_at: string & tags.Format<"date-time">;
+
+  /** Timestamp when the comment was last updated. */
+  updated_at: string & tags.Format<"date-time">;
+}
+namespace IArticleComment {
+  /** Interface for creating a new comment. */
+  export interface ICreate {
+    /** Content of the comment. */
+    body: string;
+  }
+}


### PR DESCRIPTION
This pull request refactors and improves the interface schema renaming orchestration logic in `orchestrateInterfaceSchemaRename`, adds a new test file for schema renaming, and updates documentation for JSON Schema definitions. The main changes focus on deduplication and correctness of schema renaming, better organization of code, and improved documentation for handling empty object types in JSON Schema.

### Interface Schema Renaming Improvements

* Refactored the logic in `orchestrateInterfaceSchemaRename` to deduplicate refactor operations using a `Map`, ensuring each schema is renamed only once and preventing conflicts. The renaming function is now exposed via a namespace for better modularity. [[1]](diffhunk://#diff-1cfc0008bca79ab5cb7c075e14228efc7fab3defb36ab04102d33bf703c2aaadL54-R56) [[2]](diffhunk://#diff-1cfc0008bca79ab5cb7c075e14228efc7fab3defb36ab04102d33bf703c2aaadL66-R76) [[3]](diffhunk://#diff-1cfc0008bca79ab5cb7c075e14228efc7fab3defb36ab04102d33bf703c2aaadR180-R186)
* Ensured that `$ref` changes are applied at the correct stage in the renaming process, fixing the order of operations for schema and reference updates. [[1]](diffhunk://#diff-1cfc0008bca79ab5cb7c075e14228efc7fab3defb36ab04102d33bf703c2aaadR127) [[2]](diffhunk://#diff-1cfc0008bca79ab5cb7c075e14228efc7fab3defb36ab04102d33bf703c2aaadL132)

### Testing

* Added a comprehensive test file `test_agent_interface_schema_rename.ts` that verifies the schema renaming logic using realistic OpenAPI document examples and prints results for inspection.

### Documentation Updates

* Updated `chat.md` to clarify the correct way to define empty object types in JSON Schema, providing explicit examples for both English and Korean sections. [[1]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83R1132-R1143) [[2]](diffhunk://#diff-0f611434e438d15c67ac1586b6b7cdcfca0f5a3dc3ba022e138ac19821d48c83R1342-R1353)