### PR TITLE
feat(test): check `executeCachedBatch()`.

### DIFF
--- a/packages/agent/src/utils/executeCachedBatch.ts
+++ b/packages/agent/src/utils/executeCachedBatch.ts
@@ -29,7 +29,7 @@ import { AutoBeContext } from "../context/AutoBeContext";
  * @returns Array of task results in original order
  */
 export const executeCachedBatch = async <T>(
-  ctx: AutoBeContext,
+  ctx: AutoBeContext | number,
   taskList: Task<T>[],
   promptCacheKey?: string,
 ): Promise<T[]> => {
@@ -38,9 +38,11 @@ export const executeCachedBatch = async <T>(
   promptCacheKey ??= v7();
   const first: T = await taskList[0]!(promptCacheKey);
   const semaphore: number =
-    ctx.vendor.semaphore && ctx.vendor.semaphore instanceof Semaphore
-      ? ctx.vendor.semaphore.max()
-      : (ctx.vendor.semaphore ?? AutoBeConfigConstant.SEMAPHORE);
+    typeof ctx === "number"
+      ? ctx
+      : ctx.vendor.semaphore && ctx.vendor.semaphore instanceof Semaphore
+        ? ctx.vendor.semaphore.max()
+        : (ctx.vendor.semaphore ?? AutoBeConfigConstant.SEMAPHORE);
 
   const remained: Array<Pair<Task<T>, number>> = taskList
     .slice(1)

--- a/test/src/features/utils/test_execute_cached_batch.ts
+++ b/test/src/features/utils/test_execute_cached_batch.ts
@@ -1,0 +1,30 @@
+import { executeCachedBatch } from "@autobe/agent/src/utils/executeCachedBatch";
+import { TestValidator } from "@nestia/e2e";
+import { randint, sleep_for } from "tstl";
+
+export const test_execute_cached_batch = async (): Promise<void> => {
+  const key: Set<string> = new Set();
+  const input: number[] = new Array(10).fill(0).map((_, i) => i);
+  const output: number[] = await executeCachedBatch(
+    8,
+    input.map((v) => async (promptCacheKey) => {
+      await sleep_for(await randint(0, 100));
+      key.add(promptCacheKey);
+      return v;
+    }),
+  );
+  TestValidator.equals("promptCacheKey", 1, key.size);
+  TestValidator.equals("output", input, output);
+
+  try {
+    await executeCachedBatch(
+      8,
+      input.map((_v, i) => async () => {
+        if (i === 8) throw new Error("intended error");
+      }),
+    );
+  } catch {
+    return;
+  }
+  throw new Error("Failed to catch error.");
+};


### PR DESCRIPTION
This pull request updates the `executeCachedBatch` utility to allow passing either an `AutoBeContext` object or a number as the first argument, improving flexibility for batch execution. It also adds a new test to verify the updated behavior and error handling.

**Enhancements to `executeCachedBatch`:**

* Modified the signature of `executeCachedBatch` to accept either an `AutoBeContext` or a number as the first parameter, enabling direct control over the semaphore value.
* Updated semaphore calculation logic to handle both types of input, using the number directly when provided.

**Testing improvements:**

* Added `test_execute_cached_batch` to verify that the batch execution works correctly with a number as the semaphore value, ensures prompt cache key consistency, and checks error handling for failed tasks.