### PR TITLE
fix(compiler): have missed realize common template

### DIFF
--- a/packages/agent/src/factory/getAutoBeGenerated.ts
+++ b/packages/agent/src/factory/getAutoBeGenerated.ts
@@ -150,7 +150,7 @@ function writeReadMe(state: AutoBeState, readme: string): string {
       | AutoBeTestHistory
       | AutoBeRealizeHistory
       | null,
-  ): string => (history ? (success(history) ? "✅" : "❌") : "");
+  ): string => (history ? (success(history) ? "✅" : "❌") : "⬜");
   return readme
     .replaceAll("{{ANALYSIS_EMOJI}}", emoji(state.analyze))
     .replaceAll("{{PRISMA_EMOJI}}", emoji(state.prisma))
@@ -165,16 +165,11 @@ function writeReadMe(state: AutoBeState, readme: string): string {
 }
 
 function writeBenchmarkAggregate(state: AutoBeState): string {
-  return [
-    state.analyze,
-    state.prisma,
-    state.interface,
-    state.test,
-    state.realize,
-  ]
-    .filter((h) => h !== null)
-    .map((h) =>
-      [
+  return (["analyze", "prisma", "interface", "test", "realize"] as const)
+    .map((key) => {
+      const h = state[key];
+      if (h === null) return `⬜ ${key} | | | | `;
+      return [
         `${success(h) ? "✅" : "❌"} ${h.type}`,
         Object.entries(label(h))
           .map(([k, v]) => `${k}: ${v.toLocaleString()}`)
@@ -190,8 +185,8 @@ function writeBenchmarkAggregate(state: AutoBeState): string {
             new Date(h.created_at).getTime()) /
             1_000,
         ) + " sec",
-      ].join(" | "),
-    )
+      ].join(" | ");
+    })
     .join("\n");
 }
 

