### PR TITLE
feat(agent): previous histories to `AutoBeState`.

### DIFF
--- a/packages/agent/src/AutoBeAgentBase.ts
+++ b/packages/agent/src/AutoBeAgentBase.ts
@@ -1,11 +1,9 @@
 import {
   AutoBeEvent,
   AutoBeHistory,
-  IAutoBeCompiler,
   IAutoBeGetFilesOptions,
 } from "@autobe/interface";
 
-import { AutoBeState } from "./context/AutoBeState";
 import { AutoBeTokenUsage } from "./context/AutoBeTokenUsage";
 import { emplaceMap } from "./utils/emplaceMap";
 
@@ -59,11 +57,5 @@ export abstract class AutoBeAgentBase {
         } catch {}
       }),
     );
-  }
-}
-export namespace AutoBeAgentBase {
-  export interface IAsset {
-    compiler: () => Promise<IAutoBeCompiler>;
-    state: () => AutoBeState;
   }
 }

--- a/packages/agent/src/context/AutoBeState.ts
+++ b/packages/agent/src/context/AutoBeState.ts
@@ -12,4 +12,9 @@ export interface AutoBeState {
   interface: AutoBeInterfaceHistory | null;
   test: AutoBeTestHistory | null;
   realize: AutoBeRealizeHistory | null;
+  previousAnalyze: AutoBeAnalyzeHistory | null;
+  previousPrisma: AutoBePrismaHistory | null;
+  previousInterface: AutoBeInterfaceHistory | null;
+  previousTest: AutoBeTestHistory | null;
+  previousRealize: AutoBeRealizeHistory | null;
 }

--- a/packages/agent/src/factory/createAutoBeState.ts
+++ b/packages/agent/src/factory/createAutoBeState.ts
@@ -10,5 +10,11 @@ export const createAutoBeState = (histories: AutoBeHistory[]): AutoBeState => {
     interface: reversed.find((h) => h.type === "interface") ?? null,
     test: reversed.find((h) => h.type === "test") ?? null,
     realize: reversed.find((h) => h.type === "realize") ?? null,
+    previousAnalyze: reversed.filter((h) => h.type === "analyze")[1] ?? null,
+    previousPrisma: reversed.filter((h) => h.type === "prisma")[1] ?? null,
+    previousInterface:
+      reversed.filter((h) => h.type === "interface")[1] ?? null,
+    previousTest: reversed.filter((h) => h.type === "test")[1] ?? null,
+    previousRealize: reversed.filter((h) => h.type === "realize")[1] ?? null,
   };
 };

