### PR TITLE
feat(agent): validation feedback message about string format.

### DIFF
--- a/packages/agent/src/orchestrate/interface/utils/fulfillJsonSchemaErrorMessages.ts
+++ b/packages/agent/src/orchestrate/interface/utils/fulfillJsonSchemaErrorMessages.ts
@@ -179,9 +179,10 @@ const fulfillJsonSchemaFormat = (e: IValidation.IError): boolean => {
   ) {
     e.expected = "undefined";
     e.description = StringUtil.trim`
-      **Invalid "format" Value: "${e.value}" is not supported.**
+      **Invalid "format" Value: ${JSON.stringify(e.value)} is not supported.**
 
-      The "format" property value "${e.value}" is not recognized by AutoBE.
+      The "format" property value ${JSON.stringify(e.value)} is not supported in the
+      JSOn schema specification (type: \`AutoBeOpenApi.IJsonSchema.IString.format\`).
 
       Supported values are:
       


### PR DESCRIPTION
This pull request enhances the JSON schema error handling utilities by adding support for more descriptive error messages when encountering unsupported "format" values in string schemas. It also adds a new utility function to detect and handle these specific cases.

**Improvements to error handling:**

* Added a new function, `fulfillJsonSchemaFormat`, which provides a clear and user-friendly error message when an unsupported `"format"` value is encountered in a JSON schema string property. The error message lists all supported formats and instructs the user to remove or correct the `"format"` property if it does not match exactly.
* Updated the main error fulfillment function, `fulfillJsonSchemaErrorMessages`, to include the new `fulfillJsonSchemaFormat` handler in its error resolution chain.

**Dependency update:**

* Imported the `AutoBeOpenApi` type from `@autobe/interface` to support the new format validation logic.