### PR TITLE
feat(agent): exclude JSON schema types for accuracy.

### DIFF
--- a/packages/interface/src/openapi/AutoBeOpenApi.ts
+++ b/packages/interface/src/openapi/AutoBeOpenApi.ts
@@ -1212,7 +1212,7 @@ export namespace AutoBeOpenApi {
        * the type schema info of the `T` in the TypeScript array type
        * `Array<T>`.
        */
-      items: IJsonSchema;
+      items: Exclude<IJsonSchema, IJsonSchema.IObject>;
 
       /**
        * Unique items restriction.
@@ -1269,7 +1269,10 @@ export namespace AutoBeOpenApi {
        * If you need additional properties that is represented by dynamic key,
        * you can use the {@link additionalProperties} instead.
        */
-      properties: Record<string, IJsonSchemaDescriptive>;
+      properties: Record<
+        string,
+        Exclude<IJsonSchemaDescriptive, IJsonSchemaDescriptive.IObject>
+      >;
 
       /**
        * Additional properties' info.
@@ -1284,7 +1287,7 @@ export namespace AutoBeOpenApi {
        * - `false`: No additional properties
        * - `IJsonSchema`: `Record<string, T>`
        */
-      additionalProperties?: false | IJsonSchema;
+      additionalProperties?: false | Exclude<IJsonSchema, IJsonSchema.IObject>;
 
       /**
        * List of key values of the required properties.
@@ -1350,7 +1353,7 @@ export namespace AutoBeOpenApi {
      */
     export interface IOneOf {
       /** List of the union types. */
-      oneOf: Exclude<IJsonSchema, IJsonSchema.IOneOf>[];
+      oneOf: Exclude<IJsonSchema, IJsonSchema.IOneOf | IJsonSchema.IObject>[];
 
       /** Discriminator info of the union type. */
       discriminator?: IOneOf.IDiscriminator;

--- a/test/interface.bash
+++ b/test/interface.bash
@@ -12,3 +12,9 @@ code results/qwen-qwen3-next-80b-a3b-instruct/todo/interface
 code results/qwen-qwen3-next-80b-a3b-instruct/bbs/interface
 code results/qwen-qwen3-next-80b-a3b-instruct/reddit/interface
 code results/qwen-qwen3-next-80b-a3b-instruct/shopping/interface
+
+# individual testings
+pnpm ts-node src/agent/interface.complement.ts --vendor qwen/qwen3-next-80b-a3b-instruct --project todo > test.complement.todo.log
+pnpm ts-node src/agent/interface.complement.ts --vendor qwen/qwen3-next-80b-a3b-instruct --project bbs > test.complement.bbs.log
+pnpm ts-node src/agent/interface.complement.ts --vendor qwen/qwen3-next-80b-a3b-instruct --project reddit > test.complement.reddit.log
+pnpm ts-node src/agent/interface.complement.ts --vendor qwen/qwen3-next-80b-a3b-instruct --project shopping > test.complement.shopping.log

--- a/test/src/agent/internal/validate_interface_operation.ts
+++ b/test/src/agent/internal/validate_interface_operation.ts
@@ -1,8 +1,13 @@
 import { AutoBeAgent } from "@autobe/agent";
 import { orchestrateInterfaceOperation } from "@autobe/agent/src/orchestrate/interface/orchestrateInterfaceOperation";
 import { AutoBeExampleStorage } from "@autobe/benchmark";
-import { AutoBeExampleProject, AutoBeOpenApi } from "@autobe/interface";
+import {
+  AutoBeExampleProject,
+  AutoBeInterfaceAuthorization,
+  AutoBeOpenApi,
+} from "@autobe/interface";
 
+import { validate_interface_authorization } from "./validate_interface_authorization";
 import { validate_interface_endpoint } from "./validate_interface_endpoint";
 
 export const validate_interface_operation = async (props: {
@@ -17,11 +22,21 @@ export const validate_interface_operation = async (props: {
       file: "interface.endpoint.json",
     })) ?? (await validate_interface_endpoint(props));
 
-  const operations: AutoBeOpenApi.IOperation[] =
-    await orchestrateInterfaceOperation(props.agent.getContext(), {
+  const operations: AutoBeOpenApi.IOperation[] = [
+    ...(
+      (await AutoBeExampleStorage.load<AutoBeInterfaceAuthorization[]>({
+        vendor: props.vendor,
+        project: props.project,
+        file: "interface.authorization.json",
+      })) ?? (await validate_interface_authorization(props))
+    )
+      .map((a) => a.operations)
+      .flat(),
+    ...(await orchestrateInterfaceOperation(props.agent.getContext(), {
       endpoints,
       instruction: "",
-    });
+    })),
+  ];
 
   await AutoBeExampleStorage.save({
     vendor: props.vendor,


### PR DESCRIPTION
This pull request introduces stricter type constraints to the OpenAPI schema definitions and enhances the interface operation validation process. The changes improve type safety by preventing object types from being used in array and property schemas, and extend the validation workflow to include authorization operations. Additionally, test scripts are updated to support individual project testing.

**Type Safety Improvements in OpenAPI Schema:**

* Updated the `items`, `properties`, and `additionalProperties` fields in `AutoBeOpenApi.IJsonSchema` to exclude object types, ensuring that these fields cannot directly reference object schemas. [[1]](diffhunk://#diff-8df15ff497605818e5b8b37a95eb2c6eb84dc94b58db557c9f383f4d3100baf0L1215-R1215) [[2]](diffhunk://#diff-8df15ff497605818e5b8b37a95eb2c6eb84dc94b58db557c9f383f4d3100baf0L1272-R1275) [[3]](diffhunk://#diff-8df15ff497605818e5b8b37a95eb2c6eb84dc94b58db557c9f383f4d3100baf0L1287-R1290)
* Modified the `oneOf` array in `AutoBeOpenApi.IOneOf` to exclude both `IOneOf` and object types, preventing recursive or object unions in this context.

**Validation Workflow Enhancements:**

* Updated `validate_interface_operation` to load and validate authorization operations (`interface.authorization.json`) in addition to endpoint operations, and included the new `validate_interface_authorization` in the validation process. [[1]](diffhunk://#diff-935ffd478536e678375566fe8f693af31028b1829a37d48707842df72474474cL4-R10) [[2]](diffhunk://#diff-935ffd478536e678375566fe8f693af31028b1829a37d48707842df72474474cL20-R39)

**Testing Improvements:**

* Added commands to `test/interface.bash` for running individual project interface complement tests, outputting results to separate log files for easier debugging.