### PR TITLE
feat(agent): enhance interface phase logics

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterface.ts
@@ -33,6 +33,7 @@ import { orchestrateInterfaceSchema } from "./orchestrateInterfaceSchema";
 import { orchestrateInterfaceSchemaRefine } from "./orchestrateInterfaceSchemaRefine";
 import { orchestrateInterfaceSchemaRename } from "./orchestrateInterfaceSchemaRename";
 import { orchestrateInterfaceSchemaReview } from "./orchestrateInterfaceSchemaReview";
+import { AutoBeInterfaceSchemaReviewProgrammer } from "./programmers/AutoBeInterfaceSchemaReviewProgrammer";
 import { AutoBeJsonSchemaFactory } from "./utils/AutoBeJsonSchemaFactory";
 import { AutoBeJsonSchemaNamingConvention } from "./utils/AutoBeJsonSchemaNamingConvention";
 import { AutoBeJsonSchemaValidator } from "./utils/AutoBeJsonSchemaValidator";
@@ -209,7 +210,14 @@ export const orchestrateInterface =
               operations: document.operations,
               typeName: k,
             }),
-        ).length * REVIEWERS.length,
+        ).length *
+          (REVIEWERS.length - 1) +
+        Object.keys(document.components.schemas).filter((key) =>
+          AutoBeInterfaceSchemaReviewProgrammer.filterSecurity({
+            document,
+            typeName: key,
+          }),
+        ).length,
     };
     for (const config of REVIEWERS)
       assign(

--- a/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaFactory.ts
+++ b/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaFactory.ts
@@ -299,6 +299,7 @@ export namespace AutoBeJsonSchemaFactory {
       ) {
         delete schema.minLength;
         delete schema.maxLength;
+        delete schema.contentMediaType;
       }
     }
     if (schema.contentMediaType === "") delete schema.contentMediaType;

--- a/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaValidator.ts
+++ b/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaValidator.ts
@@ -54,11 +54,6 @@ export namespace AutoBeJsonSchemaValidator {
     validateReferenceId(props);
     validatePropertyNames(props);
 
-    validateKey({
-      errors: props.errors,
-      path: `${props.path}[${JSON.stringify(props.typeName)}]`,
-      key: props.typeName,
-    });
     vo(props.typeName, props.schema);
     AutoBeOpenApiTypeChecker.skim({
       schema: props.schema,


### PR DESCRIPTION
This pull request refines the interface schema review logic and validation processes, with a particular focus on better handling of security-related schemas and improving validation accuracy. The main changes include introducing a specialized filter for security schemas, updating how review tasks are counted, and enhancing schema validation to leverage more contextual information.

**Security Schema Handling:**
* Added `filterSecurity` method to `AutoBeInterfaceSchemaReviewProgrammer` to identify security-related schemas (like those ending with `IAuthorized`, `IJoin`, or `ILogin`) for specialized processing.
* Updated reviewer task counting logic in `orchestrateInterface` to use the new security schema filter, ensuring that security schemas are reviewed appropriately and not double-counted.

**Validation Improvements:**
* Enhanced the `validate` method in `AutoBeInterfaceSchemaReviewProgrammer` to accept an `AutoBeContext` parameter and validate newly created or updated schemas with database context, improving error reporting and schema correctness. [[1]](diffhunk://#diff-7a8abb8d7cb52333943a73c6e61ea3e23e6ce5e32aa44d58e7ad84cf1835346bL40-R65) [[2]](diffhunk://#diff-7a8abb8d7cb52333943a73c6e61ea3e23e6ce5e32aa44d58e7ad84cf1835346bR83-R98) [[3]](diffhunk://#diff-063d33a56eb5e5c4043cb5f336f81a314c8c8a9ead5b4e423704c1d435753239L220-R230)
* Improved schema filtering in `orchestrateInterfaceSchemaReview` to ensure security schemas are only processed when appropriate, based on the reviewer configuration and the new filter logic.

**Miscellaneous Fixes:**
* Removed redundant property key validation in `AutoBeJsonSchemaValidator.validateSchema`, streamlining the validation flow.
* Ensured `contentMediaType` is properly deleted from schemas when not needed, preventing unnecessary metadata in generated schemas.