### PR TITLE
fix(agent): realize agent has to know `MyGlobal`.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ test/results/
 apps/hackathon-server/src/prisma/
 packages/compiler/src/raw/
 packages/agent/src/constants/AutoBeSystemPromptConstant.ts
+packages/agent/src/constants/AutoBeTemplateFileConstant.ts

--- a/packages/agent/.gitignore
+++ b/packages/agent/.gitignore
@@ -2,3 +2,4 @@ prompts/aggregate/ALL.md
 prompts/aggregate/ALL.pdf
 prompts/previous/
 src/constants/AutoBeSystemPromptConstant.ts
+src/constants/AutoBeTemplateFileConstant.ts

--- a/packages/agent/build/prompt.ts
+++ b/packages/agent/build/prompt.ts
@@ -3,67 +3,39 @@ import { StringUtil } from "@autobe/utils";
 import fs from "fs";
 import path from "path";
 
-const DIRECTORY = path.resolve(__dirname, "../prompts");
-
-// const prepareExample = async (
-//   title: string,
-// ): Promise<Record<string, string>> => {
-//   await RepositoryFileSystem.clone("samchon", `${title}-backend`);
-//   const directory: string = path.resolve(
-//     `${__dirname}/../../../internals/repositories/samchon/${title}-backend`,
-//   );
-//   const analysis: Record<string, string> = await FileSystemIterator.read({
-//     root: path.resolve(`${directory}`),
-//     extension: "md",
-//   });
-//   const prisma = await new AutoBeDatabaseCompiler().compile({
-//     files: await FileSystemIterator.read({
-//       root: path.resolve(`${directory}/prisma/schema`),
-//       extension: "prisma",
-//     }),
-//   });
-//   if (prisma.type !== "success") {
-//     console.log(prisma);
-//     throw new Error("Failed to compile prisma");
-//   }
-
-//   const swagger: OpenApi.IDocument = await RepositoryFileSystem.swagger(
-//     "samchon",
-//     `${title}-backend`,
-//   );
-//   const document: AutoBeOpenApi.IDocument = invertOpenApiDocument(swagger);
-
-//   return {
-//     [`EXAMPLE_${title.toUpperCase()}_ANALYSIS`]: JSON.stringify(analysis),
-//     [`EXAMPLE_${title.toUpperCase()}_PRISMA`]: JSON.stringify({
-//       schemas: prisma.schemas,
-//       diagrams: prisma.diagrams,
-//       document: prisma.document,
-//     }),
-//     [`EXAMPLE_${title.toUpperCase()}_DATABASE_SCHEMAS`]: JSON.stringify(
-//       prisma.schemas,
-//     ),
-//     [`EXAMPLE_${title.toUpperCase()}_INTERFACE_ENDPOINTS`]: JSON.stringify({
-//       endpoints: document.operations.map((o) => ({
-//         path: o.path,
-//         method: o.method,
-//       })),
-//     }),
-//     [`EXAMPLE_${title.toUpperCase()}_INTERFACE_OPERATIONS`]: JSON.stringify({
-//       operations: document.operations,
-//     }),
-//   };
-// };
-
-async function main(): Promise<void> {
-  const directory: string[] = await fs.promises.readdir(DIRECTORY);
+async function buildTemplate(): Promise<void> {
   const record: Record<string, string> = {};
-  const examples: Record<string, string> = {
-    // ...(await prepareExample("bbs")),
-    // ...(await prepareExample("shopping")),
+  const read = async (location: string): Promise<void> => {
+    const content: string = await fs.promises.readFile(
+      path.resolve(__dirname, "../../../internals/template", location),
+      "utf8",
+    );
+    record[location] = content.trim();
   };
+  await read("realize-of-postgres/src/MyGlobal.ts");
+  await FileSystemIterator.save({
+    files: {
+      "AutoBeTemplateFileConstant.ts": [
+        `/* eslint-disable no-template-curly-in-string */`,
+        `export const enum AutoBeTemplateFileConstant {`,
+        ...Object.entries(record).map(
+          ([key, value]) =>
+            `  ${JSON.stringify(key)} = ${JSON.stringify(value)},`,
+        ),
+        "}",
+      ].join("\n"),
+    },
+    root: path.resolve(__dirname, "../src/constants"),
+    overwrite: true,
+  });
+}
 
-  for (const file of directory) {
+async function buildPrompts(): Promise<void> {
+  const DIRECTORY = path.resolve(__dirname, "../prompts");
+
+  const fileList: string[] = await fs.promises.readdir(DIRECTORY);
+  const record: Record<string, string> = {};
+  for (const file of fileList) {
     if (file.endsWith(".md") === false) {
       continue;
     }
@@ -72,8 +44,6 @@ async function main(): Promise<void> {
       "utf8",
     );
     content = content.replaceAll("\r\n", "\n").trim();
-    for (const [key, value] of Object.entries(examples))
-      content = content.replace(`{% ${key} %}`, value);
     record[file.substring(0, file.length - 3)] = content;
   }
   await FileSystemIterator.save({
@@ -91,15 +61,17 @@ async function main(): Promise<void> {
                 ${value}
               `)},`,
         ),
-        // ...Object.entries(examples).map(
-        //   ([key, value]) =>
-        //     `  ${key.toUpperCase()} = ${JSON.stringify(value)},`,
-        // ),
-        `};`,
+        "};",
         "",
       ].join("\n"),
     },
     overwrite: true,
   });
 }
+
+const main = async (): Promise<void> => {
+  await buildPrompts();
+  await buildTemplate();
+};
+
 main().catch(console.error);

--- a/packages/agent/prompts/REALIZE_OPERATION_WRITE_ARTIFACT.md
+++ b/packages/agent/prompts/REALIZE_OPERATION_WRITE_ARTIFACT.md
@@ -3,7 +3,7 @@
 The following shows the expected props structure for this function:
 
 ```typescript
-{input}
+{{TEMPLATE}}
 ```
 
 **IMPORTANT**: The provider function you will implement must:
@@ -48,5 +48,18 @@ import { Something } from '../api/structures/Something';
 * **ALWAYS verify if fields are optional (`?`) or nullable (`| null`) in the DTO!**
 
 ```json
-{artifacts_dto}
+{{DTO}}
+```
+
+---
+
+# MyGlobal
+
+`MyGlobal` is a static utility class available in every provider file without importing. It provides two accessors:
+
+- `MyGlobal.prisma` — The singleton `PrismaClient` instance for all database operations.
+- `MyGlobal.env` — Typed environment variables (e.g., `MyGlobal.env.JWT_SECRET_KEY` for JWT signing).
+
+```typescript
+{{MyGlobal}}
 ```

--- a/packages/agent/src/orchestrate/realize/histories/transformRealizeOperationWriteHistory.ts
+++ b/packages/agent/src/orchestrate/realize/histories/transformRealizeOperationWriteHistory.ts
@@ -4,6 +4,7 @@ import { StringUtil } from "@autobe/utils";
 import { v7 } from "uuid";
 
 import { AutoBeSystemPromptConstant } from "../../../constants/AutoBeSystemPromptConstant";
+import { AutoBeTemplateFileConstant } from "../../../constants/AutoBeTemplateFileConstant";
 import { AutoBeState } from "../../../context/AutoBeState";
 import { IAutoBeOrchestrateHistory } from "../../../structures/IAutoBeOrchestrateHistory";
 import { AutoBePreliminaryController } from "../../common/AutoBePreliminaryController";
@@ -50,9 +51,14 @@ export const transformRealizeOperationWriteHistory = (props: {
         created_at: new Date().toISOString(),
         type: "systemMessage",
         text: AutoBeSystemPromptConstant.REALIZE_OPERATION_WRITE_ARTIFACT.replaceAll(
-          `{input}`,
+          `{{TEMPLATE}}`,
           getRealizeWriteInputType(operation, props.authorization),
-        ).replaceAll(`{artifacts_dto}`, JSON.stringify(props.dto)),
+        )
+          .replaceAll(`{{DTO}}`, JSON.stringify(props.dto))
+          .replaceAll(
+            "{{MyGlobal}}",
+            AutoBeTemplateFileConstant["realize-of-postgres/src/MyGlobal.ts"],
+          ),
       },
       {
         id: v7(),


### PR DESCRIPTION
This pull request introduces a new system for managing and injecting code templates into prompts, specifically by adding a mechanism to read template files and expose their contents as constants. It also updates prompt files and system message generation to use this new mechanism, improving maintainability and flexibility when working with code examples and documentation in prompts.

**Template Management and Injection:**

- Added a build step (`buildTemplate`) in `prompt.ts` that reads template files (e.g., `MyGlobal.ts`) from the `internals/template` directory and generates a new constant enum `AutoBeTemplateFileConstant` in `src/constants` for easy access to template contents throughout the codebase. [[1]](diffhunk://#diff-511bb0761de609b0b1a1fb0947b11d5b6e9b0ecae1ed9b9a5ee56bb2d19db0aeL6-R38) [[2]](diffhunk://#diff-511bb0761de609b0b1a1fb0947b11d5b6e9b0ecae1ed9b9a5ee56bb2d19db0aeL94-R76)
- Updated `.prettierignore` and `.gitignore` to include the new `AutoBeTemplateFileConstant.ts` file, ensuring proper formatting and version control handling. [[1]](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R9) [[2]](diffhunk://#diff-85961e58f498856071ae306b8ffa1a1e86eb6a57b524560b1b357e262d36c56dR5)

**Prompt and System Message Updates:**

- Modified the prompt file `REALIZE_OPERATION_WRITE_ARTIFACT.md` to use new template placeholders (`{{TEMPLATE}}`, `{{DTO}}`, `{{MyGlobal}}`) instead of hardcoded or inline code, and added documentation for the `MyGlobal` utility class. [[1]](diffhunk://#diff-e9aa442c7eef6c22ce65b567ccf4a05980e8b62a6acf5baad4f9cdec7b965497L6-R6) [[2]](diffhunk://#diff-e9aa442c7eef6c22ce65b567ccf4a05980e8b62a6acf5baad4f9cdec7b965497L51-R64)
- Updated the `transformRealizeOperationWriteHistory` function to replace the new placeholders with actual template content from `AutoBeTemplateFileConstant`, ensuring that up-to-date code snippets and documentation are injected into system messages. [[1]](diffhunk://#diff-dba89b3276f9cf6927b4b3affd60cad1a7b6398f81266111784d7e46ffe7e2f5R7) [[2]](diffhunk://#diff-dba89b3276f9cf6927b4b3affd60cad1a7b6398f81266111784d7e46ffe7e2f5L53-R61)

**Refactoring and Cleanup:**

- Refactored the prompt-building logic in `prompt.ts` to separate the building of prompts and templates, and removed unused or commented-out code related to example preparation. [[1]](diffhunk://#diff-511bb0761de609b0b1a1fb0947b11d5b6e9b0ecae1ed9b9a5ee56bb2d19db0aeL6-R38) [[2]](diffhunk://#diff-511bb0761de609b0b1a1fb0947b11d5b6e9b0ecae1ed9b9a5ee56bb2d19db0aeL75-L76) [[3]](diffhunk://#diff-511bb0761de609b0b1a1fb0947b11d5b6e9b0ecae1ed9b9a5ee56bb2d19db0aeL94-R76)