### PR TITLE
fix(agent): preliminary schema enum specifier.

### DIFF
--- a/test/src/features/preliminary/test_preliminary_application_fix_enum.ts
+++ b/test/src/features/preliminary/test_preliminary_application_fix_enum.ts
@@ -1,0 +1,165 @@
+import { AutoBeAgent } from "@autobe/agent";
+import { AutoBeState } from "@autobe/agent/src/context/AutoBeState";
+import { AutoBePreliminaryController } from "@autobe/agent/src/orchestrate/common/AutoBePreliminaryController";
+import { IAutoBePreliminaryGetAnalysisFiles } from "@autobe/agent/src/orchestrate/common/structures/IAutoBePreliminaryGetAnalysisFiles";
+import { IAutoBePreliminaryGetDatabaseSchemas } from "@autobe/agent/src/orchestrate/common/structures/IAutoBePreliminaryGetDatabaseSchemas";
+import { IAutoBePreliminaryGetInterfaceOperations } from "@autobe/agent/src/orchestrate/common/structures/IAutoBePreliminaryGetInterfaceOperations";
+import { IAutoBePreliminaryGetInterfaceSchemas } from "@autobe/agent/src/orchestrate/common/structures/IAutoBePreliminaryGetInterfaceSchemas";
+import { IAutoBeInterfaceSchemaReviewApplication } from "@autobe/agent/src/orchestrate/interface/structures/IAutoBeInterfaceSchemaReviewApplication";
+import { AutoBeExampleStorage } from "@autobe/benchmark";
+import { AutoBeCompiler } from "@autobe/compiler";
+import { TestValidator } from "@nestia/e2e";
+import { ILlmApplication, ILlmSchema } from "@samchon/openapi";
+import OpenAI from "openai";
+import typia from "typia";
+
+import { TestGlobal } from "../../TestGlobal";
+
+export const test_preliminary_application_fix_enum = async () => {
+  if (
+    (await AutoBeExampleStorage.has({
+      vendor: TestGlobal.vendorModel,
+      project: "todo",
+      phase: "interface",
+    })) === false
+  )
+    return false;
+
+  const agent: AutoBeAgent = new AutoBeAgent({
+    vendor: {
+      api: new OpenAI({ apiKey: "" }),
+      model: TestGlobal.vendorModel,
+    },
+    compiler: (listener) => new AutoBeCompiler(listener),
+    histories: await AutoBeExampleStorage.getHistories({
+      vendor: TestGlobal.vendorModel,
+      project: "todo",
+      phase: "interface",
+    }),
+  });
+
+  const application: ILlmApplication =
+    typia.llm.application<IAutoBeInterfaceSchemaReviewApplication>();
+  const preliminary: AutoBePreliminaryController<
+    | "analysisFiles"
+    | "databaseSchemas"
+    | "interfaceOperations"
+    | "interfaceSchemas"
+    | "previousAnalysisFiles"
+    | "previousDatabaseSchemas"
+    | "previousInterfaceOperations"
+    | "previousInterfaceSchemas"
+  > = new AutoBePreliminaryController({
+    application:
+      typia.json.application<IAutoBeInterfaceSchemaReviewApplication>(),
+    source: "interfaceSchemaReview",
+    kinds: [
+      "analysisFiles",
+      "databaseSchemas",
+      "interfaceOperations",
+      "interfaceSchemas",
+      "previousAnalysisFiles",
+      "previousDatabaseSchemas",
+      "previousInterfaceOperations",
+      "previousInterfaceSchemas",
+    ],
+    state: agent.getContext().state(),
+  });
+  preliminary.fixApplication(application);
+
+  const state: AutoBeState = preliminary.getState();
+  const $defs: Record<string, ILlmSchema> = application.functions.find(
+    (f) => f.name === "process",
+  )!.parameters.$defs;
+  validateAnalysisFiles(state, $defs);
+  validateDatabaseSchemas(state, $defs);
+  validateInterfaceOperations(state, $defs);
+  validateInterfaceSchemas(state, $defs);
+};
+
+const validateAnalysisFiles = (
+  state: AutoBeState,
+  $defs: Record<string, ILlmSchema>,
+): void => {
+  const type: ILlmSchema.IObject = $defs[
+    typia.reflect.name<IAutoBePreliminaryGetAnalysisFiles>()
+  ] as ILlmSchema.IObject;
+  const array: ILlmSchema.IArray = type.properties
+    .fileNames as ILlmSchema.IArray;
+  const items: ILlmSchema.IString = array.items as ILlmSchema.IString;
+  TestValidator.equals(
+    "analysisFiles",
+    (items.enum ?? []).slice().sort(),
+    (state.analyze?.files ?? []).map((f) => f.filename).sort(),
+  );
+};
+
+const validateDatabaseSchemas = (
+  state: AutoBeState,
+  $defs: Record<string, ILlmSchema>,
+): void => {
+  const type: ILlmSchema.IObject = $defs[
+    typia.reflect.name<IAutoBePreliminaryGetDatabaseSchemas>()
+  ] as ILlmSchema.IObject;
+  const array: ILlmSchema.IArray = type.properties
+    .schemaNames as ILlmSchema.IArray;
+  const items: ILlmSchema.IString = array.items as ILlmSchema.IString;
+  TestValidator.equals(
+    "databaseSchemas",
+    (items.enum ?? []).slice().sort(),
+    (
+      state.database?.result.data.files
+        .map((f) => f.models)
+        .flat()
+        .map((m) => m.name) ?? []
+    ).sort(),
+  );
+};
+
+const validateInterfaceOperations = (
+  state: AutoBeState,
+  $defs: Record<string, ILlmSchema>,
+): void => {
+  const type: ILlmSchema.IObject = $defs[
+    typia.reflect.name<IAutoBePreliminaryGetInterfaceOperations>()
+  ] as ILlmSchema.IObject;
+  const array: ILlmSchema.IArray = type.properties
+    .endpoints as ILlmSchema.IArray;
+  const items: ILlmSchema.IAnyOf = array.items as ILlmSchema.IAnyOf;
+  TestValidator.equals("interfaceOperations", items, {
+    anyOf: (state.interface?.document.operations ?? []).map(
+      (op) =>
+        ({
+          type: "object",
+          properties: {
+            path: {
+              type: "string",
+              enum: [op.path],
+            } satisfies ILlmSchema.IString,
+            method: {
+              type: "string",
+              enum: [op.method],
+            } satisfies ILlmSchema.IString,
+          },
+          required: ["path", "method"],
+        }) satisfies ILlmSchema.IObject,
+    ),
+  } satisfies ILlmSchema.IAnyOf);
+};
+
+const validateInterfaceSchemas = (
+  state: AutoBeState,
+  $defs: Record<string, ILlmSchema>,
+): void => {
+  const type: ILlmSchema.IObject = $defs[
+    typia.reflect.name<IAutoBePreliminaryGetInterfaceSchemas>()
+  ] as ILlmSchema.IObject;
+  const array: ILlmSchema.IArray = type.properties
+    .typeNames as ILlmSchema.IArray;
+  const items: ILlmSchema.IString = array.items as ILlmSchema.IString;
+  TestValidator.equals(
+    "interfaceSchemas",
+    (items.enum ?? []).slice().sort(),
+    Object.keys(state.interface?.document.components.schemas ?? {}).sort(),
+  );
+};

