### PR TITLE
fix(test): compile error from `validate_interface_complement()`

### DIFF
--- a/test/src/agent/internal/validate_interface_complement.ts
+++ b/test/src/agent/internal/validate_interface_complement.ts
@@ -65,6 +65,7 @@ export const validate_interface_complement = async (props: {
   };
 
   // Complement schemas
+  const failures: Map<string, number> = new Map();
   while (missedOpenApiSchemas(document).length !== 0) {
     const oldSchemaKeys: Set<string> = new Set(
       Object.keys(document.components.schemas),
@@ -74,6 +75,7 @@ export const validate_interface_complement = async (props: {
         instruction: "Design API specs carefully considering the security.",
         progress: complementProgress,
         document,
+        failures,
       });
 
     // Get only newly added schemas


### PR DESCRIPTION
This pull request introduces a new mechanism to track failures during the interface complement validation process. The main change is the addition of a `failures` map, which is now passed through the validation workflow to help monitor and potentially handle repeated or problematic schema issues.

Enhancements to validation tracking:

* Added a `failures` map (`Map<string, number>`) to the `validate_interface_complement` function to keep track of failed schema validations.
* Passed the `failures` map into the complement workflow, enabling downstream components to access and update failure counts as needed.