### PR TITLE
fix(agent): exact type expression from prompt.

### DIFF
--- a/packages/agent/prompts/INTERFACE_SCHEMA.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA.md
@@ -1,6 +1,6 @@
 # OpenAPI Schema Agent System Prompt
 
-You are OpenAPI Schema Agent, an expert in creating comprehensive schema definitions for OpenAPI specifications in the `AutoBeOpenApi.IJsonSchemaDescriptive` format. Your specialized role focuses on the third phase of a multi-agent orchestration process for large-scale API design.
+You are OpenAPI Schema Agent, an expert in creating comprehensive schema definitions for OpenAPI specifications in the `AutoBeOpenApi.IJsonSchema` format. Your specialized role focuses on the third phase of a multi-agent orchestration process for large-scale API design.
 
 Your mission is to analyze the provided API operations, paths, methods, database schema files, and ERD diagrams to construct a single, complete, and consistent schema definition for a specific DTO type that accurately represents the entity and its relations in the system.
 
@@ -505,10 +505,10 @@ Your specific tasks for creating a single schema component:
 2. **Define Complete Schema Definition**: Create a detailed schema definition for the target type with all necessary properties, validations, and relationships
 3. **Maintain Type Naming Conventions**: Follow the established type naming patterns
 4. **Ensure Schema Completeness**: Verify that the target type's schema definition is complete according to its role (.ICreate, .IUpdate, .ISummary, etc.)
-5. **Document Thoroughly**: Provide comprehensive descriptions for the schema definition and all its properties
+5. **Document Thoroughly**: Provide comprehensive description for the schema type in `design.description`
 6. **Validate Consistency**: Ensure the schema definition aligns with relevant API operations
 7. **Use Named References Only**: ALL relations to other DTOs MUST use $ref references - never define schemas inline
-8. **CRITICAL - Return Single Schema**: Return ONLY the schema definition itself (AutoBeOpenApi.IJsonSchemaDescriptive), NOT a Record wrapper. The type name is already provided in the input context.
+8. **CRITICAL - Return Single Schema**: Return ONLY the schema definition itself (AutoBeOpenApi.IJsonSchema), NOT a Record wrapper. The type name is already provided in the input context.
 
 ---
 
@@ -5338,7 +5338,7 @@ interface IBbsArticle.IUpdate {
 
 **D. Schema Structure Verification**:
 
-- [ ] The schema is returned as a single IJsonSchemaDescriptive object
+- [ ] The schema is returned as a single IJsonSchema object
 - [ ] NO nested schema definitions inside the schema's properties
 - [ ] All referenced types use $ref to point to components.schemas
 
@@ -5362,7 +5362,7 @@ interface IBbsArticle.IUpdate {
 
 **⚠️ THIS IS NOT OPTIONAL - IT IS AN ABSOLUTE TYPE SYSTEM REQUIREMENT ⚠️**
 
-The `AutoBeOpenApi.IJsonSchemaDescriptive` type **REQUIRES** the `description` field. This is enforced by the TypeScript type system - schemas without descriptions will fail compilation.
+The `AutoBeInterfaceSchemaDesign` type **REQUIRES** the `description` field. This is enforced by the TypeScript type system - designs without descriptions will fail compilation.
 
 **MANDATORY DESCRIPTION LOCATION:**
 

--- a/packages/agent/prompts/INTERFACE_SCHEMA_CONTENT_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_CONTENT_REVIEW.md
@@ -728,20 +728,18 @@ If IProduct is missing `stock`, `featured`, `discount`, or `createdAt`, create `
 
 **⚠️ CRITICAL: Carefully Examine Existing Properties' Fields**
 
-The `specification` (from the design structure) and `description` fields in existing properties contain ALL conceptual information about the schema's design intent. Use them to understand the patterns, then compare against the actual database schema to find what's MISSING.
+The `specification` (from the design structure) contains ALL conceptual information about each property's intended implementation. Use it to understand the patterns, then compare against the actual database schema to find what's MISSING.
 
 - **`specification`** (in design structure): Implementation specification for Realize Agent (HOW to implement/compute)
   - Shows the data mapping patterns used in this schema
   - Reveals the naming conventions (e.g., `users.email` → `email`)
   - **For Content Review**: Follow the same patterns when adding missing fields
 
-- **`description`** (on each property): API documentation for consumers (WHAT/WHY)
-  - Explains the semantic meaning of each property
-  - **For Content Review**: Helps understand the DTO's purpose and what fields it should include
+- Focus on `specification` for content review.
 
 **How to Use These Fields for Content Review**:
 
-1. **Study existing properties' `specification`** - Understand the mapping patterns
+1. **Study existing `specification`** - Understand the mapping patterns
 2. **Compare against the database schema** - Which DB fields are NOT represented?
 3. **For each missing field** → Create a `create` revision following the same patterns
 4. **Write `specification`** for new fields using the same style as existing ones

--- a/packages/agent/prompts/INTERFACE_SCHEMA_RELATION_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_RELATION_REVIEW.md
@@ -676,16 +676,14 @@ You MUST validate that every object type schema has the correct `databaseSchema`
 
 **⚠️ CRITICAL: Carefully Examine Existing Properties to Understand Relation Intent**
 
-The `specification` (from the design structure) and `description` fields in existing properties contain ALL conceptual information about each property's intended relationship. Use them to understand the Schema Agent's relation design, then verify against the actual database schema.
+The `specification` (from the design structure) contains ALL conceptual information about each property's intended relationship. Use it to understand the Schema Agent's relation design, then verify against the actual database schema.
 
 - **`specification`** (in design structure): Implementation specification for Realize Agent (HOW to implement/compute)
   - Contains the intended join strategy (FK column, related table)
   - Describes whether it's a direct mapping or a relation transformation
   - **For Relation Review**: Verify the FK column and related table actually exist in DB
 
-- **`description`** (on each property): API documentation for consumers (WHAT/WHY)
-  - Explains the semantic relationship (ownership, association, composition)
-  - **For Relation Review**: Helps classify the relation type (composition vs association vs aggregation)
+- Focus on `specification` for relation review.
 
 **How to Use These Fields for Relation Review**:
 


### PR DESCRIPTION
This pull request updates the OpenAPI Schema Agent prompt documentation to clarify the schema type requirements and simplify the documentation guidance for property fields. The changes ensure consistency in type references and focus reviewers on the most relevant fields for content and relation reviews.

**Schema type and documentation requirements:**

* Updated all references from `AutoBeOpenApi.IJsonSchemaDescriptive` to `AutoBeOpenApi.IJsonSchema` in the agent's instructions and checklist, clarifying the required schema type for output. [[1]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L3-R3) [[2]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L508-R511) [[3]](diffhunk://#diff-398cb1bbf2db0b5354bc5fea8dc65d05ec09a3dfebba0d8de5f67f184d4a2958L5341-R5341)
* Clarified that the schema type description must be provided in `design.description`, and that only the type-level description is required, not per-property descriptions.
* Updated the explanation of the required `description` field to refer to `AutoBeInterfaceSchemaDesign` instead of the previous type, aligning with the new schema requirements.

**Content and relation review simplification:**

* Revised the content review instructions to focus exclusively on the `specification` field for understanding property intent, removing the requirement to review the `description` field for each property.
* Revised the relation review instructions to focus exclusively on the `specification` field for understanding relation intent, removing the emphasis on per-property `description` fields.