### PR TITLE
fix(agen): bug on `executeCachedBatch()` function

### DIFF
--- a/packages/agent/src/utils/executeCachedBatch.ts
+++ b/packages/agent/src/utils/executeCachedBatch.ts
@@ -24,7 +24,7 @@ export const executeCachedBatch = async <Model extends ILlmSchema.Model, T>(
     .map((task, index) => new Pair(task, index));
   const tail: Pair<T, number>[] = [];
   await Promise.all(
-    new Array(semaphore).map(async () => {
+    new Array(semaphore).fill(0).map(async () => {
       while (remained.length !== 0) {
         const batch: Pair<Task<T>, number> = remained.splice(0, 1)[0]!;
         const result: T = await batch.first(promptCacheKey!);


### PR DESCRIPTION
This pull request makes a minor fix to the batching logic in `executeCachedBatch.ts`. The change ensures that the array used for concurrency control is properly initialized.

* Fixed the creation of the semaphore array in `executeCachedBatch` by adding `.fill(0)`, which ensures that the array contains actual elements for mapping and concurrency control.