### PR TITLE
feat(agent): DTO, make specification and schema equal.

### DIFF
--- a/packages/agent/prompts/INTERFACE_SCHEMA_CONTENT_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_CONTENT_REVIEW.md
@@ -711,12 +711,12 @@ If IProduct is missing `stock`, `featured`, `discount`, or `createdAt`, create `
 
 ```typescript
 {
-  type: "create",
   reason: "Database field 'stock' exists but was missing from IProduct",
   key: "stock",
   databaseSchemaProperty: "stock",
   specification: "Direct mapping from products.stock column. Integer value representing available inventory.",
   description: "Current inventory quantity. Automatically decremented when orders are placed.",
+  type: "create",
   schema: {
     type: "integer"
   },
@@ -785,12 +785,12 @@ This ordering enforces **grounded reasoning**:
 **Example - Correct Create Revision Structure**:
 ```typescript
 {
-  type: "create",
   reason: "Database field 'stock' exists but missing from IProduct",
   key: "stock",
   databaseSchemaProperty: "stock",
   specification: "Direct mapping from products.stock column. Integer value representing available inventory.",
   description: "Current inventory quantity. Automatically decremented when orders are placed.",
+  type: "create",
   schema: {
     type: "integer",
     minimum: 0
@@ -800,6 +800,8 @@ This ordering enforces **grounded reasoning**:
 ```
 
 This order is a prompt engineering technique that ensures reasoning consistency. Follow it without exception.
+
+**⚠️ Specification-Schema Consistency**: When writing a `create` revision, the `specification` and `schema` MUST be semantically consistent. If `specification` describes a list, `schema` must be `array`. If it describes a boolean flag, `schema` must be `boolean`. Never let the two contradict each other.
 
 **Revision Rules by DTO Type**:
 
@@ -814,12 +816,12 @@ This order is a prompt engineering technique that ensures reasoning consistency.
 **When DB non-null → DTO nullable/optional**: You MUST explain why in the `description`:
 ```typescript
 {
-  type: "create",
   reason: "Adding role field from database",
   key: "role",
   databaseSchemaProperty: "role",
   specification: "Direct mapping from users.role column. Uses @default value 'user' when not provided.",
   description: "User role. Optional - if not provided, defaults to 'user'.",
+  type: "create",
   schema: {
     type: "string"
   },
@@ -900,21 +902,21 @@ For Content Review, you primarily use `create` and `keep` revisions:
 ```typescript
 // Create revision - add missing property
 interface AutoBeInterfaceSchemaPropertyCreate {
-  type: "create";
   reason: string;  // Why this field is being added
   key: string;     // Property name to add
   databaseSchemaProperty: string | null;  // Database property name or null for computed
   specification: string;  // Implementation spec for Realize Agent
   description: string;  // API documentation for consumers
+  type: "create";
   schema: Exclude<AutoBeOpenApi.IJsonSchema, AutoBeOpenApi.IJsonSchema.IObject>;  // NO inline objects! Use $ref
   required: boolean;  // Add to required array?
 }
 
 // Keep revision - keep existing property unchanged
 interface AutoBeInterfaceSchemaPropertyKeep {
-  type: "keep";
   reason: string;  // Why this property is kept unchanged
   key: string;     // Property name to keep
+  type: "keep";
 }
 ```
 
@@ -940,48 +942,48 @@ process({
 - createdAt: Timestamp field exists but missing from schema`,
     revises: [
       {
-        type: "create",
         reason: "Database field 'stock' exists but missing from IProduct",
         key: "stock",
         databaseSchemaProperty: "stock",
         specification: "Direct mapping from products.stock column. Integer value representing available inventory.",
         description: "Current inventory quantity. Automatically decremented when orders are placed.",
+        type: "create",
         schema: {
           type: "integer"
         },
         required: true
       },
       {
-        type: "create",
         reason: "Database field 'featured' exists but missing from IProduct",
         key: "featured",
         databaseSchemaProperty: "featured",
         specification: "Direct mapping from products.featured column. Boolean flag for homepage display.",
         description: "Whether this product is featured on the homepage.",
+        type: "create",
         schema: {
           type: "boolean"
         },
         required: true
       },
       {
-        type: "create",
         reason: "Database field 'discount' (optional) exists but missing from IProduct",
         key: "discount",
         databaseSchemaProperty: "discount",
         specification: "Direct mapping from products.discount column. Nullable decimal value representing discount percentage.",
         description: "Discount percentage applied to the product price.",
+        type: "create",
         schema: {
           type: "number"
         },
         required: false
       },
       {
-        type: "create",
         reason: "Database field 'createdAt' exists but missing from IProduct",
         key: "createdAt",
         databaseSchemaProperty: "created_at",
         specification: "Direct mapping from products.created_at column. DateTime value converted to ISO 8601 string format.",
         description: "Timestamp when the product was created.",
+        type: "create",
         schema: {
           type: "string",
           format: "date-time"
@@ -1003,24 +1005,24 @@ process({
     review: "No missing fields found. All database fields are properly mapped to the schema.",
     revises: [
       {
-        type: "keep",
         reason: "Property correctly maps to database field with proper type",
-        key: "id"
+        key: "id",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Property correctly maps to database field with proper type",
-        key: "name"
+        key: "name",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Property correctly maps to database field with proper type",
-        key: "price"
+        key: "price",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Property correctly maps to database field with proper type",
-        key: "createdAt"
+        key: "createdAt",
+        type: "keep"
       }
     ]
   }

--- a/packages/agent/prompts/INTERFACE_SCHEMA_PHANTOM_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_PHANTOM_REVIEW.md
@@ -729,16 +729,16 @@ For Phantom Review, you use `erase`, `nullish`, and `keep` revisions:
 ```typescript
 // Erase revision - remove phantom field
 interface AutoBeInterfaceSchemaPropertyErase {
-  type: "erase";
   reason: string;  // Why this field is being removed
   key: string;     // Property name to remove
+  type: "erase";
 }
 
 // Nullish revision - correct nullable/required (DB nullable → DTO non-null only!)
 interface AutoBeInterfaceSchemaPropertyNullish {
-  type: "nullish";
   reason: string;            // Why nullability is being changed
   key: string;               // Property name
+  type: "nullish";
   specification: string | null; // null = keep existing, string = replace specification
   description: string | null;   // null = keep existing, string = replace description
   nullable: boolean;         // Should use oneOf with null?
@@ -747,9 +747,9 @@ interface AutoBeInterfaceSchemaPropertyNullish {
 
 // Keep revision - keep existing property unchanged
 interface AutoBeInterfaceSchemaPropertyKeep {
-  type: "keep";
   reason: string;  // Why this property is kept unchanged
   key: string;     // Property name to keep
+  type: "keep";
 }
 ```
 
@@ -787,28 +787,28 @@ process({
 
     revises: [
       {
-        type: "erase",
         reason: "Phantom field: 'updatedAt' does not exist in database model User",
-        key: "updatedAt"
+        key: "updatedAt",
+        type: "erase"
       },
       {
-        type: "erase",
         reason: "Phantom field: 'deletedAt' does not exist in database model User",
-        key: "deletedAt"
+        key: "deletedAt",
+        type: "erase"
       },
       {
-        type: "nullish",
         reason: "DB field 'bio' is nullable (String?) but DTO is non-null. Must allow null.",
         key: "bio",
+        type: "nullish",
         specification: null,  // Keep existing specification
         description: "User's biography. Can be null if not provided by the user.",  // Update description
         nullable: true,
         required: true
       },
       {
-        type: "nullish",
         reason: "DB field 'avatar_url' is nullable but DTO is non-null.",
         key: "avatarUrl",
+        type: "nullish",
         specification: null,  // Keep existing specification
         description: null,    // Keep existing description
         nullable: true,
@@ -829,24 +829,24 @@ process({
     review: "No phantom fields or nullish mismatches found. All schemas are consistent with their database models.",
     revises: [
       {
-        type: "keep",
         reason: "Field exists in database and nullish status is correct",
-        key: "id"
+        key: "id",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Field exists in database and nullish status is correct",
-        key: "email"
+        key: "email",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Field exists in database and nullish status is correct",
-        key: "name"
+        key: "name",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Field exists in database and nullish status is correct",
-        key: "createdAt"
+        key: "createdAt",
+        type: "keep"
       }
     ]
   }

--- a/packages/agent/prompts/INTERFACE_SCHEMA_REFINE.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_REFINE.md
@@ -352,7 +352,21 @@ This ordering enforces **grounded reasoning**:
 
 ## 4. Refinement Operations
 
-You have four operations available for property refinement:
+You have four operations available for property refinement.
+
+### 4.0. Core Principle: Specification-Schema Consistency
+
+`specification` is the natural-language description of HOW a property is implemented. `schema` is its technical JSON Schema type definition. **These two MUST be semantically consistent.**
+
+If `specification` says "list of attachments uploaded by the user", the `schema` MUST be an `array` type — not `string`, not `object`. If `specification` says "whether the user has verified their email", the `schema` MUST be `boolean` — not `string`, not `integer`.
+
+**This principle governs operation selection.** When you enrich a property, you write `databaseSchemaProperty` → `specification` → `description` first (the documentation fields), and THEN decide the operation type:
+
+- **specification aligns with existing schema** → use `depict` (documentation-only, no type change needed)
+- **specification reveals the existing schema is wrong** → use `update` (fix both documentation AND schema to be consistent)
+- **new property** → use `create` with specification and schema written together, ensuring they agree from the start
+
+This is the reasoning flow: understand the property deeply through documentation, THEN make the structural decision. Never decide the operation type before writing the specification — the specification is what reveals whether the current schema is correct.
 
 ### 4.1. `depict` - Add Documentation to Existing Property
 
@@ -360,16 +374,18 @@ Use when the property's JSON Schema type is already correct, but documentation f
 
 ```typescript
 {
-  type: "depict",
   reason: "Adding database mapping and documentation for email property",
   key: "email",
   databaseSchemaProperty: "email",
   specification: "Direct mapping from users.email column. String value with email format validation.",
-  description: "User's primary email address used for account login and notifications."
+  description: "User's primary email address used for account login and notifications.",
+  type: "depict"
 }
 ```
 
 **When to use**: Property exists with correct type, just needs documentation enrichment.
+
+**⚠️ Escalation rule**: If while writing the `specification` you realize the existing schema type does not match what the property actually represents, you MUST switch to `update` instead. `depict` cannot change the schema — so when specification-schema inconsistency is discovered, escalate to `update`.
 
 ### 4.2. `create` - Add Missing Property with Documentation
 
@@ -377,12 +393,12 @@ Use when a property that should exist is missing from the schema.
 
 ```typescript
 {
-  type: "create",
   reason: "Database field 'verified' exists but missing from schema",
   key: "verified",
   databaseSchemaProperty: "verified",
   specification: "Direct mapping from users.verified column. Boolean indicating email verification status.",
   description: "Whether the user has verified their email address.",
+  type: "create",
   schema: {
     type: "boolean"
   },
@@ -398,12 +414,13 @@ Use when a property exists but has incorrect type definition.
 
 ```typescript
 {
-  type: "update",
   reason: "Fixing incorrect type for price field - should be number not string",
   key: "price",
   databaseSchemaProperty: "price",
   specification: "Direct mapping from products.price column. Decimal value representing price in base currency.",
   description: "Product price in the store's base currency.",
+  type: "update",
+  newKey: null,
   schema: {
     type: "number"
   },
@@ -419,9 +436,9 @@ Use when a property should not exist in the schema.
 
 ```typescript
 {
-  type: "erase",
   reason: "Field 'internal_notes' is database-only and should not be exposed in API",
-  key: "internal_notes"
+  key: "internal_notes",
+  type: "erase"
 }
 ```
 
@@ -464,12 +481,12 @@ Properties come from **two sources**:
 **Example — Adding a Missing DB Field**:
 ```typescript
 {
-  type: "create",
   reason: "CONTENT: Database field 'verified' exists in users table but missing from IUser",
   key: "verified",
   databaseSchemaProperty: "verified",
   specification: "Direct mapping from users.verified column. Boolean indicating email verification status.",
   description: "Whether the user has verified their email address.",
+  type: "create",
   schema: {
     type: "boolean"
   },
@@ -480,12 +497,12 @@ Properties come from **two sources**:
 **Example — Adding a Missing Requirements-Driven Computed Field**:
 ```typescript
 {
-  type: "create",
   reason: "CONTENT: Requirements specify 'total order amount' for customer display, but ICustomer is missing this computed field",
   key: "totalOrderAmount",
   databaseSchemaProperty: null,
   specification: "Computed aggregation from requirements. SELECT COALESCE(SUM(amount), 0) FROM orders WHERE customer_id = customers.id AND status = 'completed'. Returns cumulative spending.",
   description: "Total amount of all completed orders placed by this customer.",
+  type: "create",
   schema: {
     type: "number"
   },
@@ -515,9 +532,9 @@ Properties come from **two sources**:
 **Example — Removing a Phantom Field**:
 ```typescript
 {
-  type: "erase",
   reason: "Phantom field - 'popularity_score' does not exist in products table and is not demanded by requirements",
-  key: "popularity_score"
+  key: "popularity_score",
+  type: "erase"
 }
 ```
 
@@ -546,12 +563,12 @@ Properties come from **two sources**:
 **Example — Adding a Missing Relation**:
 ```typescript
 {
-  type: "create",
   reason: "Database has author_id FK to users table, but IArticle is missing the related author object",
   key: "author",
   databaseSchemaProperty: null,
   specification: "Join from articles.author_id to users.id. Returns the author as IUser.ISummary.",
   description: "The user who authored this article.",
+  type: "create",
   schema: {
     $ref: "#/components/schemas/IUser.ISummary"
   },
@@ -562,12 +579,13 @@ Properties come from **two sources**:
 **Example — Fixing an Inline Object to $ref**:
 ```typescript
 {
-  type: "update",
   reason: "Author property uses inline object instead of $ref to IUser.ISummary",
   key: "author",
   databaseSchemaProperty: null,
   specification: "Join from articles.author_id to users.id. Returns the author as IUser.ISummary.",
   description: "The user who authored this article.",
+  type: "update",
+  newKey: null,
   schema: {
     $ref: "#/components/schemas/IUser.ISummary"
   },
@@ -628,19 +646,19 @@ Session context fields (`ip`, `href`, `referrer`) belong ONLY where sessions are
 ```typescript
 // Step 1: Erase the hashed field
 {
-  type: "erase",
   reason: "SECURITY: Clients must not send pre-hashed passwords. password_hashed in request DTO is a vulnerability.",
-  key: "password_hashed"
+  key: "password_hashed",
+  type: "erase"
 }
 
 // Step 2: Create the correct field
 {
-  type: "create",
   reason: "SECURITY: Login DTO requires plaintext password field for authentication",
   key: "password",
   databaseSchemaProperty: null,
   specification: "Plaintext password for authentication. Server hashes and compares against users.password_hashed column.",
   description: "User's password for authentication.",
+  type: "create",
   schema: {
     type: "string"
   },
@@ -651,9 +669,9 @@ Session context fields (`ip`, `href`, `referrer`) belong ONLY where sessions are
 **Example — Removing Session Field from IActor**:
 ```typescript
 {
-  type: "erase",
   reason: "SECURITY: 'ip' is a session context field, not an actor profile field. Actor is WHO, Session is HOW THEY CONNECTED.",
-  key: "ip"
+  key: "ip",
+  type: "erase"
 }
 ```
 
@@ -801,36 +819,36 @@ process({
     description: "Complete user entity with profile and account information.",
     refines: [
       {
-        type: "depict",
         reason: "Adding database mapping and documentation",
         key: "id",
         databaseSchemaProperty: "id",
         specification: "Direct mapping from users.id column. UUID primary key.",
-        description: "Unique identifier for the user."
+        description: "Unique identifier for the user.",
+        type: "depict"
       },
       {
-        type: "depict",
         reason: "Adding database mapping and documentation",
         key: "email",
         databaseSchemaProperty: "email",
         specification: "Direct mapping from users.email column. Unique constraint enforced at database level.",
-        description: "User's primary email address for login and notifications."
+        description: "User's primary email address for login and notifications.",
+        type: "depict"
       },
       {
-        type: "depict",
         reason: "Adding database mapping and documentation",
         key: "name",
         databaseSchemaProperty: "name",
         specification: "Direct mapping from users.name column. Non-nullable string.",
-        description: "User's display name shown in the application."
+        description: "User's display name shown in the application.",
+        type: "depict"
       },
       {
-        type: "depict",
         reason: "Adding database mapping and documentation for computed field",
         key: "postsCount",
         databaseSchemaProperty: null,
         specification: "Computed aggregation. SELECT COUNT(*) FROM posts WHERE author_id = users.id",
-        description: "Total number of posts created by this user."
+        description: "Total number of posts created by this user.",
+        type: "depict"
       }
     ]
   }
@@ -856,49 +874,50 @@ process({
     description: "Product entity containing item details, pricing, and inventory status.",
     refines: [
       {
-        type: "depict",
         reason: "Adding database mapping and documentation",
         key: "id",
         databaseSchemaProperty: "id",
         specification: "Direct mapping from products.id column. UUID primary key.",
-        description: "Unique product identifier."
+        description: "Unique product identifier.",
+        type: "depict"
       },
       {
-        type: "depict",
         reason: "Adding database mapping and documentation",
         key: "name",
         databaseSchemaProperty: "name",
         specification: "Direct mapping from products.name column.",
-        description: "Product display name."
+        description: "Product display name.",
+        type: "depict"
       },
       {
-        type: "update",
         reason: "Fixing type - discount should be number not string",
         key: "discount",
         databaseSchemaProperty: "discount",
         specification: "Direct mapping from products.discount column. Nullable decimal 0-100.",
         description: "Discount percentage applied to the product.",
+        type: "update",
+        newKey: null,
         schema: {
           oneOf: [{ type: "number" }, { type: "null" }]
         },
         required: true
       },
       {
-        type: "create",
         reason: "Missing database field 'featured'",
         key: "featured",
         databaseSchemaProperty: "featured",
         specification: "Direct mapping from products.featured column. Boolean for homepage display.",
         description: "Whether this product is featured on the homepage.",
+        type: "create",
         schema: {
           type: "boolean"
         },
         required: true
       },
       {
-        type: "erase",
         reason: "Phantom field - 'internal_status' does not exist in database and is not demanded by requirements",
-        key: "internal_status"
+        key: "internal_status",
+        type: "erase"
       }
     ]
   }
@@ -929,78 +948,78 @@ process({
     description: "Customer entity representing a registered member with profile and account information.",
     refines: [
       {
-        type: "depict",
         reason: "Adding database mapping and documentation",
         key: "id",
         databaseSchemaProperty: "id",
         specification: "Direct mapping from customers.id column. UUID primary key.",
-        description: "Unique identifier for the customer."
+        description: "Unique identifier for the customer.",
+        type: "depict"
       },
       {
-        type: "depict",
         reason: "Adding database mapping and documentation",
         key: "email",
         databaseSchemaProperty: "email",
         specification: "Direct mapping from customers.email column. Unique constraint.",
-        description: "Customer's email address for login and notifications."
+        description: "Customer's email address for login and notifications.",
+        type: "depict"
       },
       {
-        type: "depict",
         reason: "Adding database mapping and documentation",
         key: "name",
         databaseSchemaProperty: "name",
         specification: "Direct mapping from customers.name column.",
-        description: "Customer's display name."
+        description: "Customer's display name.",
+        type: "depict"
       },
       {
-        type: "create",
         reason: "CONTENT: Database field 'verified' exists in customers table but missing from ICustomer",
         key: "verified",
         databaseSchemaProperty: "verified",
         specification: "Direct mapping from customers.verified column. Boolean indicating email verification.",
         description: "Whether the customer has verified their email address.",
+        type: "create",
         schema: {
           type: "boolean"
         },
         required: true
       },
       {
-        type: "create",
         reason: "CONTENT: Requirements specify 'total order amount' for customer profile display, but missing from ICustomer",
         key: "totalOrderAmount",
         databaseSchemaProperty: null,
         specification: "Computed aggregation from requirements. SELECT COALESCE(SUM(amount), 0) FROM orders WHERE customer_id = customers.id AND status = 'completed'.",
         description: "Total amount of all completed orders placed by this customer.",
+        type: "create",
         schema: {
           type: "number"
         },
         required: true
       },
       {
-        type: "depict",
         reason: "PHANTOM-SAFE: No DB column, but valid requirements-driven aggregation — keeping with documentation",
         key: "orderCount",
         databaseSchemaProperty: null,
         specification: "Computed aggregation from requirements. SELECT COUNT(*) FROM orders WHERE customer_id = customers.id. Returns total number of orders.",
-        description: "Total number of orders placed by this customer."
+        description: "Total number of orders placed by this customer.",
+        type: "depict"
       },
       {
-        type: "erase",
         reason: "PHANTOM: 'loyalty_tier' does not exist in customers table and is not demanded by requirements",
-        key: "loyalty_tier"
+        key: "loyalty_tier",
+        type: "erase"
       },
       {
-        type: "erase",
         reason: "SECURITY: password_hashed must never be exposed in response DTOs",
-        key: "password_hashed"
+        key: "password_hashed",
+        type: "erase"
       },
       {
-        type: "create",
         reason: "RELATION: Database has customer_id FK in customer_sessions table, but ICustomer is missing the sessions relation",
         key: "sessions",
         databaseSchemaProperty: null,
         specification: "Join from customer_sessions.customer_id to customers.id. Returns all sessions as ICustomerSession array.",
         description: "Active sessions associated with this customer.",
+        type: "create",
         schema: {
           type: "array",
           items: {
@@ -1010,12 +1029,12 @@ process({
         required: true
       },
       {
-        type: "depict",
         reason: "Adding database mapping and documentation",
         key: "created_at",
         databaseSchemaProperty: "created_at",
         specification: "Direct mapping from customers.created_at column. DateTime as ISO 8601 string.",
-        description: "Timestamp when the customer account was created."
+        description: "Timestamp when the customer account was created.",
+        type: "depict"
       }
     ]
   }
@@ -1031,17 +1050,18 @@ Repeat these as you refine:
 **Enrichment**:
 1. **"Every property needs three documentation fields"** (databaseSchemaProperty, specification, description)
 2. **"WHICH → HOW → WHAT"** (Follow the mandatory field order)
-3. **"`depict` for existing correct types, `create`/`update` for fixes"**
-4. **"Never imagine fields — verify against database AND requirements"**
-5. **"Object-level enrichment comes with property enrichment"**
+3. **"specification describes it, schema defines it — they MUST agree"** (Specification-Schema Consistency)
+4. **"specification reveals schema is wrong? → switch from `depict` to `update`"** (Escalation)
+5. **"Never imagine fields — verify against database AND requirements"**
+6. **"Object-level enrichment comes with property enrichment"**
 
 **Pre-Review Hardening**:
-6. **"Every DB field and every requirements-driven computed field must be in the DTO — create if missing"** (Content)
-7. **"No DB column? No requirements-driven rationale? Erase it."** (Phantom)
-8. **"FK fields need a $ref relation in Read DTOs"** (Relation)
-9. **"password_hashed in request DTO = erase + create password"** (Security)
-10. **"ip/href/referrer in IActor or IAuthorized = erase immediately"** (Security)
-11. **"Actor is WHO, Session is HOW THEY CONNECTED"** (Security)
+7. **"Every DB field and every requirements-driven computed field must be in the DTO — create if missing"** (Content)
+8. **"No DB column? No requirements-driven rationale? Erase it."** (Phantom)
+9. **"FK fields need a $ref relation in Read DTOs"** (Relation)
+10. **"password_hashed in request DTO = erase + create password"** (Security)
+11. **"ip/href/referrer in IActor or IAuthorized = erase immediately"** (Security)
+12. **"Actor is WHO, Session is HOW THEY CONNECTED"** (Security)
 
 ---
 
@@ -1066,6 +1086,7 @@ Before submitting your refinement:
 - [ ] `specification` provides implementation guidance for code generation
 - [ ] `description` is clear API documentation for consumers
 - [ ] Computed fields have `null` for `databaseSchemaProperty` with detailed `specification`
+- [ ] `specification` and `schema` are semantically consistent (e.g., spec says "list" → schema is `array`; spec says "true/false" → schema is `boolean`)
 
 ### 9.4. Pre-Review Hardening
 - [ ] **Content**: All appropriate fields present in DTO — both database-mapped fields and requirements-driven computed/derived fields (missing ones added via `create`)

--- a/packages/agent/prompts/INTERFACE_SCHEMA_RELATION_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_RELATION_REVIEW.md
@@ -730,13 +730,13 @@ This ordering enforces **grounded reasoning**:
 **Example - Correct FK Transformation Update Revision**:
 ```typescript
 {
-  type: "update",
   reason: "Transform FK author_id to author with $ref to IBbsMember.ISummary",
   key: "author_id",
-  newKey: "author",
   databaseSchemaProperty: "bbs_member_id",
   specification: "Join via bbs_members table using bbs_articles.bbs_member_id. Returns ISummary variant with id, name, avatar only.",
   description: "Author who wrote this article. Contains essential member information for display.",
+  type: "update",
+  newKey: "author",
   schema: {
     $ref: "#/components/schemas/IBbsMember.ISummary"
   },
@@ -745,6 +745,8 @@ This ordering enforces **grounded reasoning**:
 ```
 
 This order is a prompt engineering technique that ensures reasoning consistency. Follow it without exception.
+
+**⚠️ Specification-Schema Consistency**: When writing an `update` revision, the `specification` and `schema` MUST be semantically consistent. If `specification` says "Join via FK to users table, returns ISummary", `schema` must be `{ $ref: "...ISummary" }` — not an inline object, not an array. If `specification` says "Composition relation, returns array of items", `schema` must be an `array` with `$ref` items. Never let the two contradict each other.
 
 ---
 
@@ -3854,29 +3856,29 @@ For Relation Review, you use `update`, `erase`, and `keep` revisions:
 ```typescript
 // Update revision - transform FK to $ref reference (with optional rename)
 interface AutoBeInterfaceSchemaPropertyUpdate {
-  type: "update";
   reason: string;     // Why this field is being transformed
   key: string;        // Current property key to update
-  newKey: string | null;  // New key after update (null = keep same key)
   databaseSchemaProperty: string | null;  // Database property name or null for computed
   specification: string;  // Implementation spec for Realize Agent
   description: string;  // API documentation for consumers
+  type: "update";
+  newKey: string | null;  // New key after update (null = keep same key)
   schema: Exclude<AutoBeOpenApi.IJsonSchema, AutoBeOpenApi.IJsonSchema.IObject>;  // NO inline objects! Use $ref
   required: boolean;  // Whether to include in required array
 }
 
 // Erase revision - remove incorrect reverse relation
 interface AutoBeInterfaceSchemaPropertyErase {
-  type: "erase";
   reason: string;  // Why this field is being removed
   key: string;     // Property name to remove
+  type: "erase";
 }
 
 // Keep revision - keep existing property unchanged
 interface AutoBeInterfaceSchemaPropertyKeep {
-  type: "keep";
   reason: string;  // Why this property is kept unchanged
   key: string;     // Property name to keep
+  type: "keep";
 }
 ```
 
@@ -3930,26 +3932,26 @@ process({
 
     revises: [
       {
-        type: "update",
         reason: "Transform FK author_id to author with $ref to IUser.ISummary",
         key: "author_id",      // Current FK field
-        newKey: "author",      // Rename to object field
         databaseSchemaProperty: "author", // belongs to relation
         specification: "Join via articles.author_id FK to users table. Returns ISummary variant with essential user fields.",
         description: "Author who created this article.",
+        type: "update",
+        newKey: "author",      // Rename to object field
         schema: {
           $ref: "#/components/schemas/IUser.ISummary"
         },
         required: true
       },
       {
-        type: "update",
         reason: "Transform FK category_id to category with $ref to ICategory.ISummary",
         key: "category_id",    // Current FK field
-        newKey: "category",    // Rename to object field
         databaseSchemaProperty: "category", // belongs to relation
         specification: "Join via articles.category_id FK to categories table. Returns ISummary variant with essential category fields.",
         description: "Category this article belongs to.",
+        type: "update",
+        newKey: "category",    // Rename to object field
         schema: {
           $ref: "#/components/schemas/ICategory.ISummary"
         },
@@ -3974,9 +3976,9 @@ process({
 
     revises: [
       {
-        type: "erase",
         reason: "Actor reversal: User should not contain articles array. Access via /users/:id/articles instead.",
-        key: "articles"
+        key: "articles",
+        type: "erase"
       }
     ]
   }
@@ -3997,13 +3999,13 @@ process({
 
     revises: [
       {
-        type: "update",
         reason: "Replace inline object with $ref to IOrderItem. INTERFACE_COMPLEMENT will create the type definition.",
         key: "items",
-        newKey: null,  // Keep same key
         databaseSchemaProperty: "order_items", // has relation
         specification: "Composition relation with order_items table. Items are created atomically with the order in the same transaction.",
         description: "Order line items. Each item represents a product in the order with quantity and pricing.",
+        type: "update",
+        newKey: null,  // Keep same key
         schema: {
           type: "array",
           items: {
@@ -4027,24 +4029,24 @@ process({
     review: "No relation or structure issues found. All relations are properly structured.",
     revises: [
       {
-        type: "keep",
         reason: "Relation is properly structured with correct $ref",
-        key: "author"
+        key: "author",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Business field - no relation concerns",
-        key: "title"
+        key: "title",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Business field - no relation concerns",
-        key: "content"
+        key: "content",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Relation array is properly scoped",
-        key: "comments"
+        key: "comments",
+        type: "keep"
       }
     ]
   }

--- a/packages/agent/prompts/INTERFACE_SCHEMA_SECURITY_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_SECURITY_REVIEW.md
@@ -935,28 +935,28 @@ For Security Review, you use `erase`, `create`, and `keep` revisions:
 ```typescript
 // Erase revision - remove security-violating field
 interface AutoBeInterfaceSchemaPropertyErase {
-  type: "erase";
   reason: string;  // Why this field is being removed (security violation type)
   key: string;     // Property name to remove
+  type: "erase";
 }
 
 // Create revision - add missing required field (e.g., password, session context)
 interface AutoBeInterfaceSchemaPropertyCreate {
-  type: "create";
   reason: string;   // Why this field is being added
   key: string;      // Property name to add
   databaseSchemaProperty: string | null;  // Database property name or null for virtual fields
   specification: string;  // Implementation spec for Realize Agent
   description: string;  // API documentation for consumers
+  type: "create";
   schema: Exclude<AutoBeOpenApi.IJsonSchema, AutoBeOpenApi.IJsonSchema.IObject>;  // NO inline objects! Use $ref
   required: boolean; // Whether the field is required
 }
 
 // Keep revision - keep existing property unchanged
 interface AutoBeInterfaceSchemaPropertyKeep {
-  type: "keep";
   reason: string;  // Why this property is kept unchanged
   key: string;     // Property name to keep
+  type: "keep";
 }
 ```
 
@@ -1025,12 +1025,12 @@ This ordering enforces **grounded reasoning**:
 **Example - Correct Create Revision Structure**:
 ```typescript
 {
-  type: "create",
   reason: "CRITICAL: Login DTO requires password field for authentication",
   key: "password",
   databaseSchemaProperty: null,  // Virtual field - not stored directly
   specification: "Plaintext password for authentication. Server compares hashed value against users.password_hashed column.",
   description: "User's password for authentication. Will be securely hashed before storage.",
+  type: "create",
   schema: {
     type: "string"
   },
@@ -1039,6 +1039,8 @@ This ordering enforces **grounded reasoning**:
 ```
 
 This order is a prompt engineering technique that ensures reasoning consistency. Follow it without exception.
+
+**⚠️ Specification-Schema Consistency**: When writing a `create` revision, the `specification` and `schema` MUST be semantically consistent. Never let the two contradict each other.
 
 ### 5.3. Output Examples
 
@@ -1059,36 +1061,36 @@ process({
 
     revises: [
       {
-        type: "erase",
         reason: "CRITICAL: Clients must not send pre-hashed passwords",
-        key: "password_hashed"
+        key: "password_hashed",
+        type: "erase"
       },
       {
-        type: "create",
         reason: "CRITICAL: Login DTO requires password field for authentication",
         key: "password",
         databaseSchemaProperty: "password_hashed",
         specification: "Plaintext password for authentication. Server compares hashed value against customers.password_hashed column.",
         description: "User's plaintext password for authentication. Will be verified against hashed password in database.",
+        type: "create",
         schema: {
           type: "string"
         },
         required: true
       },
       {
-        type: "keep",
         reason: "Required identifier field for login",
-        key: "email"
+        key: "email",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Session context field - connection metadata",
-        key: "href"
+        key: "href",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Session context field - connection metadata",
-        key: "referrer"
+        key: "referrer",
+        type: "keep"
       }
     ]
   }
@@ -1111,24 +1113,24 @@ process({
 
     revises: [
       {
-        type: "erase",
         reason: "CRITICAL: Password hash must never be exposed in responses",
-        key: "password_hashed"
+        key: "password_hashed",
+        type: "erase"
       },
       {
-        type: "erase",
         reason: "CRITICAL: Password salt must never be exposed in responses",
-        key: "salt"
+        key: "salt",
+        type: "erase"
       },
       {
-        type: "keep",
         reason: "Required actor identifier",
-        key: "id"
+        key: "id",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Required authentication token",
-        key: "token"
+        key: "token",
+        type: "keep"
       }
     ]
   }
@@ -1153,26 +1155,26 @@ process({
 
     revises: [
       {
-        type: "create",
         reason: "CRITICAL: Member registration DTO requires password field",
         key: "password",
         databaseSchemaProperty: "password_hashed",
         specification: "Plaintext password for new account. Server will hash and store in sellers.password_hashed column.",
         description: "Password for the new seller account. Will be hashed before storage.",
+        type: "create",
         schema: {
           type: "string"
         },
         required: true
       },
       {
-        type: "keep",
         reason: "Required identifier field",
-        key: "email"
+        key: "email",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Business field",
-        key: "name"
+        key: "name",
+        type: "keep"
       }
     ]
   }
@@ -1196,14 +1198,14 @@ process({
 
     revises: [
       {
-        type: "keep",
         reason: "Session context field - required",
-        key: "href"
+        key: "href",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Session context field - required",
-        key: "referrer"
+        key: "referrer",
+        type: "keep"
       }
     ]
   }
@@ -1227,38 +1229,38 @@ process({
 
     revises: [
       {
-        type: "create",
         reason: "Required session context field for session creation",
         key: "href",
         databaseSchemaProperty: "href",
         specification: "Connection URL provided by client. Server stores in sessions.href column for analytics.",
         description: "Connection URL (current page URL). For analytics and security tracking.",
+        type: "create",
         schema: {
           type: "string"
         },
         required: true
       },
       {
-        type: "create",
         reason: "Required session context field for session creation",
         key: "referrer",
         databaseSchemaProperty: null,
         specification: "Referrer URL provided by client. Server stores in sessions.referrer column for analytics.",
         description: "Referrer URL (previous page URL). For analytics and security tracking.",
+        type: "create",
         schema: {
           type: "string"
         },
         required: true
       },
       {
-        type: "keep",
         reason: "Required identifier field",
-        key: "email"
+        key: "email",
+        type: "keep"
       },
       {
-        type: "keep",
         reason: "Required for member authentication",
-        key: "password"
+        key: "password",
+        type: "keep"
       }
     ]
   }

--- a/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyCreate.ts
+++ b/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyCreate.ts
@@ -3,7 +3,8 @@ import { AutoBeOpenApi } from "../../openapi/AutoBeOpenApi";
 /**
  * Add a new property to a DTO schema.
  *
- * Use when a property is missing from the schema but should exist. Common cases:
+ * Use when a property is missing from the schema but should exist. Common
+ * cases:
  *
  * - **Missing database field**: A column exists in the database but wasn't
  *   included in the DTO
@@ -15,9 +16,6 @@ import { AutoBeOpenApi } from "../../openapi/AutoBeOpenApi";
  * @author Samchon
  */
 export interface AutoBeInterfaceSchemaPropertyCreate {
-  /** Discriminator for property revision type. */
-  type: "create";
-
   /** Reason for adding this property. */
   reason: string;
 
@@ -32,8 +30,8 @@ export interface AutoBeInterfaceSchemaPropertyCreate {
    * database schema properties.
    *
    * - Set to the exact property name (e.g., `"created_at"`, `"customer_id"` for
-   *   columns, `"orders"` for relations) when this property directly maps to
-   *   a database schema property
+   *   columns, `"orders"` for relations) when this property directly maps to a
+   *   database schema property
    * - Set to `null` for:
    *
    *   - Computed/derived properties (e.g., `totalOrders`, `averageRating`)
@@ -48,8 +46,8 @@ export interface AutoBeInterfaceSchemaPropertyCreate {
    * Implementation specification for downstream agents.
    *
    * Detailed guidance on HOW to implement data retrieval, transformation, or
-   * computation for this property. Internal documentation for Realize Agent
-   * and Test Agent - NOT exposed in public API documentation.
+   * computation for this property. Internal documentation for Realize Agent and
+   * Test Agent - NOT exposed in public API documentation.
    *
    * **When `databaseSchemaProperty` is set** (direct mapping):
    *
@@ -66,8 +64,8 @@ export interface AutoBeInterfaceSchemaPropertyCreate {
    * - Business rules and transformation logic
    * - Edge cases (nulls, empty sets, defaults)
    *
-   * Must be precise enough for downstream agents to implement the actual
-   * data retrieval or computation. Vague specifications are unacceptable.
+   * Must be precise enough for downstream agents to implement the actual data
+   * retrieval or computation. Vague specifications are unacceptable.
    */
   specification: string;
 
@@ -80,25 +78,35 @@ export interface AutoBeInterfaceSchemaPropertyCreate {
    *
    * Guidelines:
    *
-   * - Reference corresponding database schema property documentation for consistency
+   * - Reference corresponding database schema property documentation for
+   *   consistency
    * - Explain business meaning and constraints
    * - Keep accessible to API consumers (no implementation details)
    * - MUST be written in English
    */
   description: string;
 
+  /** Discriminator for property revision type. */
+  type: "create";
+
   /**
    * Schema definition for the new property.
+   *
+   * **MUST be semantically consistent with `specification`.** If `specification`
+   * describes a list, `schema` must be `array`. If it describes a boolean flag,
+   * `schema` must be `boolean`. A mismatch between the two is a violation.
    *
    * **IMPORTANT: Inline object types are NOT allowed.**
    *
    * For nested object structures, use `$ref` to reference a named schema:
    *
    * - ✅ `{ "$ref": "#/components/schemas/ICustomer.ISummary" }`
-   * - ✅ `{ "type": "array", "items": { "$ref": "#/components/schemas/IOrderItem" } }`
+   * - ✅ `{ "type": "array", "items": { "$ref": "#/components/schemas/IOrderItem"
+   *   } }`
    * - ❌ `{ "type": "object", "properties": { ... } }` - FORBIDDEN
    *
-   * Allowed types: string, number, integer, boolean, null, const, array, oneOf, $ref
+   * Allowed types: string, number, integer, boolean, null, const, array, oneOf,
+   * $ref
    */
   schema: Exclude<AutoBeOpenApi.IJsonSchema, AutoBeOpenApi.IJsonSchema.IObject>;
 

--- a/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyDepict.ts
+++ b/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyDepict.ts
@@ -1,6 +1,6 @@
 /**
- * Update documentation and metadata of an existing property without changing its
- * type structure.
+ * Update documentation and metadata of an existing property without changing
+ * its type structure.
  *
  * Use when the property's JSON Schema type is already correct, but the
  * documentation fields are missing, incomplete, or incorrect.
@@ -8,21 +8,25 @@
  * Common use cases:
  *
  * - Adding missing `databaseSchemaProperty` mapping for DB-backed properties
- * - Correcting wrong `databaseSchemaProperty` value (e.g., `"user_id"` → `"customer_id"`)
+ * - Correcting wrong `databaseSchemaProperty` value (e.g., `"user_id"` →
+ *   `"customer_id"`)
  * - Writing or revising `specification` instructions for downstream agents
  * - Improving or fixing inaccurate `description` for Swagger UI
  * - Documenting computed or aggregated properties (where `databaseSchemaProperty`
  *   is `null` and `specification` explains the computation logic)
  *
  * **Key difference from `update`**: This type ONLY modifies documentation
- * fields. Use `update` when you need to change the property's JSON Schema type.
+ * fields. Use `update` when you need to change the property's JSON Schema
+ * type.
+ *
+ * **Escalation rule**: If while writing the `specification` you discover
+ * the existing schema type is semantically inconsistent with the property's
+ * actual meaning, switch to `update` instead — `depict` cannot fix the
+ * schema.
  *
  * @author Samchon
  */
 export interface AutoBeInterfaceSchemaPropertyDepict {
-  /** Discriminator for property revision type. */
-  type: "depict";
-
   /**
    * Reason for updating the documentation.
    *
@@ -40,7 +44,8 @@ export interface AutoBeInterfaceSchemaPropertyDepict {
    * Use the exact property name from the Prisma schema (e.g., `"customer_id"`,
    * `"created_at"` for columns, `"orders"` for relations).
    *
-   * Set to `null` for properties that don't directly map to a database schema property:
+   * Set to `null` for properties that don't directly map to a database schema
+   * property:
    *
    * - Computed/aggregated values (e.g., `totalPrice`, `averageRating`)
    * - Derived fields from business logic
@@ -60,9 +65,10 @@ export interface AutoBeInterfaceSchemaPropertyDepict {
    * - Validation rules: Constraints beyond what JSON Schema expresses
    * - Edge cases: How to handle nulls, empty values, or special conditions
    *
-   * **CRITICAL when `databaseSchemaProperty` is `null`**: For computed/aggregated
-   * properties, this is the ONLY guidance downstream agents have. Be explicit
-   * about the computation formula, data sources, and expected behavior.
+   * **CRITICAL when `databaseSchemaProperty` is `null`**: For
+   * computed/aggregated properties, this is the ONLY guidance downstream agents
+   * have. Be explicit about the computation formula, data sources, and expected
+   * behavior.
    */
   specification: string;
 
@@ -79,4 +85,7 @@ export interface AutoBeInterfaceSchemaPropertyDepict {
    * Avoid implementation details - those belong in `specification`.
    */
   description: string;
+
+  /** Discriminator for property revision type. */
+  type: "depict";
 }

--- a/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyKeep.ts
+++ b/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyKeep.ts
@@ -18,9 +18,6 @@
  * @author Samchon
  */
 export interface AutoBeInterfaceSchemaPropertyKeep {
-  /** Discriminator for property revision type. */
-  type: "keep";
-
   /**
    * Reason for keeping this property unchanged.
    *
@@ -31,4 +28,7 @@ export interface AutoBeInterfaceSchemaPropertyKeep {
 
   /** Property key to keep. */
   key: string;
+
+  /** Discriminator for property revision type. */
+  type: "keep";
 }

--- a/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyNullish.ts
+++ b/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyNullish.ts
@@ -21,9 +21,6 @@
  * @author Samchon
  */
 export interface AutoBeInterfaceSchemaPropertyNullish {
-  /** Discriminator for property revision type. */
-  type: "nullish";
-
   /**
    * Reason for changing nullability (should explain DB nullable → DTO non-null
    * issue).
@@ -33,25 +30,8 @@ export interface AutoBeInterfaceSchemaPropertyNullish {
   /** Property key to modify. */
   key: string;
 
-  /**
-   * Optional: Updated implementation specification for downstream agents.
-   *
-   * When changing nullability, you may need to update the specification to
-   * document how null values should be handled during implementation.
-   *
-   * - If provided, replaces the existing specification
-   * - If `null`, the existing specification is preserved
-   */
-  specification: string | null;
-
-  /**
-   * Optional: Updated description for the property.
-   *
-   * When changing nullability, you may want to update the description to
-   * document the nullable behavior. If provided, replaces the existing
-   * description. If `null`, the existing description is preserved.
-   */
-  description: string | null;
+  /** Discriminator for property revision type. */
+  type: "nullish";
 
   /**
    * Whether property should accept null values.
@@ -72,4 +52,24 @@ export interface AutoBeInterfaceSchemaPropertyNullish {
    * - Update DTOs: Always `false` (partial update)
    */
   required: boolean;
+
+  /**
+   * Optional: Updated implementation specification for downstream agents.
+   *
+   * When changing nullability, you may need to update the specification to
+   * document how null values should be handled during implementation.
+   *
+   * - If provided, replaces the existing specification
+   * - If `null`, the existing specification is preserved
+   */
+  specification: string | null;
+
+  /**
+   * Optional: Updated description for the property.
+   *
+   * When changing nullability, you may want to update the description to
+   * document the nullable behavior. If provided, replaces the existing
+   * description. If `null`, the existing description is preserved.
+   */
+  description: string | null;
 }

--- a/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyUpdate.ts
+++ b/packages/interface/src/histories/contents/AutoBeInterfaceSchemaPropertyUpdate.ts
@@ -19,22 +19,11 @@ import { AutoBeOpenApi } from "../../openapi/AutoBeOpenApi";
  * @author Samchon
  */
 export interface AutoBeInterfaceSchemaPropertyUpdate {
-  /** Discriminator for property revision type. */
-  type: "update";
-
   /** Reason for replacing this property's schema. */
   reason: string;
 
   /** Current property key to update. */
   key: string;
-
-  /**
-   * New property key after update.
-   *
-   * - `null`: Keep the same key
-   * - `string`: Rename property (used for FK-to-object transformation)
-   */
-  newKey: string | null;
 
   /**
    * Database schema property name that this property maps to.
@@ -44,8 +33,8 @@ export interface AutoBeInterfaceSchemaPropertyUpdate {
    * database schema properties.
    *
    * - Set to the exact property name (e.g., `"created_at"`, `"customer_id"` for
-   *   columns, `"orders"` for relations) when this property directly maps to
-   *   a database schema property
+   *   columns, `"orders"` for relations) when this property directly maps to a
+   *   database schema property
    * - Set to `null` for:
    *
    *   - Computed/derived properties (e.g., `totalOrders`, `averageRating`)
@@ -60,8 +49,8 @@ export interface AutoBeInterfaceSchemaPropertyUpdate {
    * Implementation specification for downstream agents.
    *
    * Detailed guidance on HOW to implement data retrieval, transformation, or
-   * computation for this property. Internal documentation for Realize Agent
-   * and Test Agent - NOT exposed in public API documentation.
+   * computation for this property. Internal documentation for Realize Agent and
+   * Test Agent - NOT exposed in public API documentation.
    *
    * **When `databaseSchemaProperty` is set** (direct mapping):
    *
@@ -78,8 +67,8 @@ export interface AutoBeInterfaceSchemaPropertyUpdate {
    * - Business rules and transformation logic
    * - Edge cases (nulls, empty sets, defaults)
    *
-   * Must be precise enough for downstream agents to implement the actual
-   * data retrieval or computation. Vague specifications are unacceptable.
+   * Must be precise enough for downstream agents to implement the actual data
+   * retrieval or computation. Vague specifications are unacceptable.
    */
   specification: string;
 
@@ -92,25 +81,43 @@ export interface AutoBeInterfaceSchemaPropertyUpdate {
    *
    * Guidelines:
    *
-   * - Reference corresponding database schema property documentation for consistency
+   * - Reference corresponding database schema property documentation for
+   *   consistency
    * - Explain business meaning and constraints
    * - Keep accessible to API consumers (no implementation details)
    * - MUST be written in English
    */
   description: string;
 
+  /** Discriminator for property revision type. */
+  type: "update";
+
+  /**
+   * New property key after update.
+   *
+   * - `null`: Keep the same key
+   * - `string`: Rename property (used for FK-to-object transformation)
+   */
+  newKey: string | null;
+
   /**
    * New schema definition that replaces the existing one.
+   *
+   * **MUST be semantically consistent with `specification`.** If `specification`
+   * describes a list, `schema` must be `array`. If it describes a boolean flag,
+   * `schema` must be `boolean`. A mismatch between the two is a violation.
    *
    * **IMPORTANT: Inline object types are NOT allowed.**
    *
    * For nested object structures, use `$ref` to reference a named schema:
    *
    * - ✅ `{ "$ref": "#/components/schemas/ICustomer.ISummary" }`
-   * - ✅ `{ "type": "array", "items": { "$ref": "#/components/schemas/IOrderItem" } }`
+   * - ✅ `{ "type": "array", "items": { "$ref": "#/components/schemas/IOrderItem"
+   *   } }`
    * - ❌ `{ "type": "object", "properties": { ... } }` - FORBIDDEN
    *
-   * Allowed types: string, number, integer, boolean, null, const, array, oneOf, $ref
+   * Allowed types: string, number, integer, boolean, null, const, array, oneOf,
+   * $ref
    */
   schema: Exclude<AutoBeOpenApi.IJsonSchema, AutoBeOpenApi.IJsonSchema.IObject>;
 


### PR DESCRIPTION
This pull request updates the documentation for interface schema revision prompts to standardize the ordering of properties in example objects, clarify the relationship between specification and schema, and ensure consistency in revision operation examples. The changes primarily add or move the `type` property to the end of objects in code samples, introduce new guidance on specification-schema consistency, and clarify operation selection rules.

**Documentation consistency and best practices:**

* All example revision objects in `INTERFACE_SCHEMA_CONTENT_REVIEW.md`, `INTERFACE_SCHEMA_PHANTOM_REVIEW.md`, and `INTERFACE_SCHEMA_REFINE.md` now consistently place the `type` property at the end of the object, improving readability and standardization across documentation. [[1]](diffhunk://#diff-bda0326836fc5b17ba11e86c144b33d50601eaa917d36091130ecbf0c71ad4d6L714-R719) [[2]](diffhunk://#diff-bda0326836fc5b17ba11e86c144b33d50601eaa917d36091130ecbf0c71ad4d6L788-R793) [[3]](diffhunk://#diff-bda0326836fc5b17ba11e86c144b33d50601eaa917d36091130ecbf0c71ad4d6L817-R824) [[4]](diffhunk://#diff-bda0326836fc5b17ba11e86c144b33d50601eaa917d36091130ecbf0c71ad4d6L903-R919) [[5]](diffhunk://#diff-bda0326836fc5b17ba11e86c144b33d50601eaa917d36091130ecbf0c71ad4d6L943-R986) [[6]](diffhunk://#diff-bda0326836fc5b17ba11e86c144b33d50601eaa917d36091130ecbf0c71ad4d6L1006-R1025) [[7]](diffhunk://#diff-7a5696a2833fa32d6eacd55fd53975a0439e82af686b30afae8b2051586c0688L732-R741) [[8]](diffhunk://#diff-7a5696a2833fa32d6eacd55fd53975a0439e82af686b30afae8b2051586c0688L750-R752) [[9]](diffhunk://#diff-7a5696a2833fa32d6eacd55fd53975a0439e82af686b30afae8b2051586c0688L790-R811) [[10]](diffhunk://#diff-7a5696a2833fa32d6eacd55fd53975a0439e82af686b30afae8b2051586c0688L832-R849) [[11]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L401-R423) [[12]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L422-R441) [[13]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L467-R489) [[14]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L483-R505) [[15]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L518-R537) [[16]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L549-R571) [[17]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L565-R588) [[18]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L631-R661) [[19]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L654-R674)

**Specification-schema consistency and reasoning rules:**

* Added explicit guidance that the `specification` and `schema` fields in revision objects must be semantically consistent, with clear warnings and examples for mismatches (e.g., if the specification describes a list, the schema must be an array). [[1]](diffhunk://#diff-bda0326836fc5b17ba11e86c144b33d50601eaa917d36091130ecbf0c71ad4d6R804-R805) [[2]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L355-R401)
* Introduced a new section in `INTERFACE_SCHEMA_REFINE.md` detailing the reasoning flow for selecting revision operations, emphasizing that documentation fields should be written first and operation type chosen based on their consistency.
* Clarified the escalation rule: if you discover a mismatch between specification and schema while documenting, you must escalate from a documentation-only operation (`depict`) to a schema-changing operation (`update`).

**Minor improvements:**

* Added missing fields (e.g., `newKey: null`) to some example objects for completeness and clarity. [[1]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L401-R423) [[2]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L565-R588)

These changes improve the clarity, consistency, and correctness of the schema revision documentation, making it easier for both humans and automated agents to follow best practices.