### PR TITLE
fix(agent): assign p.schema to fixed Schema

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperation.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperation.ts
@@ -137,7 +137,7 @@ async function process(
         build: (op) => {
           pointer.value ??= [];
           for (const p of op.parameters)
-            AutoBeJsonSchemaFactory.fixSchema(p.schema);
+            p.schema = AutoBeJsonSchemaFactory.fixSchema(p.schema);
           const matrix: AutoBeOpenApi.IOperation[] =
             op.authorizationActors.length === 0
               ? [


### PR DESCRIPTION
This pull request makes a small change to the way schemas are handled in the `process` function. Specifically, it updates the code so that the fixed schema is assigned back to `p.schema`, ensuring that any modifications made by `AutoBeJsonSchemaFactory.fixSchema` are properly applied.

* Assigns the result of `AutoBeJsonSchemaFactory.fixSchema(p.schema)` back to `p.schema` in the `process` function to ensure schema corrections are retained.