### PR TITLE
fix(agent): DTOs gone by `AutoBeJsonSchemaNamingConvention`.

### DIFF
--- a/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaNamingConvention.ts
+++ b/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaNamingConvention.ts
@@ -16,6 +16,7 @@ export namespace AutoBeJsonSchemaNamingConvention {
     }
     for (const [key, value] of Object.entries(document.components.schemas)) {
       convention.emplace(key, (newKey) => {
+        if (key === newKey) return;
         document.components.schemas[newKey] = value;
         delete document.components.schemas[key];
       });


### PR DESCRIPTION
This pull request makes a small update to the schema renaming logic in `AutoBeJsonSchemaNamingConvention.ts`. The change ensures that a schema is only renamed if the new name is different from the current name, preventing unnecessary operations.

* Added a conditional check to skip renaming when the schema name does not change in the `emplace` callback.