### PR TITLE
fix(agent): JsonSchemaValidator to validate only one schema

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
@@ -201,7 +201,9 @@ export const orchestrateInterface =
       completed: 0,
       total: 0,
     };
-    while (missedOpenApiSchemas(document).length !== 0) {
+    for (let ci: number = 0; ci < ctx.retry; ++ci) {
+      if (missedOpenApiSchemas(document).length === 0) break;
+      
       // COMPLEMENT OMITTED
       const oldbie: Set<string> = new Set(
         Object.keys(document.components.schemas),

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchema.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchema.ts
@@ -189,7 +189,7 @@ function createController(
 
     // Check all IAuthorized types
     const errors: IValidation.IError[] = [];
-    JsonSchemaValidator.validateSchemas({
+    JsonSchemaValidator.validateSchema({
       errors,
       prismaSchemas: new Set(
         ctx
@@ -198,21 +198,14 @@ function createController(
           .flat(),
       ),
       operations: props.operations,
-      schemas: {
-        [props.typeName]: result.data.request.schema,
-      },
-      path: "$input.request.schemas",
+      typeName: props.typeName,
+      schema: result.data.request.schema,
+      path: "$input.request.schema",
     });
     if (errors.length !== 0)
       return {
         success: false,
-        errors: errors.map((e) => ({
-          ...e,
-          path: e.path.replace(
-            `$input.request.schemas[${JSON.stringify(props.typeName)}]`,
-            "$input.schema",
-          ),
-        })),
+        errors,
         data: next,
       };
     return result;

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemaReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchemaReview.ts
@@ -212,7 +212,7 @@ function createController(
     // If content is null, schema is perfect and doesn't need validation
     if (result.data.request.content !== null) {
       const errors: IValidation.IError[] = [];
-      JsonSchemaValidator.validateSchemas({
+      JsonSchemaValidator.validateSchema({
         errors,
         prismaSchemas: new Set(
           ctx
@@ -221,9 +221,8 @@ function createController(
             .flat(),
         ),
         operations: props.preliminary.getAll().interfaceOperations,
-        schemas: {
-          [props.typeName]: result.data.request.content,
-        },
+        typeName: props.typeName,
+        schema: result.data.request.content,
         path: "$input.request.content",
       });
       if (errors.length !== 0)


### PR DESCRIPTION
This pull request refactors the JSON schema validation logic in the agent's interface orchestration modules to simplify and clarify how schemas are passed and validated. The main changes involve switching from validating multiple schemas at once via a record/object to validating a single schema at a time, along with related updates to function signatures and validation logic.

The most important changes include:

### Refactoring Schema Validation API

* Changed `JsonSchemaValidator.validateSchemas` to `validateSchema`, updating the API to accept a single schema (`typeName` and `schema`) instead of a record of schemas. This impacts all callers and internal validation functions. [[1]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL12-R17) [[2]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL25-L50)
* Updated all usages in `orchestrateInterfaceSchema.ts`, `orchestrateInterfaceSchemaReview.ts`, and `orchestrateInterfaceComplement.ts` to pass a single schema and type name instead of a map of schemas. [[1]](diffhunk://#diff-063d33a56eb5e5c4043cb5f336f81a314c8c8a9ead5b4e423704c1d435753239L215-R215) [[2]](diffhunk://#diff-063d33a56eb5e5c4043cb5f336f81a314c8c8a9ead5b4e423704c1d435753239L224-R225) [[3]](diffhunk://#diff-67a588ff142072c22aeb38976269d1ca709f6c175932a1aa2451ecfaddfaf4fdL192-R192) [[4]](diffhunk://#diff-67a588ff142072c22aeb38976269d1ca709f6c175932a1aa2451ecfaddfaf4fdL201-R208) [[5]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L229-R218) [[6]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L238-R228)

### Simplifying Validation Logic

* Refactored internal validation helper functions to operate on a single schema and type name, removing unnecessary loops over schema maps and simplifying error path reporting. [[1]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL165-R174) [[2]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL217-R217) [[3]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL251-R255) [[4]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL376-R376) [[5]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL405-R405)
* Adjusted error path formatting to be more direct, reflecting the single schema context. [[1]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL251-R255) [[2]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL376-R376) [[3]](diffhunk://#diff-9da0e0e5b56730d193ffba2295f1b61eed18b0763cc43ef498e7cae882c0af4eL405-R405)

### Miscellaneous Cleanups

* Removed an unused import of `JsonSchemaFactory` and related dead code. [[1]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L18) [[2]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L207-L216)
* Replaced hardcoded retry values with `ctx.retry` for consistency in interface orchestration. [[1]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L33-R32) [[2]](diffhunk://#diff-9011b0c160648b4ccca5ed6c13b2bff42bfd46562d883e13b90885f3e3dcd84eL204-R206)

These changes make the schema validation logic more straightforward and easier to maintain, reducing complexity and potential errors from handling multiple schemas at once.