### PR TITLE
fix(agent): realize agent to use `satisfies` keyword.

### DIFF
--- a/packages/agent/prompts/REALIZE_OPERATION_WRITE.md
+++ b/packages/agent/prompts/REALIZE_OPERATION_WRITE.md
@@ -235,6 +235,36 @@ shopping_customer_id: props.customer.id // FORBIDDEN!
 | Optional field (null → undefined) | `record.field === null ? undefined : record.field` |
 | Nullable field (keep null) | `record.field ? toISOStringSafe(record.field) : null` |
 | Branded type | `record.id as string & tags.Format<"uuid">` |
+| Nested object | `{ id: record.author.id, ... } satisfies IAuthor.ISummary` |
+
+**Nested object `satisfies` rule**: When manually constructing a return object, EVERY nested object literal that maps to a known DTO type MUST have `satisfies IDtoType` appended. This catches field mismatches at compile time.
+
+```typescript
+// ✅ CORRECT - satisfies on every nested object
+return {
+  id: record.id,
+  title: record.title,
+  author: {
+    id: record.author.id,
+    name: record.author.name,
+    created_at: record.author.created_at.toISOString(),
+  } satisfies IAuthor.ISummary,
+  category: {
+    id: record.category.id,
+    name: record.category.name,
+  } satisfies ICategory.ISummary,
+  created_at: record.created_at.toISOString(),
+};
+
+// ❌ WRONG - nested object without satisfies
+return {
+  id: record.id,
+  author: {
+    id: record.author.id,
+    name: record.author.name,
+  },  // Missing satisfies — type error points to the entire return, not this object
+};
+```
 
 ### 7.5. Manual CREATE Example
 
@@ -249,7 +279,7 @@ export async function postShoppingSaleReview(props: {
   });
   if (!sale) throw new HttpException("Sale not found", 404);
 
-  const created = await MyGlobal.prisma.shopping_sale_reviews.create({
+  const review = await MyGlobal.prisma.shopping_sale_reviews.create({
     data: {
       id: v4(),
       content: props.body.content,
@@ -257,19 +287,21 @@ export async function postShoppingSaleReview(props: {
       sale: { connect: { id: props.saleId } },
       customer: { connect: { id: props.customer.id } },
       session: { connect: { id: props.customer.session_id } },
-      created_at: toISOStringSafe(new Date()),
-      updated_at: toISOStringSafe(new Date()),
+      created_at: new Date(),
+      updated_at: new Date(),
+      deleted_at: null,
     },
   });
 
   return {
-    id: created.id,
+    id: review.id,
     content: created.content,
-    rating: created.rating,
-    sale_id: created.shopping_sale_id,
-    customer_id: created.shopping_customer_id,
-    created_at: toISOStringSafe(created.created_at),
-    updated_at: toISOStringSafe(created.updated_at),
+    rating: review.rating,
+    sale_id: review.shopping_sale_id,
+    customer_id: review.shopping_customer_id,
+    created_at: review.created_at.toISOString(),
+    updated_at: review.updated_at.toISOString(),
+    deleted_at: review.deleted_at?.toISOString() ?? null,
   };
 }
 ```

--- a/packages/agent/prompts/REALIZE_TRANSFORMER_WRITE.md
+++ b/packages/agent/prompts/REALIZE_TRANSFORMER_WRITE.md
@@ -257,6 +257,28 @@ totalQuantity: input.orders.reduce((sum, o) => sum + o.quantity, 0),
 | Non-transformable DTOs | Not DB-backed (pagination, computed) |
 | Simple scalar mapping | No complex logic |
 
+**When writing inline nested objects, ALWAYS append `satisfies IDtoType`**:
+
+```typescript
+// ✅ CORRECT - inline with satisfies
+export async function transform(input: Payload): Promise<IArticle> {
+  return {
+    id: input.id,
+    author: {
+      id: input.author.id,
+      name: input.author.name,
+    } satisfies IAuthor.ISummary,
+    created_at: input.created_at.toISOString(),
+  };
+}
+
+// ❌ WRONG - inline without satisfies
+author: {
+  id: input.author.id,
+  name: input.author.name,
+},  // Type error points to the entire return, not this object
+```
+
 ## 10. Final Checklist
 
 ### Database Schema

--- a/test/src/TestGlobal.ts
+++ b/test/src/TestGlobal.ts
@@ -49,7 +49,7 @@ export class TestGlobal {
 
   public static archive: boolean = process.argv.includes("--archive");
   public static vendorModel: string =
-    this.getArguments("vendor")?.[0] ?? "qwen/qwen3-next-80b-a3b-instruct";
+    this.getArguments("vendor")?.[0] ?? "qwen/qwen3-coder-next";
 }
 
 interface IEnvironments {

--- a/test/src/archive/local.ts
+++ b/test/src/archive/local.ts
@@ -35,7 +35,10 @@ const archive = async (props: {
   });
   await FileSystemIterator.save({
     root: `${TestGlobal.ROOT}/results/${props.vendor}/${props.project}/${props.phase}`,
-    files,
+    files: {
+      ...files,
+      "pnpm-workspace.yaml": "",
+    },
   });
 };
 


### PR DESCRIPTION
This pull request introduces several improvements to TypeScript DTO safety, updates to test configurations, and a minor change to test archiving. The most significant change is the enforcement of the `satisfies IDtoType` rule for nested objects, which helps catch type mismatches at compile time. Additionally, there are updates to review creation and return object patterns, as well as adjustments to test infrastructure defaults.

**TypeScript DTO Safety and Documentation:**

* Enforced the rule that every nested object literal mapping to a known DTO type must use `satisfies IDtoType`, with detailed documentation and code examples in both `REALIZE_OPERATION_WRITE.md` and `REALIZE_TRANSFORMER_WRITE.md` to catch field mismatches at compile time. [[1]](diffhunk://#diff-4ff9e347c1f974a1fbb5ec9256c790aab7a5760d7097f5f2ed1d1c6f871111f4R238-R267) [[2]](diffhunk://#diff-59aa0d51afcebc0246fd1a2c7d49907f7dadf610293c0790345a0bc19b8535dfR260-R281)

**Review Creation and Return Object Updates:**

* Updated the review creation logic to use a `review` variable instead of `created`, store `created_at`/`updated_at` as `Date` objects in the database, and return these as ISO strings, including the new `deleted_at` field.

**Test Infrastructure and Archiving:**

* Changed the default model in `TestGlobal.vendorModel` from `"qwen/qwen3-next-80b-a3b-instruct"` to `"qwen/qwen3-coder-next"`.
* Modified the local archive script to always include an empty `pnpm-workspace.yaml` file in archived results.