### PR TITLE
fix(test): revive archive program.

### DIFF
--- a/test/src/archive/index.ts
+++ b/test/src/archive/index.ts
@@ -15,7 +15,11 @@ interface ITestFunction {
   name: string;
   step: Step;
   project: AutoBeExampleProject;
-  execute: (factory: TestFactory) => Promise<void>;
+  execute: (props: {
+    factory: TestFactory;
+    project: AutoBeExampleProject;
+    vendor: string;
+  }) => Promise<void>;
 }
 
 const PROJECT_INDEXES: Record<AutoBeExampleProject, number> = {
@@ -53,7 +57,7 @@ const collect = async (): Promise<ITestFunction[]> => {
         typia.misc.literals<AutoBeExampleProject>().forEach((project) => {
           container.push({
             name: key,
-            execute: (factory: TestFactory) => value(factory, project),
+            execute: (props) => value(props),
             project,
             step,
           });
@@ -161,7 +165,11 @@ const main = async (): Promise<void> => {
     `);
     const start: Date = new Date();
     try {
-      await tf.execute(factory);
+      await tf.execute({
+        factory,
+        project: tf.project,
+        vendor: TestGlobal.vendorModel,
+      });
       console.log(
         `- Success: ${(Date.now() - start.getTime()).toLocaleString()} ms`,
       );


### PR DESCRIPTION
This pull request updates the interface and usage of the `execute` method in the testing framework to accept a single props object instead of separate parameters. This change improves consistency and extensibility in how test functions are called and defined.

**Refactor test function execution:**

* Updated the `ITestFunction` interface so the `execute` method now takes a single props object containing `factory`, `project`, and `vendor` instead of just `factory` as a parameter.
* Modified the construction of test function objects in the `collect` function to pass the props object to the underlying test function, aligning with the new interface.
* Updated the invocation of `tf.execute` in the `main` function to pass the required props object, including `factory`, `project`, and `vendor`.