### PR TITLE
feat(test): add interface schema casting/refining feature.

### DIFF
--- a/test/src/agent/internal/validate_interface_schema.ts
+++ b/test/src/agent/internal/validate_interface_schema.ts
@@ -1,6 +1,8 @@
 import { AutoBeAgent } from "@autobe/agent";
 import { AutoBeSystemPromptConstant } from "@autobe/agent/src/constants/AutoBeSystemPromptConstant";
 import { orchestrateInterfaceSchema } from "@autobe/agent/src/orchestrate/interface/orchestrateInterfaceSchema";
+import { orchestrateInterfaceSchemaCasting } from "@autobe/agent/src/orchestrate/interface/orchestrateInterfaceSchemaCasting";
+import { orchestrateInterfaceSchemaRefine } from "@autobe/agent/src/orchestrate/interface/orchestrateInterfaceSchemaRefine";
 import { orchestrateInterfaceSchemaReview } from "@autobe/agent/src/orchestrate/interface/orchestrateInterfaceSchemaReview";
 import { AutoBeExampleStorage } from "@autobe/benchmark";
 import {
@@ -24,25 +26,49 @@ export const validate_interface_schema = async (props: {
     })) ?? (await validate_interface_operation(props));
 
   // Initial schema generation
-  const schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
-    await orchestrateInterfaceSchema(props.agent.getContext(), {
-      operations,
-      instruction: "Design API specs carefully considering the security.",
-    });
-
-  // Build document for review
   const document: AutoBeOpenApi.IDocument = {
     operations,
     components: {
       authorizations: props.agent.getContext().state().analyze?.actors ?? [],
-      schemas,
+      schemas: await orchestrateInterfaceSchema(props.agent.getContext(), {
+        operations,
+        instruction: "Design API specs carefully considering the security.",
+      }),
     },
   };
+
+  // Casting schemas
+  Object.assign(
+    document.components.schemas,
+    await orchestrateInterfaceSchemaCasting(props.agent.getContext(), {
+      document,
+      schemas: document.components.schemas,
+      instruction: "",
+      progress: {
+        completed: 0,
+        total: 0,
+      },
+    }),
+  );
+
+  // Refine schemas
+  Object.assign(
+    document.components.schemas,
+    await orchestrateInterfaceSchemaRefine(props.agent.getContext(), {
+      instruction: "",
+      document,
+      schemas: document.components.schemas,
+      progress: {
+        completed: 0,
+        total: 0,
+      },
+    }),
+  );
 
   // Review schemas with all reviewers
   const reviewProgress: AutoBeProgressEventBase = {
     completed: 0,
-    total: Object.keys(schemas).length * REVIEWERS.length,
+    total: Object.keys(document.components.schemas).length * REVIEWERS.length,
   };
 
   for (const config of REVIEWERS) {


### PR DESCRIPTION
This pull request enhances the schema validation process in `validate_interface_schema` by introducing additional schema processing steps—casting and refinement—after the initial schema generation. These changes improve the robustness and accuracy of the API schema before it is reviewed.

Enhancements to schema validation workflow:

* Added imports for `orchestrateInterfaceSchemaCasting` and `orchestrateInterfaceSchemaRefine` to enable new schema processing steps.
* After generating initial schemas, the code now performs schema casting and refinement by invoking `orchestrateInterfaceSchemaCasting` and `orchestrateInterfaceSchemaRefine`, updating `document.components.schemas` with their results.

Improvements to review process:

* The schema review progress calculation now uses the final, processed schemas (after casting and refinement) to determine the total number of review tasks.