### PR TITLE
fix(agent): while complementation

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
@@ -207,9 +207,9 @@ export const orchestrateInterface =
       completed: 0,
       total: 0,
     };
-    for (let ci: number = 0; ci < ctx.retry; ++ci) {
+    while (true) {
       if (missedOpenApiSchemas(document).length === 0) break;
-      
+
       // COMPLEMENT OMITTED
       const oldbie: Set<string> = new Set(
         Object.keys(document.components.schemas),
@@ -226,6 +226,7 @@ export const orchestrateInterface =
             .filter((key) => oldbie.has(key) === false)
             .map((key) => [key, complemented[key]]),
         );
+      if (Object.keys(complemented).length === 0) break;
       assign(complemented);
 
       // REVIEW COMPLEMENTED


### PR DESCRIPTION
This pull request updates the retry logic in the `orchestrateInterface` function to improve how missing OpenAPI schemas are handled. The main change is replacing the fixed retry loop with a more flexible loop that exits based on completion criteria, ensuring the process only continues as long as necessary.

**Improvements to retry and completion logic:**

* Replaced the fixed retry `for` loop with a `while (true)` loop, allowing the process to continue until all missing OpenAPI schemas are resolved, rather than relying on a set number of retries.
* Added an early exit condition to break out of the loop if no new complemented schemas are found, preventing unnecessary iterations.