### PR TITLE
fix(agent): enforce `.IRequest` to has `page` and `limit` properties.

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchema.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceSchema.ts
@@ -112,7 +112,10 @@ export const orchestrateInterfaceSchema = async (
       });
 
       // special logics
-      AutoBeJsonSchemaFactory.authorize(document.components.schemas);
+      AutoBeJsonSchemaFactory.fixPaginationSchemas(document.components.schemas);
+      AutoBeJsonSchemaFactory.fixAuthorizationSchemas(
+        document.components.schemas,
+      );
       AutoBeJsonSchemaFactory.finalize({
         application: ctx.state().database!.result.data,
         operations: document.operations,

--- a/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaFactory.ts
+++ b/packages/agent/src/orchestrate/interface/utils/AutoBeJsonSchemaFactory.ts
@@ -28,14 +28,32 @@ export namespace AutoBeJsonSchemaFactory {
     for (const key of typeNames)
       if (AutoBeJsonSchemaValidator.isPage(key)) {
         const data: string = getPageName(key);
-        schemas[key] = page(data);
+        schemas[key] = writePageSchema(data);
         typeNames.delete(key);
         typeNames.add(data);
       }
     return schemas;
   };
 
-  export const authorize = (
+  export const fixPaginationSchemas = (
+    schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>,
+  ): void => {
+    const pageRequest: AutoBeOpenApi.IJsonSchemaDescriptive.IObject =
+      DEFAULT_SCHEMAS[
+        "IPage.IRequest"
+      ] as AutoBeOpenApi.IJsonSchemaDescriptive.IObject;
+    for (const [key, value] of Object.entries(schemas)) {
+      if (key.endsWith(".IPage") === false) continue;
+      else if (AutoBeOpenApiTypeChecker.isObject(value) === false) continue;
+
+      if (value.properties.page === undefined)
+        value.properties.page = pageRequest.properties.page;
+      if (value.properties.limit === undefined)
+        value.properties.limit = pageRequest.properties.limit;
+    }
+  };
+
+  export const fixAuthorizationSchemas = (
     schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>,
   ): void => {
     for (const [key, value] of Object.entries(schemas)) {
@@ -248,7 +266,7 @@ export namespace AutoBeJsonSchemaFactory {
   /* -----------------------------------------------------------
     PAGINATION
   ----------------------------------------------------------- */
-  export const page = (
+  export const writePageSchema = (
     key: string,
   ): AutoBeOpenApi.IJsonSchemaDescriptive.IObject => ({
     type: "object",
@@ -277,25 +295,25 @@ export namespace AutoBeJsonSchemaFactory {
     "x-autobe-database-schema": null, // filled by relation review agent
   });
 
-  export const fixPage = (path: string, input: unknown): void => {
-    if (isRecord(input) === false || isRecord(input[path]) === false) return;
-    if (input[path].description) delete input[path].description;
-    if (input[path].required) delete input[path].required;
+  // export const fixPage = (path: string, input: unknown): void => {
+  //   if (isRecord(input) === false || isRecord(input[path]) === false) return;
+  //   if (input[path].description) delete input[path].description;
+  //   if (input[path].required) delete input[path].required;
 
-    for (const key of Object.keys(input[path]))
-      if (DEFAULT_SCHEMAS[key] !== undefined)
-        input[path][key] = DEFAULT_SCHEMAS[key];
-      else if (AutoBeJsonSchemaValidator.isPage(key) === true) {
-        const data: string = key.substring("IPage".length);
-        input[path][key] = page(data);
-      }
-  };
+  //   for (const key of Object.keys(input[path]))
+  //     if (DEFAULT_SCHEMAS[key] !== undefined)
+  //       input[path][key] = DEFAULT_SCHEMAS[key];
+  //     else if (AutoBeJsonSchemaValidator.isPage(key) === true) {
+  //       const data: string = key.substring("IPage".length);
+  //       input[path][key] = writePageSchema(data);
+  //     }
+  // };
 
   export const getPageName = (key: string): string =>
     key.substring("IPage".length);
 
-  const isRecord = (input: unknown): input is Record<string, unknown> =>
-    typeof input === "object" && input !== null;
+  // const isRecord = (input: unknown): input is Record<string, unknown> =>
+  //   typeof input === "object" && input !== null;
 
   export const DEFAULT_SCHEMAS = (() => {
     const init: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =

--- a/test/src/features/utils/test_json_schema_authorized.ts
+++ b/test/src/features/utils/test_json_schema_authorized.ts
@@ -7,7 +7,7 @@ export const test_json_schema_authorized = (): void => {
   const schemas: Record<string, AutoBeOpenApi.IJsonSchemaDescriptive> =
     typia.json.schemas<[IBbsMember, IBbsMember.IAuthorized]>().components
       .schemas as Record<string, AutoBeOpenApi.IJsonSchemaDescriptive>;
-  AutoBeJsonSchemaFactory.authorize(schemas);
+  AutoBeJsonSchemaFactory.fixAuthorizationSchemas(schemas);
 
   const type: AutoBeOpenApi.IJsonSchemaDescriptive.IObject = schemas[
     "IBbsMember.IAuthorized"


### PR DESCRIPTION
This pull request refactors and improves the handling of JSON schema utilities related to pagination and authorization in the orchestrate interface. The main focus is on renaming and splitting responsibilities of utility functions, enhancing schema correction logic, and updating usages throughout the codebase.

**Refactoring and Improvements to JSON Schema Utilities:**

* Split and renamed the `authorize` function in `AutoBeJsonSchemaFactory` to two more specific functions: `fixPaginationSchemas` and `fixAuthorizationSchemas`, improving clarity and separation of concerns.
* Updated the usage in `orchestrateInterfaceSchema.ts` to call the new `fixPaginationSchemas` and `fixAuthorizationSchemas` methods instead of the old `authorize` method.
* Renamed the `page` function to `writePageSchema` for clearer intent, and updated all internal calls accordingly.
* Deprecated (commented out) the `fixPage` and `isRecord` utility functions, as their logic has been superseded by the new schema correction approach.

**Test Updates:**

* Updated the test utility `test_json_schema_authorized.ts` to use the new `fixAuthorizationSchemas` function.