### PR TITLE
fix(agent): guide DB schema's properties by descriptions.

### DIFF
--- a/packages/utils/src/prisma/writePrismaApplication.ts
+++ b/packages/utils/src/prisma/writePrismaApplication.ts
@@ -198,28 +198,52 @@ function writeRelations(props: {
         props.model.plainIndexes.every((p) => p.fieldNames[0] !== f.name)
       );
     });
-  const contents: string[][] = [
-    props.model.foreignFields.map((foreign) =>
-      writeConstraint({
-        dbms: props.dbms,
-        model: props.model,
-        foreign,
-      }),
+
+  const print = (title: string, content: string[]): string[] => {
+    if (content.length === 0) return [];
+    return [
+      // title
+      "//----",
+      ...title.split("\n").map((l) => `// ${l}`),
+      "//----",
+      // main content
+      ...content,
+    ];
+  };
+  return ArrayUtil.paddle([
+    print(
+      StringUtil.trim`
+        BELONED RELATIONS,
+          - format: (propertyKey targetModel constraint)
+      `,
+      props.model.foreignFields.map((foreign) =>
+        writeConstraint({
+          dbms: props.dbms,
+          model: props.model,
+          foreign,
+        }),
+      ),
     ),
-    hasRelationships.map((r) =>
-      [
-        r.oppositeName ?? r.mappingName ?? r.modelName, // for legacy histories
-        `${r.modelName}${r.unique ? "?" : "[]"}`,
-        ...(r.mappingName ? [`@relation("${r.mappingName}")`] : []),
-      ].join(" "),
+    print(
+      StringUtil.trim`
+        HAS RELATIONS
+          - format: (propertyKey targetModel)
+      `,
+      hasRelationships.map((r) =>
+        [
+          r.oppositeName ?? r.mappingName ?? r.modelName, // for legacy histories
+          `${r.modelName}${r.unique ? "?" : "[]"}`,
+          ...(r.mappingName ? [`@relation("${r.mappingName}")`] : []),
+        ].join(" "),
+      ),
     ),
-    foreignIndexes.map((field) =>
-      writeForeignIndex({
-        model: props.model,
-        field,
-      }),
-    ),
-    [
+    print("INDEXES", [
+      ...foreignIndexes.map((field) =>
+        writeForeignIndex({
+          model: props.model,
+          field,
+        }),
+      ),
       ...props.model.uniqueIndexes.map((unique) =>
         writeUniqueIndex({
           model: props.model,
@@ -240,16 +264,8 @@ function writeRelations(props: {
             }),
           )
         : []),
-    ],
-  ];
-  if (contents.every((c) => c.length === 0)) return [];
-  return [
-    "//----",
-    "// RELATIONS",
-    "//----",
-    // paddled content
-    ...ArrayUtil.paddle(contents),
-  ];
+    ]),
+  ]);
 }
 
 function writeConstraint(props: {

--- a/test/src/experimental/prisma.ts
+++ b/test/src/experimental/prisma.ts
@@ -1,0 +1,25 @@
+import { AutoBeExampleStorage } from "@autobe/benchmark";
+import { FileSystemIterator } from "@autobe/filesystem";
+import { writePrismaApplication } from "@autobe/utils";
+
+import { TestGlobal } from "../TestGlobal";
+
+const main = async (): Promise<void> => {
+  const histories = await AutoBeExampleStorage.getHistories({
+    vendor: "qwen/qwen3-coder-next",
+    project: "bbs",
+    phase: "database",
+  });
+  const database = histories.find((h) => h.type === "database");
+  if (database === undefined) throw new Error("Database history not found");
+
+  const files: Record<string, string> = writePrismaApplication({
+    dbms: "postgres",
+    application: database.result.data,
+  });
+  await FileSystemIterator.save({
+    root: `${TestGlobal.ROOT}/results/prisma`,
+    files,
+  });
+};
+main().catch(console.error);


### PR DESCRIPTION
This pull request refactors the `writeRelations` function in `writePrismaApplication.ts` to improve the formatting and organization of generated relation and index comments, and adds a new experimental test file for generating and saving Prisma application files. The changes make the output more readable and modular, and introduce an example usage for testing.

Formatting and organization improvements in relation/index output:

* Refactored the relation and index output in `writeRelations` to use a new `print` helper function, grouping each section with a titled comment block for better readability and modularity.
* Removed the previous generic "RELATIONS" section header and now prints separate titled blocks for "BELONED RELATIONS", "HAS RELATIONS", and "INDEXES".

Experimental test addition:

* Added `test/src/experimental/prisma.ts` to demonstrate generating Prisma application files from example histories and saving them to the filesystem using `AutoBeExampleStorage` and `FileSystemIterator`.