### PR TITLE
fix(agent): json parse error prompt.

### DIFF
--- a/packages/agent/src/AutoBeAgent.ts
+++ b/packages/agent/src/AutoBeAgent.ts
@@ -174,8 +174,11 @@ export class AutoBeAgent extends AutoBeAgentBase implements IAutoBeAgent {
           common: (config) => getCommonPrompt(config),
           execute: () => transformFacadeStateMessage(this.state_),
           validate: (events) => getValidationErrorPrompt(events),
-          jsonParseError: () =>
-            AutoBeSystemPromptConstant.AGENTICA_JSON_PARSE_ERROR,
+          jsonParseError: (event) =>
+            AutoBeSystemPromptConstant.AGENTICA_JSON_PARSE_ERROR.replace(
+              "${{ERROR_MESSAGE}}",
+              event.errorMessage,
+            ),
         },
         retry: props.config?.retry ?? AutoBeConfigConstant.RETRY,
         // stream: false,

--- a/packages/agent/src/factory/consentFunctionCall.ts
+++ b/packages/agent/src/factory/consentFunctionCall.ts
@@ -74,8 +74,11 @@ export const consentFunctionCall = async (props: {
         common: () => getCommonPrompt(props.config),
         execute: () => AutoBeSystemPromptConstant.AGENTICA_EXECUTE,
         validate: (events) => getValidationErrorPrompt(events),
-        jsonParseError: () =>
-          AutoBeSystemPromptConstant.AGENTICA_JSON_PARSE_ERROR,
+        jsonParseError: (event) =>
+          AutoBeSystemPromptConstant.AGENTICA_JSON_PARSE_ERROR.replace(
+            "${{ERROR_MESSAGE}}",
+            event.errorMessage,
+          ),
       },
       retry: props.config?.retry ?? AutoBeConfigConstant.RETRY,
       // stream: false,

--- a/packages/agent/src/factory/createAutoBeContext.ts
+++ b/packages/agent/src/factory/createAutoBeContext.ts
@@ -154,8 +154,11 @@ export const createAutoBeContext = (props: {
               common: () => getCommonPrompt(props.config),
               execute: () => AutoBeSystemPromptConstant.AGENTICA_EXECUTE,
               validate: (events) => getValidationErrorPrompt(events),
-              jsonParseError: () =>
-                AutoBeSystemPromptConstant.AGENTICA_JSON_PARSE_ERROR,
+              jsonParseError: (event) =>
+                AutoBeSystemPromptConstant.AGENTICA_JSON_PARSE_ERROR.replace(
+                  "${{ERROR_MESSAGE}}",
+                  event.errorMessage,
+                ),
             },
             retry: props.config?.retry ?? AutoBeConfigConstant.RETRY,
             // stream: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   agentica:
     '@agentica/core':
-      specifier: ^0.41.1
-      version: 0.41.1
+      specifier: ^0.41.2
+      version: 0.41.2
   libs:
     openai:
       specifier: ^6.15.0
@@ -767,7 +767,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.41.1(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))
+        version: 0.41.2(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))
       '@autobe/interface':
         specifier: workspace:^
         version: link:../interface
@@ -1102,7 +1102,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.41.1(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))
+        version: 0.41.2(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))
       '@autobe/agent':
         specifier: workspace:^
         version: link:../packages/agent
@@ -1255,8 +1255,8 @@ importers:
 
 packages:
 
-  '@agentica/core@0.41.1':
-    resolution: {integrity: sha512-/+5QUmSpl1f9kCchztRFxlfw2ZMk4f4ljxpb9jDRsoVsWEhRgu7LH753KB+S4SaaF/OU39rGirFPJt2GTq9bbw==}
+  '@agentica/core@0.41.2':
+    resolution: {integrity: sha512-F+XXdUn+d1f/NQkzHEzsYBRnkhAi/3+SAHXEIjbaaxLKgb0s/ScM05cKKjrKbZTnp1vmFiGOweQmb6lawCFDRQ==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.12.0
       '@samchon/openapi': ^6.0.1
@@ -8382,7 +8382,7 @@ packages:
 
 snapshots:
 
-  '@agentica/core@0.41.1(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))':
+  '@agentica/core@0.41.2(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))':
     dependencies:
       '@samchon/openapi': 6.0.1
       es-jsonkit: 0.1.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ packages:
   - website
 catalogs:
   agentica:
-    '@agentica/core': ^0.41.1
+    '@agentica/core': ^0.41.2
   samchon:
     '@nestia/benchmark': ^10.0.2
     '@nestia/core': ^10.0.2


### PR DESCRIPTION
This pull request updates error handling and dependency versions in the agent package. The main improvement is that JSON parse error prompts now include specific error messages, making debugging easier. Additionally, the `@agentica/core` dependency is updated to version 0.41.2 across the workspace.

**Error handling improvements:**
- Updated all usages of `jsonParseError` in `AutoBeAgent`, `consentFunctionCall`, and `createAutoBeContext` to include the actual error message in the prompt, replacing the placeholder `${{ERROR_MESSAGE}}` with the value from the event. [[1]](diffhunk://#diff-eb5845bde058399222e7eb37fcc40ccd00bee27a5d2531830decea25dc197e73L177-R181) [[2]](diffhunk://#diff-8a095d8180de26c2aaf67615d051e9588ae2be98458ebb284da5e93bcefed018L77-R81) [[3]](diffhunk://#diff-2e9aa7131e94861eba6cd14756925e70dbf8ab549bbc098686a5ece7ab964c8eL157-R161)

**Dependency updates:**
- Bumped `@agentica/core` from version 0.41.1 to 0.41.2 in `pnpm-lock.yaml` and `pnpm-workspace.yaml` to ensure the latest features and fixes are included. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R11) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL770-R770) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1105-R1105) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1258-R1259) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8385-R8385) [[6]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL12-R12)