### PR TITLE
fix(agent): add empty user message checking logic to AutoBeAgent.conversate

### DIFF
--- a/packages/agent/src/AutoBeAgent.ts
+++ b/packages/agent/src/AutoBeAgent.ts
@@ -294,6 +294,11 @@ export class AutoBeAgent extends AutoBeAgentBase implements IAutoBeAgent {
         : Array.isArray(content)
           ? content
           : [content];
+    for (const c of userContent) {
+      if (c.type === "text" && c.text.trim().length === 0) {
+        throw new Error("User message cannot be empty");
+      }
+    }
     this.dispatch({
       type: "userMessage",
       id: v7(),


### PR DESCRIPTION
This pull request adds validation to user messages in the `AutoBeAgent` class to prevent empty text messages from being processed.

- **Validation improvements:**
  * Added a check in `AutoBeAgent.ts` to throw an error if a user message of type `"text"` is empty or contains only whitespace, ensuring that only meaningful user messages are accepted.