### PR TITLE
fix(agent): not to erase `page` and `limit` by prompts.

### DIFF
--- a/packages/agent/prompts/INTERFACE_SCHEMA_PHANTOM_REVIEW.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_PHANTOM_REVIEW.md
@@ -40,6 +40,19 @@ Keep (not phantom):
 - `x-autobe-database-schema-property` is non-null (has DB mapping)
 - `x-autobe-specification` explains valid logic (DB aggregation, algorithmic computation, auth tokens, derived values — not fabricated wishful thinking)
 
+**Concrete examples of valid null-mapped fields** (NEVER erase these):
+
+| Property | DTO Type | Why valid |
+|----------|----------|-----------|
+| `page`, `limit`, `search`, `sort` | `IRequest` | Pagination/search parameters — query logic, not DB columns |
+| `ip`, `href`, `referrer` | `IJoin`, `ILogin` | Session context — stored in session table, not actor table |
+| `password` | `IJoin`, `ILogin` | Plain-text input → backend hashes to `password_hashed` column |
+| `*_count` | Read DTOs | Aggregation — `COUNT()` of related records |
+| `token` / `access` / `refresh` / `expired_at` | `IAuthorized` | Auth response — computed by server, not stored as-is |
+| `pagination`, `data` | `IPage*` | Fixed pagination envelope structure |
+
+These fields have `databaseSchemaProperty: null` by design. Their specification describes a cross-table mapping, a transformation, or a query parameter role — that IS valid business logic.
+
 ## 3. Nullability Rules
 
 | Direction | Rule |
@@ -152,7 +165,7 @@ process({
 
 - [ ] Every property has exactly one revision (no missing, no duplicates)
 - [ ] All required database models loaded
-- [ ] Before `erase`: Verified `x-autobe-database-schema-property` is null AND `x-autobe-specification` has no valid business logic
+- [ ] Before `erase`: Verified `x-autobe-database-schema-property` is null AND read `x-autobe-specification` carefully — cross-table mapping, transformation, or query parameter role means valid (not phantom)
 - [ ] `erase` for phantom fields only (no DB mapping AND no valid specification)
 - [ ] `nullish` for DB nullable → DTO non-null only
 - [ ] Did NOT "fix" DB non-null → DTO nullable (it's intentional)

--- a/packages/agent/prompts/INTERFACE_SCHEMA_REFINE.md
+++ b/packages/agent/prompts/INTERFACE_SCHEMA_REFINE.md
@@ -210,8 +210,21 @@ While enriching, also inspect and fix:
 
 **Decision**:
 - Found in columns OR relations → NOT phantom. Use the property name in `databaseSchemaProperty`.
-- Not in DB BUT has valid business logic (aggregation, algorithm, auth token, derived value) → Keep with `databaseSchemaProperty: null`
+- Not in DB BUT has valid business logic → Keep with `databaseSchemaProperty: null`
 - Not in DB AND no requirements rationale → Erase
+
+**Concrete examples of valid `databaseSchemaProperty: null`** (these are NOT phantom):
+
+| Property | DTO Type | Why valid |
+|----------|----------|-----------|
+| `page`, `limit`, `search`, `sort` | `IRequest` | Pagination/search parameters — query logic, not DB columns |
+| `ip`, `href`, `referrer` | `IJoin`, `ILogin` | Session context — stored in session table, not actor table |
+| `password` | `IJoin`, `ILogin` | Plain-text input → backend hashes to `password_hashed` column |
+| `*_count` | Read DTOs | Aggregation — `COUNT()` of related records |
+| `token` / `access` / `refresh` / `expired_at` | `IAuthorized` | Auth response — computed by server, not stored as-is |
+| `pagination`, `data` | `IPage*` | Fixed pagination envelope structure |
+
+These fields serve cross-table mappings, transformations, or query parameter roles. Verify against loaded DB schemas and requirements before erasing.
 
 **Common mistake**: Setting `databaseSchemaProperty: null` for properties that ARE in the database. Always verify against the loaded schema before using `null`.
 
@@ -400,6 +413,7 @@ Before calling `complete`:
 - [ ] No duplicates (one action per key)
 - [ ] WHICH → HOW → WHAT order followed
 - [ ] `databaseSchemaProperty: null` only for computed values (not in DB)
+- [ ] Before `erase`: verify against loaded DB schemas and requirements — cross-table mapping, transformation, or query parameter role means valid (not phantom)
 
 **Pre-Review Hardening**:
 - [ ] Content: All fields present (DB + computed)


### PR DESCRIPTION
This pull request clarifies and strengthens the documentation for handling DTO fields that are not directly mapped to database columns ("phantom" fields) in interface schema review and refinement prompts. The main focus is to provide concrete examples and clearer guidance on when such fields are valid, ensuring reviewers do not mistakenly erase fields that serve legitimate business logic or query roles.

Clarification and guidance improvements:

* Added a table of concrete examples for valid `databaseSchemaProperty: null` fields, explaining why certain properties (like pagination parameters, session context, aggregation counts, and auth tokens) are intentionally not mapped to DB columns, both in `INTERFACE_SCHEMA_PHANTOM_REVIEW.md` and `INTERFACE_SCHEMA_REFINE.md`. [[1]](diffhunk://#diff-7a5696a2833fa32d6eacd55fd53975a0439e82af686b30afae8b2051586c0688R43-R55) [[2]](diffhunk://#diff-d89bdbf0f40e44a3f1a7aab91d0d797a86091e5407ba8721ad8f3bbb68cccde6L213-R228)
* Revised checklist instructions to emphasize careful reading of `x-autobe-specification`: fields with cross-table mapping, transformation, or query parameter roles should not be erased as phantom, even if not mapped to DB.
* Updated enrichment and review steps to require verification against loaded DB schemas and requirements before erasing fields, reinforcing that valid business logic (not just DB mapping) justifies keeping a field.