--- a/test/src/features/preliminary/test_preliminary_application_fix_erase.ts
+++ b/test/src/features/preliminary/test_preliminary_application_fix_erase.ts
@@ -10,7 +10,7 @@ import typia from "typia";
 
 import { TestGlobal } from "../../TestGlobal";
 
-export const test_preliminary_controller_fix_of_chatgpt = async () => {
+export const test_preliminary_application_fix_erase = async () => {
   if (
     (await AutoBeExampleStorage.has({
       vendor: TestGlobal.vendorModel,
@@ -23,7 +23,7 @@ export const test_preliminary_controller_fix_of_chatgpt = async () => {
   const agent: AutoBeAgent = new AutoBeAgent({
     vendor: {
       api: new OpenAI({ apiKey: "" }),
-      model: "gpt-4.1",
+      model: TestGlobal.vendorModel,
     },
     compiler: (listener) => new AutoBeCompiler(listener),
     histories: await AutoBeExampleStorage.getHistories({


### PR DESCRIPTION
This pull request significantly enhances the preliminary application fixing logic and adds comprehensive test coverage for enum population in preliminary application schemas. The main improvements include the introduction of an extensible `ApplicationFixer` namespace for handling various preliminary kinds, dynamic population of enum values in schema definitions, and new tests to validate this behavior. Additionally, a test file was renamed for clarity and consistency.

**Enhancements to preliminary application fixing:**

* Introduced the `ApplicationFixer` namespace in `fixPrelminaryApplication.ts` to modularize logic for populating enums in schema definitions for different preliminary kinds, including handling both current and previous data.
* Updated the main `fixPreliminaryApplication` function to iterate over all preliminary kinds, dynamically invoking the appropriate fixer from `ApplicationFixer` and distinguishing between current and previous kinds.

**Test improvements:**

* Added a new test `test_preliminary_application_fix_enum.ts` that validates the correct population of enum values in the application schema for analysis files, database schemas, interface operations, and interface schemas.
* Renamed the test file `test_preliminary_controller_fix.ts` to `test_preliminary_application_fix_erase.ts` and updated the test name for clarity and consistency.
* Updated the model used in the erase test to use `TestGlobal.vendorModel` for consistency with other tests.