### PR TITLE
fix(agent): `AutoBePreliminaryController.fixApplication(app, enum)`

### DIFF
--- a/packages/agent/src/orchestrate/common/AutoBePreliminaryController.ts
+++ b/packages/agent/src/orchestrate/common/AutoBePreliminaryController.ts
@@ -212,12 +212,17 @@ export class AutoBePreliminaryController<Kind extends AutoBePreliminaryKind> {
    * controller's `all`/`local` collections.
    *
    * @param application LLM application to modify (mutated in-place).
+   * @param enumerable Whether to use `enum` values for item lists
    */
-  public fixApplication(application: ILlmApplication): ILlmApplication {
+  public fixApplication(
+    application: ILlmApplication,
+    enumerable: boolean = false,
+  ): ILlmApplication {
     fixPreliminaryApplication({
       state: this.state,
       preliminary: this,
       application,
+      enumerable,
     });
     return application;
   }

--- a/packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts
+++ b/packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts
@@ -32,6 +32,7 @@ export const fixPreliminaryApplication = <
   state: AutoBeState;
   preliminary: AutoBePreliminaryController<Kind>;
   application: ILlmApplication;
+  enumerable: boolean;
 }): void => {
   if (
     props.preliminary.getKinds().some((k) => k.includes("previous")) === false
@@ -82,23 +83,23 @@ export const fixPreliminaryApplication = <
       }
     }
 
-  // for (const kind of props.preliminary.getKinds()) {
-  //   const accessor: Exclude<AutoBePreliminaryKind, `previous${string}`> = (
-  //     kind.startsWith("previous")
-  //       ? (() => {
-  //           const value = kind.replace("previous", "");
-  //           return value[0].toLowerCase() + value.substring(1);
-  //         })()
-  //       : kind
-  //   ) as Exclude<AutoBePreliminaryKind, `previous${string}`>;
-  //   const previous: boolean = kind.startsWith("previous");
-  //   ApplicationFixer[accessor]({
-  //     $defs: func.parameters.$defs,
-  //     controller: props.preliminary as any,
-  //     previous,
-  //   });
-  // }
-  ApplicationFixer;
+  if (props.enumerable === true)
+    for (const kind of props.preliminary.getKinds()) {
+      const accessor: Exclude<AutoBePreliminaryKind, `previous${string}`> = (
+        kind.startsWith("previous")
+          ? (() => {
+              const value = kind.replace("previous", "");
+              return value[0].toLowerCase() + value.substring(1);
+            })()
+          : kind
+      ) as Exclude<AutoBePreliminaryKind, `previous${string}`>;
+      const previous: boolean = kind.startsWith("previous");
+      ApplicationFixer[accessor]({
+        $defs: func.parameters.$defs,
+        controller: props.preliminary as any,
+        previous,
+      });
+    }
 };
 
 const getUnionErasure = (props: {

--- a/test/src/features/schema/test_schema_preliminary_enum.ts
+++ b/test/src/features/schema/test_schema_preliminary_enum.ts
@@ -65,7 +65,7 @@ export const test_schema_preliminary_enum = async () => {
     ],
     state: agent.getContext().state(),
   });
-  preliminary.fixApplication(application);
+  preliminary.fixApplication(application, true);
 
   const state: AutoBeState = preliminary.getState();
   const $defs: Record<string, ILlmSchema> = application.functions.find(


### PR DESCRIPTION
This pull request introduces an enhancement to the preliminary application fixing logic, allowing the use of enum values for item lists when desired. The main change is the addition of an `enumerable` parameter, which enables or disables this behavior. The test suite is also updated to exercise this new functionality.

**Enhancements to application fixing logic:**

* Added an `enumerable` parameter to the `fixApplication` method in `AutoBePreliminaryController`, allowing callers to specify whether to use enum values for item lists. (`packages/agent/src/orchestrate/common/AutoBePreliminaryController.ts`, [packages/agent/src/orchestrate/common/AutoBePreliminaryController.tsR215-R225](diffhunk://#diff-2332057b907e7e101bdc21bafc8fb3c1a982c1e5abf28a95bce68fe5742b480bR215-R225))
* Updated the `fixPreliminaryApplication` function to accept and utilize the `enumerable` parameter, enabling conditional logic for applying enum-based fixes. (`packages/agent/src/orchestrate/common/internal/fixPrelminaryApplication.ts`, [[1]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4R35) [[2]](diffhunk://#diff-754cf4777de7d343032631fb99f67f7de72d5257db97adab2faa44dc4810b7e4L85-R102)

**Testing updates:**

* Modified the `test_schema_preliminary_enum` test to pass `true` for the new `enumerable` parameter, ensuring the new functionality is covered by tests. (`test/src/features/schema/test_schema_preliminary_enum.ts`, [test/src/features/schema/test_schema_preliminary_enum.tsL68-R68](diffhunk://#diff-637438afdce601bb3165148485af62f47986078f7a0220b07a4602df233072d0L68-R68))