### PR TITLE
feat(website): new commit program of the examples.

### DIFF
--- a/apps/playground-ui/src/movies/replay/AutoBePlaygroundReplayProjectMovie.tsx
+++ b/apps/playground-ui/src/movies/replay/AutoBePlaygroundReplayProjectMovie.tsx
@@ -76,6 +76,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
   const getPhaseIndex = (p: AutoBePhase | null) => phases.indexOf(p ?? "null");
   const phaseColor = getPhaseColor(replay.phase);
   const vendorColor = getVendorColor(replay.vendor);
+  const tokenUsage = replay.aggregates.total.tokenUsage;
 
   return (
     <Card
@@ -373,7 +374,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
                     },
                   }}
                 >
-                  {formatTokenCount(replay.tokenUsage.aggregate.total)}
+                  {formatTokenCount(tokenUsage.total)}
                 </Typography>
                 <Stack direction="column" spacing={0} sx={{ mt: 0.2 }}>
                   <Typography
@@ -386,11 +387,9 @@ export const AutoBePlaygroundReplayProjectMovie = ({
                       color: "text.secondary",
                     }}
                   >
-                    in:{" "}
-                    {formatTokenCount(replay.tokenUsage.aggregate.input.total)}
-                    {replay.tokenUsage.aggregate.input.cached &&
-                    replay.tokenUsage.aggregate.input.cached > 0
-                      ? ` (${formatTokenCount(replay.tokenUsage.aggregate.input.cached)} cached)`
+                    in: {formatTokenCount(tokenUsage.input.total)}
+                    {tokenUsage.input.cached && tokenUsage.input.cached > 0
+                      ? ` (${formatTokenCount(tokenUsage.input.cached)} cached)`
                       : ""}
                   </Typography>
                   <Typography
@@ -403,8 +402,7 @@ export const AutoBePlaygroundReplayProjectMovie = ({
                       color: "text.secondary",
                     }}
                   >
-                    out:{" "}
-                    {formatTokenCount(replay.tokenUsage.aggregate.output.total)}
+                    out: {formatTokenCount(tokenUsage.output.total)}
                   </Typography>
                 </Stack>
               </Stack>

--- a/test/src/archive/utils/AutoBePlaygroundReplayDocumentation.ts
+++ b/test/src/archive/utils/AutoBePlaygroundReplayDocumentation.ts
@@ -15,20 +15,35 @@ export namespace AutoBePlaygroundReplayDocumentation {
     
         ## Benchmark
     
-        AI Model | Score | Status 
-        :--------|------:|:------:
+        AI Model | Score | FCSR | Status 
+        :--------|------:|-----:|:------:
         ${experiments
           .map((e) =>
             [
               `[\`${TestHistory.slugModel(
                 e.vendor,
                 false,
-              )}\`](#${TestHistory.slugModel(e.vendor, true)})`,
+              )}\`](#${TestHistory.slugModel(e.vendor, false)
+                .replaceAll("/", "")
+                .replaceAll(".", "")})`,
               e.score.aggregate,
+              (() => {
+                const [x, y] = e.replays
+                  .map((r) => r.aggregates.total.metric)
+                  .map((m) => [m.success, m.attempt])
+                  .reduce((a, b) => [a[0] + b[0], a[1] + b[1]], [0, 0]);
+                return y === 0 ? "0%" : Math.floor((x / y) * 100) + "%";
+              })(),
               e.emoji,
             ].join(" | "),
           )
           .join("\n")}
+
+        - FCSR: Function Calling Success Rate
+        - Status:
+          - 🟢: All projects completed successfully
+          - 🟡: Some projects failed
+          - ❌: All projects failed or not executed
 
         ${experiments.map(vendor).join("\n\n\n")}
       `;
@@ -66,17 +81,14 @@ export namespace AutoBePlaygroundReplayDocumentation {
       ${row("reddit")}
       ${row("shopping")}
 
-      ![](https://autobe.dev/images/demonstrate/replay-${TestHistory.slugModel(
-        exp.vendor,
-        true,
-      )}.png)
-
-      ${exp.replays.map((r) =>
-        project({
-          replay: r,
-          score: (exp.score as any)[r.project],
-        }),
-      )}
+      ${exp.replays
+        .map((r) =>
+          project({
+            replay: r,
+            score: (exp.score as any)[r.project],
+          }),
+        )
+        .join("\n\n\n")}
     `;
   };
 