--- a/packages/benchmark/src/example/AutoBeExampleBenchmark.ts
+++ b/packages/benchmark/src/example/AutoBeExampleBenchmark.ts
@@ -111,7 +111,8 @@ export namespace AutoBeExampleBenchmark {
               if (
                 event.type !== "jsonValidateError" &&
                 event.type !== "jsonParseError" &&
-                event.type !== "preliminary"
+                event.type !== "preliminary" &&
+                event.type !== "consentFunctionCall"
               )
                 phaseState.snapshot = s;
               props.report();

--- a/packages/benchmark/src/replay/AutoBeReplayDocumentation.ts
+++ b/packages/benchmark/src/replay/AutoBeReplayDocumentation.ts
@@ -15,8 +15,8 @@ export namespace AutoBeReplayDocumentation {
   
       ## Benchmark
   
-      AI Model | Score | FCSR | Status 
-      :--------|------:|-----:|:------:
+      AI Model | Success | Score | FCSR | Status 
+      :--------|---------|------:|-----:|:------:
       ${experiments
         .map((e) =>
           [
@@ -26,6 +26,7 @@ export namespace AutoBeReplayDocumentation {
             )}\`](#${AutoBeExampleStorage.slugModel(e.vendor, false)
               .replaceAll("/", "")
               .replaceAll(".", "")})`,
+            e.replays.filter((r) => r.realize?.success === true).length,
             e.score.aggregate,
             (() => {
               const [x, y] = e.replays

--- a/packages/compiler/src/AutoBeCompiler.ts
+++ b/packages/compiler/src/AutoBeCompiler.ts
@@ -15,6 +15,7 @@ import { AutoBeInterfaceCompiler } from "./interface/AutoBeInterfaceCompiler";
 import { AutoBePrismaCompiler } from "./prisma/AutoBePrismaCompiler";
 import { AutoBeCompilerCommonTemplate } from "./raw/AutoBeCompilerCommonTemplate";
 import { AutoBeCompilerInterfaceTemplate } from "./raw/AutoBeCompilerInterfaceTemplate";
+import { AutoBeCompilerRealizeTemplate } from "./raw/AutoBeCompilerRealizeTemplate";
 import { AutoBeCompilerRealizeTemplateOfPostgres } from "./raw/AutoBeCompilerRealizeTemplateOfPostgres";
 import { AutoBeCompilerRealizeTemplateOfSQLite } from "./raw/AutoBeCompilerRealizeTemplateOfSQLite";
 import { AutoBeCompilerTestTemplate } from "./raw/AutoBeCompilerTestTemplate";
@@ -68,9 +69,10 @@ export class AutoBeCompiler implements IAutoBeCompiler {
     if (index >= OF_INTERFACE)
       Object.assign(result, AutoBeCompilerInterfaceTemplate);
     if (index >= OF_TEST) Object.assign(result, AutoBeCompilerTestTemplate);
-    if (options.phase === "realize")
+    if (index >= OF_REALIZE)
       Object.assign(
         result,
+        AutoBeCompilerRealizeTemplate,
         options.dbms === "postgres"
           ? AutoBeCompilerRealizeTemplateOfPostgres
           : AutoBeCompilerRealizeTemplateOfSQLite,
@@ -88,3 +90,4 @@ const PHASES: AutoBePhase[] = [
 ];
 const OF_INTERFACE: number = PHASES.indexOf("interface");
 const OF_TEST: number = PHASES.indexOf("test");
+const OF_REALIZE: number = PHASES.indexOf("realize");

--- a/test/src/features/compiler/test_compiler_realize_files.ts
+++ b/test/src/features/compiler/test_compiler_realize_files.ts
@@ -1,23 +1,38 @@
 import { AutoBeAgent } from "@autobe/agent";
+import { compileRealizeFiles } from "@autobe/agent/src/orchestrate/realize/internal/compileRealizeFiles";
 import { AutoBeExampleStorage } from "@autobe/benchmark";
 import { AutoBeCompiler } from "@autobe/compiler";
 import { FileSystemIterator } from "@autobe/filesystem";
-import { AutoBeProcessAggregateFactory } from "@autobe/utils";
+import {
+  AutoBeHistory,
+  AutoBeRealizeHistory,
+  AutoBeRealizeValidateEvent,
+} from "@autobe/interface";
+import { TestValidator } from "@nestia/e2e";
 import cp from "child_process";
 import OpenAI from "openai";
-import { v7 } from "uuid";
 
 import { TestGlobal } from "../../TestGlobal";
 
 export const test_compiler_realize_files = async () => {
   if (
     (await AutoBeExampleStorage.has({
-      vendor: TestGlobal.vendorModel,
+      vendor: "openai/gpt-4.1",
       project: "todo",
       phase: "test",
     })) === false
   )
     return false;
+
+  const histories: AutoBeHistory[] = await AutoBeExampleStorage.getHistories({
+    vendor: "openai/gpt-4.1",
+    project: "todo",
+    phase: "realize",
+  });
+  const realize: AutoBeRealizeHistory | undefined = histories.find(
+    (h) => h.type === "realize",
+  );
+  if (realize?.compiled.type !== "success") return false;
 
   const agent: AutoBeAgent<"chatgpt"> = new AutoBeAgent({
     model: "chatgpt",
@@ -26,29 +41,16 @@ export const test_compiler_realize_files = async () => {
       model: "gpt-4.1",
     },
     compiler: (listener) => new AutoBeCompiler(listener),
-    histories: [
-      ...(await AutoBeExampleStorage.getHistories({
-        vendor: TestGlobal.vendorModel,
-        project: "todo",
-        phase: "test",
-      })),
-      {
-        type: "realize",
-        functions: [],
-        authorizations: [],
-        controllers: {},
-        compiled: {
-          type: "success",
-        },
-        id: v7(),
-        aggregates: AutoBeProcessAggregateFactory.createCollection(),
-        created_at: new Date().toISOString(),
-        completed_at: new Date().toISOString(),
-        instruction: "Realize files for compiler",
-        step: 0,
-      },
-    ],
+    histories,
   });
+  const event: AutoBeRealizeValidateEvent = await compileRealizeFiles(
+    agent.getContext(),
+    {
+      authorizations: realize.authorizations,
+      functions: realize.functions,
+    },
+  );
+  TestValidator.equals("local compile", event.result.type, "success");
 
   const files: Record<string, string> = await agent.getFiles();
   const root: string = `${TestGlobal.ROOT}/results/compiler.realize.files`;


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the agent, benchmark, compiler, and test suites to enhance benchmarking output, compiler template selection, and test coverage for the realize phase. The main themes are improved reporting of benchmarking results, more robust compiler template selection logic, and expanded test validation for realize file compilation.

**Benchmarking Output and Reporting Improvements:**

* The benchmarking tables in `AutoBeReplayDocumentation` now include a "Success" column, showing the count of successful realizations per AI model, providing clearer insights into model performance. [[1]](diffhunk://#diff-e18a8dc4fe2ecf343d93e6994738ec22d6d8fd5e30c677f67d1ef88712e98855L18-R19) [[2]](diffhunk://#diff-e18a8dc4fe2ecf343d93e6994738ec22d6d8fd5e30c677f67d1ef88712e98855R29)
* The aggregate benchmark output in `getAutoBeGenerated.ts` now displays a placeholder emoji ("⬜") for phases with missing history, ensuring that all benchmarked phases are represented in the output, even if not executed. [[1]](diffhunk://#diff-fc0178a8e0563575ac404ad57a2c4b5a4d73bedd7c5f5aabfd81545e7b0b66e1L153-R153) [[2]](diffhunk://#diff-fc0178a8e0563575ac404ad57a2c4b5a4d73bedd7c5f5aabfd81545e7b0b66e1R168-L177) [[3]](diffhunk://#diff-fc0178a8e0563575ac404ad57a2c4b5a4d73bedd7c5f5aabfd81545e7b0b66e1L193-R189)
* The event filtering logic in `AutoBeExampleBenchmark.ts` was updated to exclude `consentFunctionCall` events from phase state snapshots, improving the accuracy of benchmark phase tracking.

**Compiler Template Selection Logic:**

* The compiler in `AutoBeCompiler.ts` now uses a phase index check (`OF_REALIZE`) to determine when to include realize templates, making template selection more robust and consistent with other phases. This change also adds the missing import for `AutoBeCompilerRealizeTemplate`. [[1]](diffhunk://#diff-f6a904872bb8ad007a0cc7a2277b6f0a5511ed75f1b927616135b87df8b9892dR18) [[2]](diffhunk://#diff-f6a904872bb8ad007a0cc7a2277b6f0a5511ed75f1b927616135b87df8b9892dL71-R75) [[3]](diffhunk://#diff-f6a904872bb8ad007a0cc7a2277b6f0a5511ed75f1b927616135b87df8b9892dR93)

**Test Coverage and Validation Enhancements:**

* The realize file compilation test (`test_compiler_realize_files.ts`) was reworked to directly fetch and validate realize histories and their compilation results, ensuring that only successful realize compilations are tested and validated. This increases reliability and coverage of the realize phase tests.