### PR TITLE
fix(compiler): `.gitignore` rule to `autobe` directory.

### DIFF
--- a/internals/template/interface/.gitignore
+++ b/internals/template/interface/.gitignore
@@ -1,4 +1,4 @@
-autobe/
+./autobe/
 bin/
 dist/
 lib/


### PR DESCRIPTION
This pull request makes a minor update to the `.gitignore` file in the `internals/template/interface` directory. The change improves the path specification for the `autobe` directory to ensure it is correctly ignored.