@@ -89,45 +101,45 @@ export namespace AutoBePlaygroundReplayDocumentation {
       if (props.replay[key] === null)
         return [`⚪ ${title}`, "", "", "", ""].join(" | ");
       return [
-        `${props.replay[key].success === true ? "🟢" : "🔴"} title`,
+        `${props.replay[key].success === true ? "🟢" : "🔴"} ${title}`,
         Object.entries(props.replay[key].commodity)
           .map(([key, value]) => `\`${key}\`: ${value}`)
           .join(", "),
-        props.replay[key].aggregates.total.tokenUsage.total,
+        formatTokens(props.replay[key].aggregates.total.tokenUsage.total),
         formatElapsedTime(props.replay[key].elapsed),
+        Math.floor(
+          (props.replay.aggregates.total.metric.success /
+            props.replay.aggregates.total.metric.attempt) *
+            100,
+        ) + "%",
       ].join(" | ");
     };
-    const records: string[] = Object.entries(props.replay.aggregates)
-      .filter(([a]) => a !== "all")
-      .map(([k, { metric }]) =>
-        [
-          k,
-          metric.attempt,
-          metric.success,
-          metric.consent,
-          metric.validationFailure,
-          metric.invalidJson,
-        ].join(" | "),
-      );
     return StringUtil.trim`
       ### \`${props.replay.vendor} - ${props.replay.project}\`
 
-      - Github Repository: ${`[\`${props.replay}.project}\`](./${props.replay.vendor}/${props.replay.project}/)`}
+      - Source Code: ${`[\`${TestHistory.slugModel(
+        props.replay.vendor,
+        false,
+      )}/${props.replay.project}\`](./${TestHistory.slugModel(
+        props.replay.vendor,
+        false,
+      )}/${props.replay.project}/)`}
       - Score: ${props.score}
+      - Elapsed Time: ${formatElapsedTime(props.replay.elapsed)}
+      - Token Usage: ${formatTokens(
+        props.replay.aggregates.total.tokenUsage.total,
+      )}
+      - Function Calling Success Rate: ${(
+        (props.replay.aggregates.total.metric.success /
+          props.replay.aggregates.total.metric.attempt) *
+        100
+      ).toFixed(2)}%
 
-      #### Phase Performance
-
-      Phase | Generated | Token Consumption | Elapsed Time
-      :-----|:----------|:------------------:|:-----------:
+      Phase | Generated | Token Usage | Elapsed Time | FCSR
+      :-----|:----------|------------:|-------------:|------:
       ${(["analyze", "prisma", "interface", "test", "realize"] as const)
         .map((key) => phase(key))
         .join("\n")}
-      
-      #### Function Calling Performance
-
-      Event | Attempt | Success | Consent | Validation Failure | Invalid JSON
-      :-----|--------:|:-------:|:-------:|:------------------:|:-------------:
-      ${records.join("\n")}
     `;
   };
 }
@@ -148,4 +160,13 @@ function formatElapsedTime(ms: number): string {
   } else {
     return `${s}s`;
   }
+}
+
+function formatTokens(num: number): string {
+  if (num >= 1000000) {
+    return `${(num / 1000000).toFixed(2)}M`;
+  } else if (num >= 1000) {
+    return `${(num / 1000).toFixed(1)}K`;
+  }
+  return num.toString();
 }


### PR DESCRIPTION
This pull request introduces a new utility module for generating detailed README documentation for AutoBe Playground replay benchmarks. The module provides functions to format experiment results, project phase performance, and function calling metrics into markdown tables for improved reporting and visibility.

**New documentation generation utilities:**

* Added `AutoBePlaygroundReplayDocumentation` namespace in `AutoBePlaygroundReplayDocumentation.ts` with functions to generate markdown-formatted summaries of benchmark experiments, including overall scores and status indicators.
* Implemented helper functions to display per-project and per-phase performance, including token consumption and elapsed time, as well as function calling metrics (attempts, successes, validation failures, etc.) for each replay.
* Introduced the `formatElapsedTime` function for human-readable time formatting in documentation outputs.