### PR TITLE
fix(agent): give up dynamic function calling schema from preliminary.

### DIFF
--- a/packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts
+++ b/packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts
@@ -82,22 +82,23 @@ export const fixPreliminaryApplication = <
       }
     }
 
-  for (const kind of props.preliminary.getKinds()) {
-    const accessor: Exclude<AutoBePreliminaryKind, `previous${string}`> = (
-      kind.startsWith("previous")
-        ? (() => {
-            const value = kind.replace("previous", "");
-            return value[0].toLowerCase() + value.substring(1);
-          })()
-        : kind
-    ) as Exclude<AutoBePreliminaryKind, `previous${string}`>;
-    const previous: boolean = kind.startsWith("previous");
-    ApplicationFixer[accessor]({
-      $defs: func.parameters.$defs,
-      controller: props.preliminary as any,
-      previous,
-    });
-  }
+  // for (const kind of props.preliminary.getKinds()) {
+  //   const accessor: Exclude<AutoBePreliminaryKind, `previous${string}`> = (
+  //     kind.startsWith("previous")
+  //       ? (() => {
+  //           const value = kind.replace("previous", "");
+  //           return value[0].toLowerCase() + value.substring(1);
+  //         })()
+  //       : kind
+  //   ) as Exclude<AutoBePreliminaryKind, `previous${string}`>;
+  //   const previous: boolean = kind.startsWith("previous");
+  //   ApplicationFixer[accessor]({
+  //     $defs: func.parameters.$defs,
+  //     controller: props.preliminary as any,
+  //     previous,
+  //   });
+  // }
+  ApplicationFixer;
 };
 
 const getUnionErasure = (props: {


### PR DESCRIPTION
This pull request makes a small change to the `fixPreliminaryApplication` function by commenting out the logic that iterated over preliminary kinds and invoked the corresponding `ApplicationFixer` methods. The `ApplicationFixer` reference remains in place, but its invocation logic is now disabled. 

- Commented out the loop that called `ApplicationFixer` methods for each preliminary kind in `fixPreliminaryApplication`, effectively disabling that functionality. (`packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts`, [packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.tsL85-R101](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L85-R101))