### PR TITLE
fix(agent): propagate exception from function calling execution.

### DIFF
--- a/packages/agent/src/AutoBeAgent.ts
+++ b/packages/agent/src/AutoBeAgent.ts
@@ -32,6 +32,7 @@ import { createAutoBeState } from "./factory/createAutoBeState";
 import { getAutoBeGenerated } from "./factory/getAutoBeGenerated";
 import { getCommonPrompt } from "./factory/getCommonPrompt";
 import { supportMistral } from "./factory/supportMistral";
+import { throwExecuteFailure } from "./factory/throwExecuteFailure";
 import { createAutoBeFacadeController } from "./orchestrate/facade/createAutoBeFacadeController";
 import { transformFacadeStateMessage } from "./orchestrate/facade/structures/transformFacadeStateMessage";
 import { IAutoBeProps } from "./structures/IAutoBeProps";
@@ -313,15 +314,7 @@ export class AutoBeAgent extends AutoBeAgentBase implements IAutoBeAgent {
         (h): h is AgenticaExecuteHistory =>
           h.type === "execute" && h.success === false,
       );
-    if (errorHistory !== undefined) {
-      if (errorHistory.value instanceof Error) throw errorHistory.value;
-      else {
-        const v = new Error();
-        Object.assign(v, errorHistory.value);
-        throw v;
-      }
-    }
-
+    if (errorHistory !== undefined) throwExecuteFailure(errorHistory);
     return this.histories_.slice(index);
   }
 

--- a/packages/agent/src/factory/throwExecuteFailure.ts
+++ b/packages/agent/src/factory/throwExecuteFailure.ts
@@ -1,0 +1,13 @@
+import { AgenticaExecuteHistory } from "@agentica/core";
+
+export const throwExecuteFailure = (history: AgenticaExecuteHistory): never => {
+  if (history.success === true)
+    throw new Error("Cannot throw execute success history");
+  else if (history.value instanceof Error) throw history.value;
+  else if (typeof history.value === "object" && history.value !== null) {
+    const error: Error = new Error();
+    Object.assign(error, history.value);
+    throw error;
+  }
+  throw history.value;
+};


### PR DESCRIPTION
This pull request refactors error handling for execution failures in the `AutoBeAgent` and `createAutoBeContext` modules by introducing a new utility function, `throwExecuteFailure`. The changes centralize and standardize the logic for throwing execution errors, improving maintainability and consistency across the codebase.

**Centralized error handling:**

* Added a new utility function `throwExecuteFailure` in `throwExecuteFailure.ts` to encapsulate the logic for throwing errors from `AgenticaExecuteHistory` objects.

**Refactoring to use the new utility:**

* Updated `AutoBeAgent` in `AutoBeAgent.ts` to use `throwExecuteFailure` instead of inline error handling when an execution failure is detected. [[1]](diffhunk://#diff-eb5845bde058399222e7eb37fcc40ccd00bee27a5d2531830decea25dc197e73R35) [[2]](diffhunk://#diff-eb5845bde058399222e7eb37fcc40ccd00bee27a5d2531830decea25dc197e73L316-R317)
* Updated `createAutoBeContext` in `createAutoBeContext.ts` to use `throwExecuteFailure` for handling execution failures, replacing the previous inline logic. [[1]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eR2) [[2]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eR57) [[3]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eL271-R282) [[4]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eR332)