### PR TITLE
feat(agent): type name to be singular.

### DIFF
--- a/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaNamingConvention.ts
+++ b/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaNamingConvention.ts
@@ -51,8 +51,8 @@ class Convention {
       setter,
     });
 
-    const top: string = elements[0]!;
-    MapUtil.take(this.dict, top.toLowerCase(), () => new Set()).add(top);
+    const head: string = elements[0]!;
+    MapUtil.take(this.dict, head.toLowerCase(), () => new Set()).add(head);
   }
 
   public execute(): void {
@@ -66,8 +66,8 @@ class Convention {
       );
     for (const closure of this.closures) {
       const elements: string[] = closure.value.split(".");
-      const value: string = mapping.get(elements[0]!.toLowerCase())!;
-      closure.setter([value, ...elements.slice(1)].join("."));
+      const head: string = mapping.get(elements[0]!.toLowerCase())!;
+      closure.setter([head, ...elements.slice(1)].join("."));
     }
   }
 }


### PR DESCRIPTION
This pull request introduces a minor change to the schema normalization logic in the `AutoBeJsonSchemaNamingConvention` utility. The main update ensures that schema reference keys are always converted to their singular form, which helps maintain consistency in naming conventions.

- **Schema Reference Normalization:**
  - Updated the reference key extraction to use the `singular` function from the `pluralize` library, ensuring all schema reference names are singularized during normalization. [[1]](diffhunk://#diff-6e70bc07f0dc2c355814a2837d892b9c02c506a38d1816b1326244df2c748f5fR3) [[2]](diffhunk://#diff-6e70bc07f0dc2c355814a2837d892b9c02c506a38d1816b1326244df2c748f5fL28-R29)