--- a/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeReview.ts
+++ b/packages/agent/src/orchestrate/analyze/orchestrateAnalyzeReview.ts
@@ -32,7 +32,6 @@ export const orchestrateAnalyzeReview = async <Model extends ILlmSchema.Model>(
       application: typia.json.application<IAutoBeAnalyzeReviewApplication>(),
       source: SOURCE,
       kinds: ["analysisFiles"],
-      histories: ctx.histories(),
       state: ctx.state(),
       all: {
         analysisFiles: props.allFiles,

--- a/packages/agent/src/orchestrate/common/AutoBePreliminaryController.ts
+++ b/packages/agent/src/orchestrate/common/AutoBePreliminaryController.ts
@@ -1,9 +1,5 @@
 import { IMicroAgenticaHistoryJson } from "@agentica/core";
-import {
-  AutoBeEventSource,
-  AutoBeHistory,
-  AutoBePreliminaryKind,
-} from "@autobe/interface";
+import { AutoBeEventSource, AutoBePreliminaryKind } from "@autobe/interface";
 import {
   ILlmApplication,
   ILlmSchema,
@@ -49,9 +45,6 @@ export class AutoBePreliminaryController<Kind extends AutoBePreliminaryKind> {
   private readonly all: Pick<IAutoBePreliminaryCollection, Kind>;
   private readonly local: Pick<IAutoBePreliminaryCollection, Kind>;
   private readonly config: AutoBePreliminaryController.IConfig<Kind>;
-
-  // RESERVED DATA
-  private readonly histories: readonly AutoBeHistory[];
   private readonly state: AutoBeState;
 
   /**
@@ -113,15 +106,8 @@ export class AutoBePreliminaryController<Kind extends AutoBePreliminaryKind> {
       });
     })();
 
-    this.histories = props.histories;
     this.state = props.state;
-    this.all = createPreliminaryCollection(
-      {
-        histories: props.histories,
-        state: props.state,
-      },
-      props.all,
-    );
+    this.all = createPreliminaryCollection(props.state, props.all);
     this.local = createPreliminaryCollection(null, props.local);
 
     complementPreliminaryCollection({
@@ -223,7 +209,6 @@ export class AutoBePreliminaryController<Kind extends AutoBePreliminaryKind> {
     application: ILlmApplication<Model>,
   ): void {
     fixPreliminaryApplication({
-      histories: this.histories,
       state: this.state,
       preliminary: this,
       application,
@@ -285,9 +270,6 @@ export namespace AutoBePreliminaryController {
 
     /** Data types to enable (e.g., `["prismaSchemas", "interfaceOperations"]`). */
     kinds: Kind[];
-
-    /** Event history for accessing previous iteration data. */
-    histories: readonly AutoBeHistory[];
 
     /** Current AutoBe state containing generated artifacts. */
     state: AutoBeState;

--- a/packages/agent/src/orchestrate/common/internal/createPreliminaryCollection.ts
+++ b/packages/agent/src/orchestrate/common/internal/createPreliminaryCollection.ts
@@ -1,16 +1,11 @@
-import { AutoBeHistory } from "@autobe/interface";
-
 import { AutoBeState } from "../../../context/AutoBeState";
 import { IAutoBePreliminaryCollection } from "../structures/IAutoBePreliminaryCollection";
 
 export function createPreliminaryCollection(
-  ctx: null | {
-    histories: readonly AutoBeHistory[];
-    state: AutoBeState;
-  },
+  state: AutoBeState | null,
   defined?: Partial<IAutoBePreliminaryCollection>,
 ): IAutoBePreliminaryCollection {
-  if (ctx === null)
+  if (state === null)
     return {
       analysisFiles: (defined?.analysisFiles ?? []).slice(),
       prismaSchemas: (defined?.prismaSchemas ?? []).slice(),
@@ -29,18 +24,6 @@ export function createPreliminaryCollection(
         defined?.previousInterfaceOperations ?? []
       ).slice(),
     };
-
-  const reversed: AutoBeHistory[] = ctx.histories.slice().reverse();
-  const state: AutoBeState = ctx.state;
-  const previous = <Type extends "analyze" | "prisma" | "interface">(
-    type: Type,
-  ): AutoBeHistory.Mapper[Type] | undefined => {
-    if (state[type] === null) return undefined;
-    return reversed.find(
-      (h): h is AutoBeHistory.Mapper[Type] =>
-        h.type === type && h !== state[type],
-    );
-  };
   return {
     analysisFiles: defined?.analysisFiles ?? state.analyze?.files ?? [],
     prismaSchemas:
@@ -63,14 +46,12 @@ export function createPreliminaryCollection(
       defined?.realizeTransformers ??
       state.realize?.functions.filter((f) => f.type === "transformer") ??
       [],
-    previousAnalysisFiles: previous("analyze")?.files ?? [],
+    previousAnalysisFiles: state.previousAnalyze?.files ?? [],
     previousPrismaSchemas:
-      previous("prisma")
-        ?.result.data.files.map((f) => f.models)
-        .flat() ?? [],
+      state.previousPrisma?.result.data.files.map((f) => f.models).flat() ?? [],
     previousInterfaceSchemas:
-      previous("interface")?.document.components.schemas ?? {},
+      state.previousInterface?.document.components.schemas ?? {},
     previousInterfaceOperations:
-      previous("interface")?.document.operations ?? [],
+      state.previousInterface?.document.operations ?? [],
   };
 }

--- a/packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts
+++ b/packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts
@@ -1,4 +1,4 @@
-import { AutoBeHistory, AutoBePreliminaryKind } from "@autobe/interface";
+import { AutoBePreliminaryKind } from "@autobe/interface";
 import {
   ChatGptTypeChecker,
   ClaudeTypeChecker,
@@ -16,7 +16,6 @@ export const fixPreliminaryApplication = <
   Kind extends AutoBePreliminaryKind,
   Model extends Exclude<ILlmSchema.Model, "3.0">,
 >(props: {
-  histories: readonly AutoBeHistory[];
   state: AutoBeState;
   preliminary: AutoBePreliminaryController<Kind>;
   application: ILlmApplication<Model>;
@@ -49,29 +48,25 @@ export const fixPreliminaryApplication = <
   });
   if (eraseMetadata === null) return;
 
-  const reversed: AutoBeHistory[] = props.histories.slice().reverse();
-  const previous = (type: "analyze" | "prisma" | "interface"): boolean =>
-    props.state[type] !== null &&
-    reversed.some((h) => h.type === type && h !== props.state[type]);
   for (const kind of props.preliminary.getKinds()) {
     if (kind.startsWith("previous") === false) continue;
     else if (kind === "previousAnalysisFiles") {
-      if (previous("analyze")) {
+      if (props.state.previousAnalyze === null) {
         eraseMetadata("getPreviousAnalysisFiles");
         eraseKind(kind);
       }
     } else if (kind === "previousPrismaSchemas") {
-      if (previous("prisma")) {
+      if (props.state.previousPrisma === null) {
         eraseMetadata("getPreviousPrismaSchemas");
         eraseKind(kind);
       }
     } else if (kind === "previousInterfaceOperations") {
-      if (previous("interface")) {
+      if (props.state.previousInterface === null) {
         eraseMetadata("getPreviousInterfaceOperations");
         eraseKind(kind);
       }
     } else if (kind === "previousInterfaceSchemas") {
-      if (previous("interface")) {
+      if (props.state.previousInterface === null) {
         eraseMetadata("getPreviousInterfaceSchemas");
         eraseKind(kind);
       }

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceAuthorization.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceAuthorization.ts
@@ -69,7 +69,6 @@ async function process<Model extends ILlmSchema.Model>(
       typia.json.application<IAutoBeInterfaceAuthorizationsApplication>(),
     source: SOURCE,
     kinds: ["analysisFiles", "prismaSchemas"],
-    histories: ctx.histories(),
     state: ctx.state(),
   });
   return await preliminary.orchestrate(ctx, async (out) => {

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceComplement.ts
@@ -136,7 +136,6 @@ async function process<Model extends ILlmSchema.Model>(
       "interfaceOperations",
       "interfaceSchemas",
     ],
-    histories: ctx.histories(),
     state: ctx.state(),
     all: {
       interfaceOperations: props.document.operations,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceEndpoint.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceEndpoint.ts
@@ -83,7 +83,6 @@ async function process<Model extends ILlmSchema.Model>(
     application: typia.json.application<IAutoBeInterfaceEndpointApplication>(),
     source: SOURCE,
     kinds: ["analysisFiles", "prismaSchemas"],
-    histories: ctx.histories(),
     state: ctx.state(),
     local: {
       prismaSchemas: props.group.prismaSchemas

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceEndpointReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceEndpointReview.ts
@@ -24,7 +24,6 @@ export async function orchestrateInterfaceEndpointReview<
       typia.json.application<IAutoBeInterfaceEndpointReviewApplication>(),
     source: SOURCE,
     kinds: ["analysisFiles", "prismaSchemas"],
-    histories: ctx.histories(),
     state: ctx.state(),
   });
   return await preliminary.orchestrate(ctx, async () => {

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperation.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperation.ts
@@ -124,7 +124,6 @@ async function process<Model extends ILlmSchema.Model>(
     application: typia.json.application<IAutoBeInterfaceOperationApplication>(),
     source: SOURCE,
     kinds: ["analysisFiles", "prismaSchemas"],
-    histories: ctx.histories(),
     state: ctx.state(),
   });
   return await preliminary.orchestrate(ctx, async (out) => {

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperationReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperationReview.ts
@@ -45,7 +45,6 @@ async function process<Model extends ILlmSchema.Model>(
       typia.json.application<IAutoBeInterfaceOperationReviewApplication>(),
     source: SOURCE,
     kinds: ["analysisFiles", "prismaSchemas"],
-    histories: ctx.histories(),
     state: ctx.state(),
   });
   return await preliminary.orchestrate(ctx, async (out) => {

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfacePrerequisite.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfacePrerequisite.ts
@@ -140,7 +140,6 @@ async function process<Model extends ILlmSchema.Model>(
       "interfaceOperations",
       "interfaceSchemas",
     ],
-    histories: ctx.histories(),
     state: ctx.state(),
     all: {
       interfaceOperations: props.document.operations,

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchema.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchema.ts
@@ -129,7 +129,6 @@ async function process<Model extends ILlmSchema.Model>(
     application: typia.json.application<IAutoBeInterfaceSchemaApplication>(),
     source: SOURCE,
     kinds: ["analysisFiles", "prismaSchemas", "interfaceOperations"],
-    histories: ctx.histories(),
     state: ctx.state(),
   });
   return await preliminary.orchestrate(ctx, async (out) => {

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemaReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemaReview.ts
@@ -127,7 +127,6 @@ async function process<Model extends ILlmSchema.Model>(
       "interfaceOperations",
       "interfaceSchemas",
     ],
-    histories: ctx.histories(),
     state: ctx.state(),
     all: {
       interfaceOperations: props.document.operations,

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaCorrect.ts
@@ -121,7 +121,6 @@ async function execute<Model extends ILlmSchema.Model>(
     application: typia.json.application<IAutoBePrismaCorrectApplication>(),
     source: SOURCE,
     kinds: ["analysisFiles", "prismaSchemas"],
-    histories: ctx.histories(),
     state: ctx.state(),
     all: {
       prismaSchemas: failure.data.files.map((f) => f.models).flat(),

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaReview.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaReview.ts
@@ -62,7 +62,6 @@ async function step<Model extends ILlmSchema.Model>(
     application: typia.json.application<IAutoBePrismaReviewApplication>(),
     source: SOURCE,
     kinds: ["analysisFiles", "prismaSchemas"],
-    histories: ctx.histories(),
     state: ctx.state(),
     all: {
       prismaSchemas: props.application.files.map((f) => f.models).flat(),

--- a/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
+++ b/packages/agent/src/orchestrate/prisma/orchestratePrismaSchema.ts
@@ -63,7 +63,6 @@ async function process<Model extends ILlmSchema.Model>(
       application: typia.json.application<IAutoBePrismaSchemaApplication>(),
       source: SOURCE,
       kinds: ["analysisFiles"],
-      histories: ctx.histories(),
       state: ctx.state(),
     });
   return await preliminary.orchestrate(ctx, async (out) => {

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeAuthorizationCorrect.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeAuthorizationCorrect.ts
@@ -82,7 +82,6 @@ export async function orchestrateRealizeAuthorizationCorrect<
       application:
         typia.json.application<IAutoBeRealizeAuthorizationCorrectApplication>(),
       kinds: ["prismaSchemas"],
-      histories: ctx.histories(),
       state: ctx.state(),
     });
   return await preliminary.orchestrate(ctx, async (out) => {

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeAuthorizationWrite.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeAuthorizationWrite.ts
@@ -88,7 +88,6 @@ async function process<Model extends ILlmSchema.Model>(
       application:
         typia.json.application<IAutoBeRealizeAuthorizationWriteApplication>(),
       kinds: ["prismaSchemas"],
-      histories: ctx.histories(),
       state: ctx.state(),
     });
   return await preliminary.orchestrate(ctx, async (out) => {

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeCollectorCorrectOverall.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeCollectorCorrectOverall.ts
@@ -71,7 +71,6 @@ export const orchestrateRealizeCollectorCorrectOverall = async <
           application:
             typia.json.application<IAutoBeRealizeCollectorCorrectApplication>(),
           kinds: ["prismaSchemas"],
-          histories: ctx.histories(),
           state: ctx.state(),
           local: {
             prismaSchemas: ctx

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeCollectorPlan.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeCollectorPlan.ts
@@ -84,7 +84,6 @@ async function process<Model extends ILlmSchema.Model>(
   const preliminary: AutoBePreliminaryController<
     "prismaSchemas" | "interfaceSchemas" | "interfaceOperations"
   > = new AutoBePreliminaryController({
-    histories: ctx.histories(),
     state: ctx.state(),
     source: SOURCE,
     application:

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeCollectorWrite.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeCollectorWrite.ts
@@ -95,7 +95,6 @@ async function process<Model extends ILlmSchema.Model>(
   const location: string = `src/collectors/${AutoBeRealizeCollectorProgrammer.getName(dtoTypeName)}.ts`;
   const preliminary: AutoBePreliminaryController<"prismaSchemas"> =
     new AutoBePreliminaryController({
-      histories: ctx.histories(),
       state: ctx.state(),
       source: SOURCE,
       application:

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeOperationCorrectOverall.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeOperationCorrectOverall.ts
@@ -68,7 +68,6 @@ export const orchestrateRealizeOperationCorrectOverall = async <
           application:
             typia.json.application<IAutoBeRealizeOperationCorrectApplication>(),
           kinds: ["prismaSchemas", "realizeCollectors", "realizeTransformers"],
-          histories: ctx.histories(),
           state: ctx.state(),
           all: {
             realizeCollectors: props.collectors,

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeOperationWrite.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeOperationWrite.ts
@@ -85,7 +85,6 @@ async function process<Model extends ILlmSchema.Model>(
     application:
       typia.json.application<IAutoBeRealizeOperationWriteApplication>(),
     kinds: ["prismaSchemas", "realizeCollectors", "realizeTransformers"],
-    histories: ctx.histories(),
     state: ctx.state(),
     all: {
       realizeCollectors: props.collectors,

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeTransformerCorrectOverall.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeTransformerCorrectOverall.ts
@@ -74,7 +74,6 @@ export const orchestrateRealizeTransformerCorrectOverall = async <
           application:
             typia.json.application<IAutoBeRealizeTransformerCorrectApplication>(),
           kinds: ["prismaSchemas"],
-          histories: ctx.histories(),
           state: ctx.state(),
           local: {
             prismaSchemas: ctx

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeTransformerPlan.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeTransformerPlan.ts
@@ -89,7 +89,6 @@ async function process<Model extends ILlmSchema.Model>(
   const preliminary: AutoBePreliminaryController<
     "prismaSchemas" | "interfaceSchemas"
   > = new AutoBePreliminaryController({
-    histories: ctx.histories(),
     state: ctx.state(),
     source: SOURCE,
     application:

--- a/packages/agent/src/orchestrate/realize/orchestrateRealizeTransformerWrite.ts
+++ b/packages/agent/src/orchestrate/realize/orchestrateRealizeTransformerWrite.ts
@@ -92,7 +92,6 @@ async function process<Model extends ILlmSchema.Model>(
   const dtoTypeName: string = props.plan.dtoTypeName;
   const preliminary: AutoBePreliminaryController<"prismaSchemas"> =
     new AutoBePreliminaryController({
-      histories: ctx.histories(),
       state: ctx.state(),
       source: SOURCE,
       application:

--- a/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
+++ b/packages/agent/src/orchestrate/test/orchestrateTestScenario.ts
@@ -170,7 +170,6 @@ const process = async <Model extends ILlmSchema.Model>(
     application: typia.json.application<IAutoBeTestScenarioApplication>(),
     source: SOURCE,
     kinds: ["analysisFiles", "interfaceOperations", "interfaceSchemas"],
-    histories: ctx.histories(),
     state: ctx.state(),
     local: {
       interfaceOperations: (() => {

--- a/test/src/features/utils/test_predicate_state_message.ts
+++ b/test/src/features/utils/test_predicate_state_message.ts
@@ -1,18 +1,22 @@
 import { AutoBeState } from "@autobe/agent/src/context/AutoBeState";
 import { predicateStateMessage } from "@autobe/agent/src/utils/predicateStateMessage";
+import { AutoBePhase } from "@autobe/interface";
 import { TestValidator } from "@nestia/e2e";
 import typia from "typia";
 
-type Step = "analyze" | "prisma" | "interface" | "test" | "realize";
-
 export const test_predicate_state_message = (): void => {
-  typia.misc.literals<Step>().forEach((y) => {
+  typia.misc.literals<AutoBePhase>().forEach((y) => {
     const state: AutoBeState = {
       analyze: null,
       prisma: null,
       interface: null,
       test: null,
       realize: null,
+      previousAnalyze: null,
+      previousPrisma: null,
+      previousInterface: null,
+      previousTest: null,
+      previousRealize: null,
     };
     const message: string | null = predicateStateMessage(state, y);
     const expected: boolean = y === "analyze";
@@ -20,14 +24,19 @@ export const test_predicate_state_message = (): void => {
     TestValidator.equals(`null -> ${y}`, expected, actual);
   });
 
-  typia.misc.literals<Step>().forEach((x, i, array) => {
-    typia.misc.literals<Step>().forEach((y, j) => {
+  typia.misc.literals<AutoBePhase>().forEach((x, i, array) => {
+    typia.misc.literals<AutoBePhase>().forEach((y, j) => {
       const state: AutoBeState = {
         analyze: null,
         prisma: null,
         interface: null,
         test: null,
         realize: null,
+        previousAnalyze: null,
+        previousPrisma: null,
+        previousInterface: null,
+        previousTest: null,
+        previousRealize: null,
       };
       for (const key of array.slice(0, i + 1)) state[key] = { step: 0 } as any;
       const message: string | null = predicateStateMessage(state, y);


### PR DESCRIPTION
This pull request refactors how previous iteration data is accessed throughout the AutoBe agent orchestration code. The main improvement is the migration from passing and searching through explicit `histories` arrays to storing previous state references directly in the `AutoBeState` object. This simplifies the codebase, reduces redundancy, and improves maintainability by centralizing previous state tracking.

Key changes:

**State Management Improvements**
- The `AutoBeState` interface now includes new fields for previous iteration data: `previousAnalyze`, `previousPrisma`, `previousInterface`, `previousTest`, and `previousRealize` to directly store references to the previous relevant histories.
- The `createAutoBeState` factory function is updated to populate these new fields by selecting the second most recent history of each type, if available.

**Refactoring of Preliminary Collection and Application Logic**
- The `createPreliminaryCollection` function is refactored to use the new `previous*` fields from `AutoBeState` instead of searching through a reversed histories array. This reduces complexity and improves clarity. [[1]](diffhunk://#diff-1d843e70090df6f3327e8e8012dec2a8b7f257ede8537c8799973dc666fd7dcbL1-R8) [[2]](diffhunk://#diff-1d843e70090df6f3327e8e8012dec2a8b7f257ede8537c8799973dc666fd7dcbL32-L43) [[3]](diffhunk://#diff-1d843e70090df6f3327e8e8012dec2a8b7f257ede8537c8799973dc666fd7dcbL66-R55)
- The `fixPreliminaryApplication` function is updated to check the new `previous*` state fields instead of searching histories, streamlining logic for erasing metadata when previous data is unavailable. [[1]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L1-R1) [[2]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L19) [[3]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L52-R69)

**API and Interface Clean-up**
- All orchestration and controller functions that previously received a `histories` parameter are refactored to remove this argument, relying solely on the `state` parameter for previous data. This change affects multiple orchestrate functions across analyze, interface, prisma, and realize modules. [[1]](diffhunk://#diff-14d408842b8740ea059a1ea38ad91c8c287428304f0076703d9a87877c19d0e0L35) [[2]](diffhunk://#diff-fbc8cc5d1de4c2e9bef9e5e1274e546767f4a3d9879d33285c3d6ba8b6d04957L72) [[3]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L139) [[4]](diffhunk://#diff-c7bec6abf2e61b59513e772afd2bc8cdfdd1732f71f2a0d3c1ba1a263f9593e5L86) [[5]](diffhunk://#diff-e4c81280621cac2373c9dc6e0adf16bf4b24820a3c144b4b0b6e051ad539da18L27) [[6]](diffhunk://#diff-f71b0724ece56eb6555d090dc324b9b6d355a54622613a6828d931f96f76a170L127) [[7]](diffhunk://#diff-ad41bb760f861400b76fc9f69e907e0fff91bb6921e9120b2acf22c15c98bed9L48) [[8]](diffhunk://#diff-d0ebfde114a9799e80a17ff3f1fd39627e0b2e61ed7c8aa3faa7d35fd5dd7c76L143) [[9]](diffhunk://#diff-67a588ff142072c22aeb38976269d1ca709f6c175932a1aa2451ecfaddfaf4fdL132) [[10]](diffhunk://#diff-063d33a56eb5e5c4043cb5f336f81a314c8c8a9ead5b4e423704c1d435753239L130) [[11]](diffhunk://#diff-ef86dd4305e40242004412ee7909671fd0ffa7985080fe9b62574ab1f1b0fdafL124) [[12]](diffhunk://#diff-2d19213671f0b90e0fb2b553abcc5cc6b55b8683376104e0945914b275c03effL65) [[13]](diffhunk://#diff-a845895ec2d362db67d593064547c951226e4932be1fa43b640b89e335aa944aL66) [[14]](diffhunk://#diff-adb09c0d091dd899a8bfc0c58c0dd7da8b6d792a3d0f418da890d0519dfde88dL85)
- The `AutoBePreliminaryController` and its config interface are updated to remove all references to `histories`, further simplifying the API surface. [[1]](diffhunk://#diff-2332057b907e7e101bdc21bafc8fb3c1a982c1e5abf28a95bce68fe5742b480bL2-R2) [[2]](diffhunk://#diff-2332057b907e7e101bdc21bafc8fb3c1a982c1e5abf28a95bce68fe5742b480bL52-L54) [[3]](diffhunk://#diff-2332057b907e7e101bdc21bafc8fb3c1a982c1e5abf28a95bce68fe5742b480bL116-R110) [[4]](diffhunk://#diff-2332057b907e7e101bdc21bafc8fb3c1a982c1e5abf28a95bce68fe5742b480bL226) [[5]](diffhunk://#diff-2332057b907e7e101bdc21bafc8fb3c1a982c1e5abf28a95bce68fe5742b480bL289-L291)

**Codebase Simplification**
- Removed the now-unnecessary `AutoBeAgentBase.IAsset` interface and related imports. [[1]](diffhunk://#diff-802fda59f259e15b3c204c26848f2f7cc25592d1f385bec01307d1adf9f8a2fdL4-L8) [[2]](diffhunk://#diff-802fda59f259e15b3c204c26848f2f7cc25592d1f385bec01307d1adf9f8a2fdL64-L69)

These changes collectively make the orchestration logic more robust and easier to maintain by consolidating previous state tracking into a single, well-defined place.