### PR TITLE
feat(agent): bump up `agentica`

### DIFF
--- a/packages/agent/src/orchestrate/interface/histories/transformInterfaceComplementHistory.ts
+++ b/packages/agent/src/orchestrate/interface/histories/transformInterfaceComplementHistory.ts
@@ -9,7 +9,7 @@ import { AutoBePreliminaryController } from "../../common/AutoBePreliminaryContr
 export const transformInterfaceComplementHistory = (props: {
   state: AutoBeState;
   instruction: string;
-  missed: string;
+  typeName: string;
   preliminary: AutoBePreliminaryController<
     | "analysisFiles"
     | "databaseSchemas"
@@ -61,7 +61,7 @@ export const transformInterfaceComplementHistory = (props: {
 
         You need to create a schema definition for this missing type:
 
-        **${props.missed}**
+        **${props.typeName}**
 
         This type is referenced in API operations but not yet defined in
         components.schemas. Create a complete JSON schema definition for it.
@@ -69,11 +69,11 @@ export const transformInterfaceComplementHistory = (props: {
     },
   ],
   userMessage: StringUtil.trim`
-    Complete the missing schema type ${JSON.stringify(props.missed)} 
+    Complete the missing schema type ${JSON.stringify(props.typeName)} 
     based on the provided API design instructions.
 
     Note that, not making "Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>"
     type, but making "AutoBeOpenApi.IJsonSchemaDescriptive" type directly for
-    the ${JSON.stringify(props.missed)} type.
+    the ${JSON.stringify(props.typeName)} type.
   `,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   agentica:
     '@agentica/core':
-      specifier: ^0.36.2
-      version: 0.36.2
+      specifier: ^0.36.3
+      version: 0.36.3
   libs:
     openai:
       specifier: ^6.15.0
@@ -767,7 +767,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.36.2(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))
+        version: 0.36.3(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))
       '@autobe/interface':
         specifier: workspace:^
         version: link:../interface
@@ -1102,7 +1102,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.36.2(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))
+        version: 0.36.3(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))
       '@autobe/agent':
         specifier: workspace:^
         version: link:../packages/agent
@@ -1255,8 +1255,8 @@ importers:
 
 packages:
 
-  '@agentica/core@0.36.2':
-    resolution: {integrity: sha512-Qdx/Caq2TPwzyWGGf47YvWz361zz9vSgdC+6mB16NWK8+FEC9aED9sQTgjpnPmKzFki+KaSubktCjd1YgN16AQ==}
+  '@agentica/core@0.36.3':
+    resolution: {integrity: sha512-3WApeACCG5s10R9YqNzZy6SHGXxG/1KU/0Hy8vqLKN3zyvz463fqcgZETAlm/ACblvSb7Chttd7bf33ly3vkHQ==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.12.0
       '@samchon/openapi': ^6.0.0
@@ -4768,9 +4768,6 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-jsonkit@0.1.6:
-    resolution: {integrity: sha512-fQ1ufr6cQcpBliliEU4eOW2ZFdaWbfu1wpgizt1Z2F+WI2akLJDI2a203S0MEtEYQCXNxMD8Y070bABMF5dTaQ==}
-
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -5681,6 +5678,10 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonrepair@3.13.1:
+    resolution: {integrity: sha512-WJeiE0jGfxYmtLwBTEk8+y/mYcaleyLXWaqp5bJu0/ZTSeG0KQq/wWQ8pmnkKenEdN6pdnn6QtcoSUkbqDHWNw==}
+    hasBin: true
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -8378,10 +8379,10 @@ packages:
 
 snapshots:
 
-  '@agentica/core@0.36.2(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))':
+  '@agentica/core@0.36.3(@samchon/openapi@6.0.0)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.0(typescript@5.9.3))':
     dependencies:
       '@samchon/openapi': 6.0.0
-      es-jsonkit: 0.1.6
+      jsonrepair: 3.13.1
       openai: 6.15.0(ws@8.18.3)(zod@4.2.1)
       tstl: 3.0.0
       typia: 11.0.0(typescript@5.9.3)
@@ -12079,8 +12080,6 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-jsonkit@0.1.6: {}
-
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
@@ -13203,6 +13202,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonrepair@3.13.1: {}
 
   jsonwebtoken@9.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,8 +9,8 @@ packages:
   - website
 catalogs:
   agentica:
-    '@agentica/core': ^0.36.2
-    '@agentica/rpc': ^0.36.2
+    '@agentica/core': ^0.36.3
+    '@agentica/rpc': ^0.36.3
   samchon:
     '@nestia/benchmark': ^10.0.0
     '@nestia/core': ^10.0.0


### PR DESCRIPTION
This pull request primarily refactors the interface complement orchestration logic to consistently use the property name `typeName` instead of `missed` throughout the codebase, improving clarity and maintainability. Additionally, it updates the dependency on `@agentica/core` to version 0.36.3 and synchronizes related lockfile and workspace configurations.

Key changes include:

### Refactoring and Code Consistency

* Replaced all occurrences of the property `missed` with `typeName` in the interface complement orchestration logic, including function parameters, object properties, and string interpolations in `transformInterfaceComplementHistory.ts` and `orchestrateInterfaceComplement.ts`. This improves code readability and makes the purpose of the property clearer. [[1]](diffhunk://#diff-20d4925348f4db78376ed027a090b86e361f0f848f5bd6a7ca153b9e79784183L12-R12) [[2]](diffhunk://#diff-20d4925348f4db78376ed027a090b86e361f0f848f5bd6a7ca153b9e79784183L64-R77) [[3]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L43-R44) [[4]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L57-R58) [[5]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L93-R95) [[6]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L108-R109) [[7]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L125-R140) [[8]](diffhunk://#diff-26583e55ae3b74acf31e514c5192640a0b9fde8641efa54b0fb4e919d2c75900L149-R168)

### Dependency and Package Updates

* Upgraded `@agentica/core` from version 0.36.2 to 0.36.3 in both `pnpm-lock.yaml` and `pnpm-workspace.yaml`, ensuring compatibility with the latest features and bug fixes. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R11) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL770-R770) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1105-R1105) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1258-R1259) [[5]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL12-R13)
* Updated lockfile snapshots to reflect the new dependency version and replaced the `es-jsonkit` package with `jsonrepair` as a dependency of `@agentica/core`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8381-R8385) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4771-L4773) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5682-R5685) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12082-L12083) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR13206-R13207)