### PR TITLE
fix(agent): test prompts are guiding wrong reference.

### DIFF
--- a/packages/agent/prompts/COMMON_CORRECT_CASTING.md
+++ b/packages/agent/prompts/COMMON_CORRECT_CASTING.md
@@ -91,7 +91,21 @@ const value = date?.toISOString() ?? null;  // Preserves null
 const value = (date ?? new Date()).toISOString();  // Provides default
 ```
 
-### 3.3. Nullable/Undefined Type Assignment
+### 3.3. Missing `tags.` Prefix on Typia Tag Types
+
+**Error:** `Property 'X' does not exist on type 'typeof import("node_modules/typia/lib/tags/index")'.`
+
+**Solution:** Add `tags.` prefix to all Typia tag types (`Format`, `MaxLength`, `Minimum`, etc.)
+
+```typescript
+// ❌ WRONG
+const url: string & Format<"uri"> = getValue();
+
+// ✅ CORRECT
+const url: string & tags.Format<"uri"> = getValue();
+```
+
+### 3.4. Nullable/Undefined Type Assignment
 
 **Core Rule:** Check ALL union members explicitly.
 
@@ -117,7 +131,7 @@ if (value !== null && value !== undefined) {
 const memberId: string | undefined = post?.community_platform_member_id ?? undefined;
 ```
 
-### 3.4. typia.assert vs typia.assertGuard
+### 3.5. typia.assert vs typia.assertGuard
 
 **Critical Distinction:**
 
@@ -148,7 +162,7 @@ if (item) {
 }
 ```
 
-### 3.5. String to Literal Type Assignment
+### 3.6. String to Literal Type Assignment
 
 **Error:** `Type 'string' is not assignable to type '"admin" | "user"'`
 
@@ -160,7 +174,7 @@ const role: "admin" | "user" = getValue(); // ERROR
 const role = typia.assert<"admin" | "user">(getValue());
 ```
 
-### 3.6. Literal Type to Literal Type (Different Values)
+### 3.7. Literal Type to Literal Type (Different Values)
 
 **Error:** `Type '"laptop"' is not assignable to type '"laptops"'`
 
@@ -173,7 +187,7 @@ const categoryMap: Record<"laptop" | "smartphone", "laptops" | "smartphones"> = 
 const plural = categoryMap[singular];
 ```
 
-### 3.7. Optional Chaining with Array Methods
+### 3.8. Optional Chaining with Array Methods
 
 **Problem:** `article.tags?.includes("blog")` returns `boolean | undefined`
 
@@ -185,7 +199,7 @@ TestValidator.predicate("has tag", article.tags?.includes("blog") === true);
 TestValidator.predicate("has tag", article.tags?.includes("blog") ?? false);
 ```
 
-### 3.8. Object Index Access Returns undefined
+### 3.9. Object Index Access Returns undefined
 
 **Problem:** `MAPPING[key]` returns `T | undefined` when key doesn't exist
 
@@ -201,7 +215,7 @@ const mimeType = input?.ext
 
 **Rule:** `OBJECT[dynamicKey]` always needs `?? fallback` immediately after.
 
-### 3.9. Type Narrowing "No Overlap" Errors
+### 3.10. Type Narrowing "No Overlap" Errors
 
 **Error:** `Types 'X' and 'Y' have no overlap`
 
@@ -223,7 +237,7 @@ if (value === false) {
 }
 ```
 
-### 3.10. Escape Sequences in Function Calling
+### 3.11. Escape Sequences in Function Calling
 
 When code goes through JSON, escape characters get consumed:
 
@@ -235,7 +249,7 @@ When code goes through JSON, escape characters get consumed:
 { draft: `const x = "Hello.\\nWorld";` }
 ```
 
-### 3.11. Severe Syntax Structure Errors
+### 3.12. Severe Syntax Structure Errors
 
 **Pattern:** Variable declarations nested inside object literals
 

