### PR TITLE
fix(compiler): refresh function does not require auth decorator.

### DIFF
--- a/packages/compiler/src/realize/writeRealizeControllers.ts
+++ b/packages/compiler/src/realize/writeRealizeControllers.ts
@@ -42,7 +42,8 @@ export const writeRealizeControllers = async (
         const authorization: AutoBeRealizeAuthorization | undefined =
           operate.authorizationActor !== null &&
           operate.authorizationType !== "join" &&
-          operate.authorizationType !== "login"
+          operate.authorizationType !== "login" &&
+          operate.authorizationType !== "refresh"
             ? props.authorizations.find(
                 (d) => d.actor.name === operate.authorizationActor,
               )


### PR DESCRIPTION
This pull request introduces a small update to the controller authorization logic, specifically in the `writeRealizeControllers.ts` file. The change adds an additional check for the `refresh` authorization type, ensuring that operations with this type are handled similarly to `join` and `login` types.

* Authorization logic: Updated the conditional to exclude operations with `authorizationType` set to `"refresh"`, alongside `"join"` and `"login"`, from receiving an `AutoBeRealizeAuthorization`.