### PR TITLE
chore: add Realize Complete compile failure log

### DIFF
--- a/test/src/archive/utils/ArchiveLogger.ts
+++ b/test/src/archive/utils/ArchiveLogger.ts
@@ -162,6 +162,16 @@ export namespace ArchiveLogger {
           .map((line) => `    ${line}`)
           .join("\n"),
       );
+    else if (
+      event.type === "realizeComplete" &&
+      event.compiled.type === "failure"
+    )
+      content.push(
+        JSON.stringify(event.compiled.diagnostics, null, 2)
+          .split("\n")
+          .map((line) => `    ${line}`)
+          .join("\n"),
+      );
     // PRINT
     console.log(content.join("\n"));
   };


### PR DESCRIPTION
This pull request adds improved logging for failure events in the `ArchiveLogger` utility. Now, when a "realizeComplete" event with a failure occurs, the diagnostics for the failure are included in the log output for better visibility.

Logging improvements:

* [`ArchiveLogger`](diffhunk://#diff-793156a8a392baff96aabe24d037505466486d8a3ec32334cc77ae11d795efcfR165-R174): Added logic to log detailed diagnostics when a "realizeComplete" event fails, by serializing and formatting the diagnostics object for easier debugging.