### PR TITLE
fix(interface): let design to database name as snake.

### DIFF
--- a/packages/interface/src/histories/contents/AutoBeDatabaseComponentTableCreate.ts
+++ b/packages/interface/src/histories/contents/AutoBeDatabaseComponentTableCreate.ts
@@ -1,3 +1,5 @@
+import { SnakeCasePattern } from "../../typings/SnakeCasePattern";
+
 /**
  * Request to create a new table in the component.
  *
@@ -32,7 +34,7 @@ export interface AutoBeDatabaseComponentTableCreate {
    *
    * Must follow snake_case naming convention with appropriate domain prefix.
    */
-  table: string;
+  table: string & SnakeCasePattern;
 
   /**
    * Description of what this table stores.

--- a/packages/interface/src/histories/contents/AutoBeDatabaseComponentTableErase.ts
+++ b/packages/interface/src/histories/contents/AutoBeDatabaseComponentTableErase.ts
@@ -1,3 +1,5 @@
+import { SnakeCasePattern } from "../../typings/SnakeCasePattern";
+
 /**
  * Request to erase a table from the component.
  *
@@ -32,5 +34,5 @@ export interface AutoBeDatabaseComponentTableErase {
    *
    * Must be from the current component's table list. Must match exactly.
    */
-  table: string;
+  table: string & SnakeCasePattern;
 }

--- a/packages/interface/src/histories/contents/AutoBeDatabaseComponentTableUpdate.ts
+++ b/packages/interface/src/histories/contents/AutoBeDatabaseComponentTableUpdate.ts
@@ -1,3 +1,5 @@
+import { SnakeCasePattern } from "../../typings/SnakeCasePattern";
+
 /**
  * Request to update (rename) an existing table in the component.
  *
@@ -31,14 +33,14 @@ export interface AutoBeDatabaseComponentTableUpdate {
    *
    * Must be from the current component's table list. Must match exactly.
    */
-  original: string;
+  original: string & SnakeCasePattern;
 
   /**
    * The updated table name.
    *
    * Must follow snake_case naming convention with appropriate domain prefix.
    */
-  updated: string;
+  updated: string & SnakeCasePattern;
 
   /**
    * Updated description of what this table stores.


### PR DESCRIPTION
This pull request strengthens type safety for table names in the database component history interfaces by introducing the `SnakeCasePattern` type. Now, all table name fields in create, erase, and update requests are explicitly required to conform to the snake_case naming convention.

**Type safety and naming convention enforcement:**

* Added imports of the `SnakeCasePattern` type to `AutoBeDatabaseComponentTableCreate.ts`, `AutoBeDatabaseComponentTableErase.ts`, and `AutoBeDatabaseComponentTableUpdate.ts` to enforce snake_case naming for table names. [[1]](diffhunk://#diff-97bfa6e35cd8a9d8a453645e5bcff839ac57533987e2472c0cea97933857ae95R1-R2) [[2]](diffhunk://#diff-cf2db58e6299a2dbaa0fa0df2e512283d64c950dccd9ccdda707297177ccbe2fR1-R2) [[3]](diffhunk://#diff-8511da3b9bfaefc25b386100bd070d61a3e4be52a94bc70c01fd4ec51dc0a1b3R1-R2)
* Updated the `table`, `original`, and `updated` fields in the respective interfaces to use `string & SnakeCasePattern`, ensuring compile-time validation of snake_case naming. [[1]](diffhunk://#diff-97bfa6e35cd8a9d8a453645e5bcff839ac57533987e2472c0cea97933857ae95L35-R37) [[2]](diffhunk://#diff-cf2db58e6299a2dbaa0fa0df2e512283d64c950dccd9ccdda707297177ccbe2fL35-R37) [[3]](diffhunk://#diff-8511da3b9bfaefc25b386100bd070d61a3e4be52a94bc70c01fd4ec51dc0a1b3L34-R43)