### PR TITLE
fix(test): log agent testing

### DIFF
--- a/test/src/agent/internal/prepare_analyze_agent.ts
+++ b/test/src/agent/internal/prepare_analyze_agent.ts
@@ -2,18 +2,27 @@ import { AutoBeAgent } from "@autobe/agent";
 import { describe } from "@autobe/agent/src/describe/describe";
 import { AutoBeExampleStorage } from "@autobe/benchmark";
 import { AutoBeCompiler } from "@autobe/compiler";
-import { AutoBeExampleProject } from "@autobe/interface";
+import {
+  AutoBeEventOfSerializable,
+  AutoBeExampleProject,
+} from "@autobe/interface";
+import typia from "typia";
 
 import { TestGlobal } from "../../TestGlobal";
+import { ArchiveLogger } from "../../archive/utils/ArchiveLogger";
 
 export const prepare_analyze_agent = async (props: {
   project: AutoBeExampleProject;
   vendor: string;
 }): Promise<AutoBeAgent> => {
+  const start: Date = new Date();
   const agent: AutoBeAgent = new AutoBeAgent({
     vendor: TestGlobal.getVendorConfig(),
     compiler: (listener) => new AutoBeCompiler(listener),
   });
+  for (const type of typia.misc.literals<AutoBeEventOfSerializable.Type>())
+    agent.on(type, (event) => ArchiveLogger.event(start, event));
+
   agent.getHistories().push(
     await describe(agent.getContext(), {
       content: await AutoBeExampleStorage.getUserMessage({

--- a/test/src/agent/internal/prepare_interface_agent.ts
+++ b/test/src/agent/internal/prepare_interface_agent.ts
@@ -1,15 +1,21 @@
 import { AutoBeAgent } from "@autobe/agent";
 import { AutoBeExampleStorage } from "@autobe/benchmark";
 import { AutoBeCompiler } from "@autobe/compiler";
-import { AutoBeExampleProject } from "@autobe/interface";
+import {
+  AutoBeEventOfSerializable,
+  AutoBeExampleProject,
+} from "@autobe/interface";
+import typia from "typia";
 import { v7 } from "uuid";
 
 import { TestGlobal } from "../../TestGlobal";
+import { ArchiveLogger } from "../../archive/utils/ArchiveLogger";
 
 export const prepare_interface_agent = async (props: {
   project: AutoBeExampleProject;
   vendor: string;
 }): Promise<AutoBeAgent> => {
+  const start: Date = new Date();
   const agent: AutoBeAgent = new AutoBeAgent({
     vendor: TestGlobal.getVendorConfig(),
     compiler: (listener) => new AutoBeCompiler(listener),
@@ -19,6 +25,9 @@ export const prepare_interface_agent = async (props: {
       phase: "prisma",
     }),
   });
+  for (const type of typia.misc.literals<AutoBeEventOfSerializable.Type>())
+    agent.on(type, (event) => ArchiveLogger.event(start, event));
+
   agent.getHistories().push({
     id: v7(),
     type: "userMessage",

--- a/test/src/agent/internal/prepare_prisma_agent.ts
+++ b/test/src/agent/internal/prepare_prisma_agent.ts
@@ -1,15 +1,21 @@
 import { AutoBeAgent } from "@autobe/agent";
 import { AutoBeExampleStorage } from "@autobe/benchmark";
 import { AutoBeCompiler } from "@autobe/compiler";
-import { AutoBeExampleProject } from "@autobe/interface";
+import {
+  AutoBeEventOfSerializable,
+  AutoBeExampleProject,
+} from "@autobe/interface";
+import typia from "typia";
 import { v7 } from "uuid";
 
 import { TestGlobal } from "../../TestGlobal";
+import { ArchiveLogger } from "../../archive/utils/ArchiveLogger";
 
 export const prepare_prisma_agent = async (props: {
   project: AutoBeExampleProject;
   vendor: string;
 }): Promise<AutoBeAgent> => {
+  const start: Date = new Date();
   const agent: AutoBeAgent = new AutoBeAgent({
     vendor: TestGlobal.getVendorConfig(),
     compiler: (listener) => new AutoBeCompiler(listener),
@@ -19,6 +25,9 @@ export const prepare_prisma_agent = async (props: {
       phase: "analyze",
     }),
   });
+  for (const type of typia.misc.literals<AutoBeEventOfSerializable.Type>())
+    agent.on(type, (event) => ArchiveLogger.event(start, event));
+
   agent.getHistories().push({
     id: v7(),
     type: "userMessage",

--- a/test/src/agent/internal/prepare_realize_agent.ts
+++ b/test/src/agent/internal/prepare_realize_agent.ts
@@ -1,15 +1,21 @@
 import { AutoBeAgent } from "@autobe/agent";
 import { AutoBeExampleStorage } from "@autobe/benchmark";
 import { AutoBeCompiler } from "@autobe/compiler";
-import { AutoBeExampleProject } from "@autobe/interface";
+import {
+  AutoBeEventOfSerializable,
+  AutoBeExampleProject,
+} from "@autobe/interface";
+import typia from "typia";
 import { v7 } from "uuid";
 
 import { TestGlobal } from "../../TestGlobal";
+import { ArchiveLogger } from "../../archive/utils/ArchiveLogger";
 
 export const prepare_realize_agent = async (props: {
   project: AutoBeExampleProject;
   vendor: string;
 }): Promise<AutoBeAgent> => {
+  const start: Date = new Date();
   const agent: AutoBeAgent = new AutoBeAgent({
     vendor: TestGlobal.getVendorConfig(),
     compiler: (listener) => new AutoBeCompiler(listener),
@@ -19,6 +25,9 @@ export const prepare_realize_agent = async (props: {
       phase: "test",
     }),
   });
+  for (const type of typia.misc.literals<AutoBeEventOfSerializable.Type>())
+    agent.on(type, (event) => ArchiveLogger.event(start, event));
+
   agent.getHistories().push({
     id: v7(),
     type: "userMessage",

--- a/test/src/agent/internal/prepare_test_agent.ts
+++ b/test/src/agent/internal/prepare_test_agent.ts
@@ -1,15 +1,21 @@
 import { AutoBeAgent } from "@autobe/agent";
 import { AutoBeExampleStorage } from "@autobe/benchmark";
 import { AutoBeCompiler } from "@autobe/compiler";
-import { AutoBeExampleProject } from "@autobe/interface";
+import {
+  AutoBeEventOfSerializable,
+  AutoBeExampleProject,
+} from "@autobe/interface";
+import typia from "typia";
 import { v7 } from "uuid";
 
 import { TestGlobal } from "../../TestGlobal";
+import { ArchiveLogger } from "../../archive/utils/ArchiveLogger";
 
 export const prepare_test_agent = async (props: {
   project: AutoBeExampleProject;
   vendor: string;
 }): Promise<AutoBeAgent> => {
+  const start: Date = new Date();
   const agent: AutoBeAgent = new AutoBeAgent({
     vendor: TestGlobal.getVendorConfig(),
     compiler: (listener) => new AutoBeCompiler(listener),
@@ -19,6 +25,9 @@ export const prepare_test_agent = async (props: {
       phase: "interface",
     }),
   });
+  for (const type of typia.misc.literals<AutoBeEventOfSerializable.Type>())
+    agent.on(type, (event) => ArchiveLogger.event(start, event));
+
   agent.getHistories().push({
     id: v7(),
     type: "userMessage",


### PR DESCRIPTION
This pull request enhances the test agent preparation utilities by adding event logging for all serializable agent events across several agent setup functions. This is achieved by registering event listeners for each event type and logging them with a timestamp using the `ArchiveLogger`. Additionally, there are some import cleanups and refactoring for consistency.

**Event Logging Enhancements:**

* In all agent preparation files (`prepare_analyze_agent.ts`, `prepare_interface_agent.ts`, `prepare_prisma_agent.ts`, `prepare_realize_agent.ts`, and `prepare_test_agent.ts`), a loop registers listeners for all types in `AutoBeEventOfSerializable.Type`, logging events via `ArchiveLogger.event(start, event)` with a consistent timestamp (`start`). This ensures comprehensive event tracking during agent setup. [[1]](diffhunk://#diff-77706cfb2d80caa42da78b98ad8c531082a5143763dcac4962ef674f469fdb9aL5-R25) [[2]](diffhunk://#diff-80ebb1331655d8ad03a622047d437e0ffa8409a7b0b01c08124e0d1e1b2b5ad1R28-R30) [[3]](diffhunk://#diff-4044c4bb8b23873b51529a3eb7e6f6f24bf34e2a0fbd7b53d6b811fd93db0422R28-R30) [[4]](diffhunk://#diff-834d98456013e0bba21910d61da057da05d6e39654b1a387f3e1da8ec5a69795R28-R30) [[5]](diffhunk://#diff-55df7838565964deec8e60a76b65ac81b996cffcf89128bbf9e58b4d56a9b923R28-R30)

**Import and Refactoring Updates:**

* Updated imports in all affected files to include `AutoBeEventOfSerializable` and `typia`, and added the `ArchiveLogger` import for event logging. This also removes redundant individual imports and improves code consistency. [[1]](diffhunk://#diff-77706cfb2d80caa42da78b98ad8c531082a5143763dcac4962ef674f469fdb9aL5-R25) [[2]](diffhunk://#diff-80ebb1331655d8ad03a622047d437e0ffa8409a7b0b01c08124e0d1e1b2b5ad1L4-R18) [[3]](diffhunk://#diff-4044c4bb8b23873b51529a3eb7e6f6f24bf34e2a0fbd7b53d6b811fd93db0422L4-R18) [[4]](diffhunk://#diff-834d98456013e0bba21910d61da057da05d6e39654b1a387f3e1da8ec5a69795L4-R18) [[5]](diffhunk://#diff-55df7838565964deec8e60a76b65ac81b996cffcf89128bbf9e58b4d56a9b923L4-R18)