### PR TITLE
feat(benchmark): not 3-3-3, but 1-1-3

### DIFF
--- a/packages/benchmark/src/example/AutoBeExampleBenchmark.ts
+++ b/packages/benchmark/src/example/AutoBeExampleBenchmark.ts
@@ -98,7 +98,7 @@ export namespace AutoBeExampleBenchmark {
         count: 0,
       };
       props.projectState.phases.push(phaseState);
-      for (let i: number = 0; i < 3; ++i) {
+      for (let i: number = 0; i < 1; ++i) {
         try {
           ++phaseState.trial;
           phaseState.started_at = new Date();


### PR DESCRIPTION
This pull request makes a minor adjustment to the benchmarking logic by reducing the number of trials in the `AutoBeExampleBenchmark` from three to one. This change likely aims to speed up the benchmarking process or reduce resource usage.