### PR TITLE
fix(agent): validation feedback for nested object types

### DIFF
--- a/packages/agent/src/orchestrate/interface/utils/JsonSchemaValidator.ts
+++ b/packages/agent/src/orchestrate/interface/utils/JsonSchemaValidator.ts
@@ -554,5 +554,4 @@ const isExcludedObjectType = (error: IValidation.IError): boolean =>
       ))) &&
   typia.is<{
     type: "object";
-    properties: object;
   }>(error.value) === true;


### PR DESCRIPTION
This pull request enhances the JSON schema validation logic to enforce best practices for schema definitions in AutoBE. The main improvement is the introduction of a new validation step that detects and provides descriptive feedback when inline (nested) object type definitions are used, guiding developers to use named schemas instead. This helps maintain a clean, reusable, and AI-friendly schema structure.

**Schema validation improvements:**

* Added a new `validateNestedObject` function to the `JsonSchemaValidator` namespace, which checks for and flags nested inline object type definitions, enforcing the use of named schemas referenced via `$ref` instead. The error message explains the rationale and provides clear examples for correct usage.
* Updated the schema validation pipeline to call `validateNestedObject` alongside other validation steps, ensuring this check is performed during validation.
* Introduced the `isExcludedObjectType` helper function to accurately identify errors caused by inline object definitions in various schema contexts.

**Dependency update:**

* Changed the import of `typia` to a default import to support the new type-checking logic.