### PR TITLE
fix(agent): zero length case for `fixPreliminaryApplication()`

### DIFF
--- a/packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts
+++ b/packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts
@@ -1,4 +1,9 @@
-import { AutoBeOpenApi, AutoBePreliminaryKind } from "@autobe/interface";
+import {
+  AutoBeAnalyzeFile,
+  AutoBeDatabase,
+  AutoBeOpenApi,
+  AutoBePreliminaryKind,
+} from "@autobe/interface";
 import {
   ILlmApplication,
   ILlmFunction,
@@ -133,6 +138,12 @@ namespace ApplicationFixer {
     >;
     previous: boolean;
   }): void => {
+    const analysisFiles: AutoBeAnalyzeFile[] =
+      props.controller.getAll()[
+        props.previous ? "previousAnalysisFiles" : "analysisFiles"
+      ];
+    if (analysisFiles.length === 0) return;
+
     const type: ILlmSchema.IObject = props.$defs[
       props.previous
         ? typia.reflect.name<IAutoBePreliminaryGetPreviousAnalysisFiles>()
@@ -141,11 +152,7 @@ namespace ApplicationFixer {
     const array: ILlmSchema.IArray = type.properties
       .fileNames as ILlmSchema.IArray;
     const items: ILlmSchema.IString = array.items as ILlmSchema.IString;
-    items.enum = props.controller
-      .getAll()
-      [
-        props.previous ? "previousAnalysisFiles" : "analysisFiles"
-      ].map((x) => x.filename);
+    items.enum = analysisFiles.map((x) => x.filename);
   };
 
   export const databaseSchemas = (props: {
@@ -155,6 +162,12 @@ namespace ApplicationFixer {
     >;
     previous: boolean;
   }): void => {
+    const schemas: AutoBeDatabase.IModel[] =
+      props.controller.getAll()[
+        props.previous ? "previousDatabaseSchemas" : "databaseSchemas"
+      ];
+    if (schemas.length === 0) return;
+
     const type: ILlmSchema.IObject = props.$defs[
       props.previous
         ? typia.reflect.name<IAutoBePreliminaryGetPreviousDatabaseSchemas>()
@@ -163,11 +176,7 @@ namespace ApplicationFixer {
     const array: ILlmSchema.IArray = type.properties
       .schemaNames as ILlmSchema.IArray;
     const items: ILlmSchema.IString = array.items as ILlmSchema.IString;
-    items.enum = props.controller
-      .getAll()
-      [
-        props.previous ? "previousDatabaseSchemas" : "databaseSchemas"
-      ].map((x) => x.name);
+    items.enum = schemas.map((x) => x.name);
   };
 
   export const interfaceOperations = (props: {
@@ -177,6 +186,12 @@ namespace ApplicationFixer {
     >;
     previous: boolean;
   }): void => {
+    const operations: AutoBeOpenApi.IOperation[] =
+      props.controller.getAll()[
+        props.previous ? "previousInterfaceOperations" : "interfaceOperations"
+      ];
+    if (operations.length === 0) return;
+
     const type: ILlmSchema.IObject = props.$defs[
       props.previous
         ? typia.reflect.name<IAutoBePreliminaryGetPreviousInterfaceOperations>()
@@ -185,27 +200,23 @@ namespace ApplicationFixer {
     const array: ILlmSchema.IArray = type.properties
       .endpoints as ILlmSchema.IArray;
     array.items = {
-      anyOf: props.controller
-        .getAll()
-        [
-          props.previous ? "previousInterfaceOperations" : "interfaceOperations"
-        ].map(
-          (op) =>
-            ({
-              type: "object",
-              properties: {
-                path: {
-                  type: "string",
-                  enum: [op.path],
-                } satisfies ILlmSchema.IString,
-                method: {
-                  type: "string",
-                  enum: [op.method],
-                } satisfies ILlmSchema.IString,
-              },
-              required: ["path", "method"],
-            }) satisfies ILlmSchema.IObject,
-        ),
+      anyOf: operations.map(
+        (op) =>
+          ({
+            type: "object",
+            properties: {
+              path: {
+                type: "string",
+                enum: [op.path],
+              } satisfies ILlmSchema.IString,
+              method: {
+                type: "string",
+                enum: [op.method],
+              } satisfies ILlmSchema.IString,
+            },
+            required: ["path", "method"],
+          }) satisfies ILlmSchema.IObject,
+      ),
     } satisfies ILlmSchema.IAnyOf;
   };
 
@@ -216,6 +227,13 @@ namespace ApplicationFixer {
     >;
     previous: boolean;
   }): void => {
+    const dtoTypeNames: string[] = Object.keys(
+      props.controller.getAll()[
+        props.previous ? "previousInterfaceSchemas" : "interfaceSchemas"
+      ] satisfies Record<string, AutoBeOpenApi.IJsonSchema>,
+    );
+    if (dtoTypeNames.length === 0) return;
+
     const type: ILlmSchema.IObject = props.$defs[
       props.previous
         ? typia.reflect.name<IAutoBePreliminaryGetPreviousInterfaceSchemas>()
@@ -224,17 +242,15 @@ namespace ApplicationFixer {
     const array: ILlmSchema.IArray = type.properties
       .typeNames as ILlmSchema.IArray;
     const items: ILlmSchema.IString = array.items as ILlmSchema.IString;
-    items.enum = Object.keys(
-      props.controller.getAll()[
-        props.previous ? "previousInterfaceSchemas" : "interfaceSchemas"
-      ] satisfies Record<string, AutoBeOpenApi.IJsonSchema>,
-    );
+    items.enum = dtoTypeNames;
   };
 
   export const realizeCollectors = (props: {
     $defs: Record<string, ILlmSchema>;
     controller: AutoBePreliminaryController<"realizeCollectors">;
   }): void => {
+    if (props.controller.getAll().realizeCollectors.length === 0) return;
+
     const type: ILlmSchema.IObject = props.$defs[
       typia.reflect.name<IAutoBePreliminaryGetRealizeCollectors>()
     ] as ILlmSchema.IObject;
@@ -250,6 +266,8 @@ namespace ApplicationFixer {
     $defs: Record<string, ILlmSchema>;
     controller: AutoBePreliminaryController<"realizeTransformers">;
   }): void => {
+    if (props.controller.getAll().realizeTransformers.length === 0) return;
+
     const type: ILlmSchema.IObject = props.$defs[
       typia.reflect.name<IAutoBePreliminaryGetRealizeTransformers>()
     ] as ILlmSchema.IObject;

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchema.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchema.ts
@@ -114,6 +114,21 @@ async function process(
       "previousInterfaceSchemas",
     ],
     state: ctx.state(),
+    all: {
+      interfaceOperations: props.operations,
+    },
+    local: {
+      interfaceOperations: props.operations.filter((o) => {
+        const predicate = (key: string) =>
+          key === props.typeName ||
+          (JsonSchemaValidator.isPage(key) &&
+            JsonSchemaFactory.getPageName(key) === props.typeName);
+        return (
+          (o.requestBody && predicate(o.requestBody.typeName)) ||
+          (o.responseBody && predicate(o.responseBody.typeName))
+        );
+      }),
+    },
   });
   return await preliminary.orchestrate(ctx, async (out) => {
     const pointer: IPointer<AutoBeOpenApi.IJsonSchemaDescriptive | null> = {


### PR DESCRIPTION
This pull request refactors several functions in `fixPrelminaryApplication.ts` to improve code clarity and robustness when updating schema enums and collections. It introduces local variables to store filtered data, adds early returns for empty collections, and simplifies how enums are set. Additionally, it updates `orchestrateInterfaceSchema.ts` to include `interfaceOperations` in the orchestration state.

**Refactoring and robustness improvements:**

* Added local variables in multiple functions (`analysisFiles`, `schemas`, `operations`, `dtoTypeNames`) to store filtered data and replaced repeated property access with these variables for clarity. Early returns were added when collections are empty to prevent unnecessary processing. [[1]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4R141-R146) [[2]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4R165-R170) [[3]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4R189-R194) [[4]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4R230-R236)
* Simplified how enums are set for schema properties by using these local variables, replacing previous chained property accesses and mapping. [[1]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L144-R155) [[2]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L166-R179) [[3]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L188-R203) [[4]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L227-R253)

**Orchestration state updates:**

* In `orchestrateInterfaceSchema.ts`, added `interfaceOperations` to both the `all` and `local` orchestration state, with local filtering based on request/response body type names.

**Miscellaneous improvements:**

* Added early return checks for empty `realizeCollectors` and `realizeTransformers` arrays to avoid unnecessary schema updates. [[1]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L227-R253) [[2]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4R269-R270)

**Type imports:**

* Updated import statements to include missing types used in the new local variable assignments.