--- a/packages/agent/prompts/TEST_OPERATION_CORRECT_OVERALL.md
+++ b/packages/agent/prompts/TEST_OPERATION_CORRECT_OVERALL.md
@@ -170,16 +170,80 @@ const x = typia.random();
 const x = typia.random<string & tags.Format<"uuid">>();
 ```
 
-### 4.8. Type System Errors
+### 4.8. Typia Tag Type Incompatibility
 
-**See COMMON_CORRECT_CASTING.md** for detailed patterns:
-- Typia tag incompatibility → `satisfies BaseType as BaseType`
-- Date to string → `.toISOString()`
-- typia.assert vs assertGuard distinction
-- Nullable/undefined handling
-- Object index access fallback
+**Error:** `Types of property '"typia.tag"' are incompatible`
 
-### 4.9. Variable Declaration - const Only
+```typescript
+// ❌ ERROR
+const page: number & tags.Type<"int32"> = getValue();
+const y: number & tags.Type<"int32"> & tags.Minimum<0> = page;
+
+// ✅ CORRECT: satisfies pattern
+const y = page satisfies number as number;
+```
+
+### 4.9. Missing `tags.` Prefix
+
+**Error:** `Property 'X' does not exist on type 'typeof import("node_modules/typia/lib/tags/index")'.`
+
+```typescript
+// ❌ WRONG
+const url: string & Format<"uri"> = getValue();
+
+// ✅ CORRECT
+const url: string & tags.Format<"uri"> = getValue();
+```
+
+### 4.10. Date to String Conversion
+
+```typescript
+// ❌ ERROR
+const timestamp: string & tags.Format<"date-time"> = new Date();
+
+// ✅ CORRECT
+const timestamp: string & tags.Format<"date-time"> = new Date().toISOString();
+```
+
+### 4.11. typia.assert vs typia.assertGuard
+
+| Function | Returns | Use Case |
+|----------|---------|----------|
+| `typia.assert(value!)` | Validated value | Assignment |
+| `typia.assertGuard(value!)` | void | Type narrowing |
+
+```typescript
+// ✅ assert WITH assignment
+const safeItem = typia.assert(item!);
+
+// ✅ assertGuard for narrowing
+typia.assertGuard(item!);
+console.log(item.name); // item is now narrowed
+```
+
+### 4.12. Nullable/Undefined Handling
+
+```typescript
+// ❌ WRONG: partial check
+if (value !== null) { processString(value); } // could be undefined
+
+// ✅ CORRECT: exhaustive check
+if (value !== null && value !== undefined) { processString(value); }
+```
+
+### 4.13. Object Index Access Fallback
+
+```typescript
+// ❌ WRONG
+const mimeType = input?.ext ? MIMETYPE_MAP[input.ext] : "application/octet-stream";
+
+// ✅ CORRECT: inner ?? catches undefined
+const mimeType = input?.ext
+  ? (MIMETYPE_MAP[input.ext] ?? "application/octet-stream")
+  : "application/octet-stream";
+```
+
+### 4.14. Variable Declaration - const Only
 
 ```typescript
 // ❌ WRONG: let violates immutability


### PR DESCRIPTION
This pull request updates the documentation in `COMMON_CORRECT_CASTING.md` and `TEST_OPERATION_CORRECT_OVERALL.md` to clarify and expand on correct usage patterns with Typia tag types, type narrowing, and assignment. The changes reorganize and add new sections to address common errors and best practices, making the guidance more comprehensive and easier to follow.

Typia tag type usage and compatibility:

* Added explicit instructions to always use the `tags.` prefix for Typia tag types (e.g., `tags.Format`, `tags.MaxLength`) to prevent type errors, with examples and error messages. [[1]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L94-R108) [[2]](diffhunk://#diff-c3987f1dcd0624904caa03d6741aee1d4fd4d64bc82bbe34466793bed1bdd6a1L173-R246)
* Introduced new guidance on Typia tag type incompatibility, showing how to use the `satisfies` pattern for assignment, and expanded examples for tag type handling.

Type conversion and assignment patterns:

* Added new sections covering correct date-to-string conversion for Typia tag types, including examples of `.toISOString()` usage.
* Clarified the distinction between `typia.assert` and `typia.assertGuard` with a comparison table and assignment/narrowing examples. [[1]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L120-R134) [[2]](diffhunk://#diff-c3987f1dcd0624904caa03d6741aee1d4fd4d64bc82bbe34466793bed1bdd6a1L173-R246)
* Improved guidance for exhaustive nullable/undefined checks and object index access fallback patterns, with updated examples and explanations. [[1]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L204-R218) [[2]](diffhunk://#diff-c3987f1dcd0624904caa03d6741aee1d4fd4d64bc82bbe34466793bed1bdd6a1L173-R246)

Section renumbering and organization:

* Renumbered and reorganized section headers for clarity and consistency, ensuring each topic is grouped logically and easy to reference. [[1]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L94-R108) [[2]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L120-R134) [[3]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L151-R165) [[4]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L163-R177) [[5]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L176-R190) [[6]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L188-R202) [[7]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L204-R218) [[8]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L226-R240) [[9]](diffhunk://#diff-c21c474999d654ca643faf3ace44253a8c29e33f4e810ead44a268f05ecb6e32L238-R252)