### PR TITLE
fix(agent): bump up agentica for runtime validation feedback.

### DIFF
--- a/packages/agent/src/orchestrate/interface/utils/JsonSchemaValidator.ts
+++ b/packages/agent/src/orchestrate/interface/utils/JsonSchemaValidator.ts
@@ -33,8 +33,7 @@ export namespace JsonSchemaValidator {
 
   export const isPreset = (typeName: string): boolean =>
     JsonSchemaFactory.DEFAULT_SCHEMAS[typeName] !== undefined ||
-    JsonSchemaValidator.isPage(typeName) === true ||
-    typeName.endsWith(".IAuthorized") === true;
+    JsonSchemaValidator.isPage(typeName) === true;
 
   export interface IProps {
     errors: IValidation.IError[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   agentica:
     '@agentica/core':
-      specifier: ^0.36.0
-      version: 0.36.0
+      specifier: ^0.36.1
+      version: 0.36.1
   libs:
     openai:
       specifier: ^6.15.0
@@ -767,7 +767,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.36.0(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))
+        version: 0.36.1(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))
       '@autobe/interface':
         specifier: workspace:^
         version: link:../interface
@@ -1102,7 +1102,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.36.0(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))
+        version: 0.36.1(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))
       '@autobe/agent':
         specifier: workspace:^
         version: link:../packages/agent
@@ -1255,8 +1255,8 @@ importers:
 
 packages:
 
-  '@agentica/core@0.36.0':
-    resolution: {integrity: sha512-qx9wlomuKDXg5GscVpd5ZaABMsH1PEi8yXERu5Gd0SnrGG5GWgGpckqE7o44HzAkm2seobDW4FEBqo055+43Aw==}
+  '@agentica/core@0.36.1':
+    resolution: {integrity: sha512-DQIaZFqqH2UFnNDJxbhd7gCk+aKPDEXU5Rk1SCgGlfIZT6W3d6pb5VjD+txQvFzEdYgrL9zRw1hhEXuqXK21rg==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.12.0
       '@samchon/openapi': ^6.0.0
@@ -8378,7 +8378,7 @@ packages:
 
 snapshots:
 
-  '@agentica/core@0.36.0(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))':
+  '@agentica/core@0.36.1(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))':
     dependencies:
       '@samchon/openapi': 6.0.0
       es-jsonkit: 0.1.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,8 +9,8 @@ packages:
   - website
 catalogs:
   agentica:
-    '@agentica/core': ^0.36.0
-    '@agentica/rpc': ^0.36.0
+    '@agentica/core': ^0.36.1
+    '@agentica/rpc': ^0.36.1
   samchon:
     '@nestia/benchmark': ^10.0.0
     '@nestia/core': ^10.0.0

--- a/test/interface.bash
+++ b/test/interface.bash
@@ -8,10 +8,10 @@ pnpm run archive:go --vendor qwen/qwen3-next-80b-a3b-instruct --project reddit -
 pnpm run archive:go --vendor qwen/qwen3-next-80b-a3b-instruct --project shopping --from interface --to interface > archive.qwen-qwen3-next-80b-a3b-instruct.shopping.log
 
 # opening projects
-code results/qwen-qwen3-next-80b-a3b-instruct/todo/interface
-code results/qwen-qwen3-next-80b-a3b-instruct/bbs/interface
-code results/qwen-qwen3-next-80b-a3b-instruct/reddit/interface
-code results/qwen-qwen3-next-80b-a3b-instruct/shopping/interface
+code results/qwen/qwen3-next-80b-a3b-instruct/todo/interface
+code results/qwen/qwen3-next-80b-a3b-instruct/bbs/interface
+code results/qwen/qwen3-next-80b-a3b-instruct/reddit/interface
+code results/qwen/qwen3-next-80b-a3b-instruct/shopping/interface
 
 # individual testings
 pnpm ts-node src/agent/interface.complement.ts --vendor qwen/qwen3-next-80b-a3b-instruct --project todo > test.complement.todo.log


### PR DESCRIPTION
This pull request primarily updates the `@agentica/core` and `@agentica/rpc` dependencies to version `0.36.1` across the codebase, and makes a small adjustment to the `isPreset` logic in the `JsonSchemaValidator` utility. It also corrects file paths in a test script for improved consistency.

Dependency updates:

* Upgraded `@agentica/core` and `@agentica/rpc` to version `0.36.1` in `pnpm-lock.yaml` and `pnpm-workspace.yaml`, ensuring the project uses the latest features and fixes from these packages. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R11) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL770-R770) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1105-R1105) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1258-R1259) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8381-R8381) [[6]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL12-R13)

Logic adjustment:

* Removed the check for types ending with `.IAuthorized` from the `isPreset` function in `JsonSchemaValidator.ts`, simplifying the preset type logic.

Test script maintenance:

* Fixed file paths in `test/interface.bash` to use the correct directory structure for opening project results.