### PR TITLE
fix(agent): enforce delete method operation not to has response body.

### DIFF
--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperation.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperation.ts
@@ -181,6 +181,7 @@ async function process(
     });
     if (pointer.value === null) return out(result)(null);
 
+    AutoBeInterfaceOperationProgrammer.fix(pointer.value.operation);
     for (const p of pointer.value.operation.parameters)
       p.schema = AutoBeJsonSchemaFactory.fixSchema(p.schema);
 

--- a/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperationReview.ts
+++ b/packages/agent/src/orchestrate/interface/orchestrateInterfaceOperationReview.ts
@@ -105,6 +105,7 @@ async function process(
             responseBody: pointer.value.content.responseBody,
           }
         : null;
+    if (content !== null) AutoBeInterfaceOperationProgrammer.fix(content);
     ctx.dispatch({
       type: SOURCE,
       id: v7(),

--- a/packages/agent/src/orchestrate/interface/programmers/AutoBeInterfaceAuthorizationProgrammer.ts
+++ b/packages/agent/src/orchestrate/interface/programmers/AutoBeInterfaceAuthorizationProgrammer.ts
@@ -32,6 +32,8 @@ export namespace AutoBeInterfaceAuthorizationProgrammer {
     operations: AutoBeOpenApi.IOperation[];
     prefix: string;
   }): AutoBeOpenApi.IOperation[] => {
+    for (const op of props.operations)
+      AutoBeInterfaceOperationProgrammer.fix(op);
     return props.operations
       .filter((op) => op.authorizationType !== null)
       .map((op) => {

--- a/packages/agent/src/orchestrate/interface/programmers/AutoBeInterfaceOperationProgrammer.ts
+++ b/packages/agent/src/orchestrate/interface/programmers/AutoBeInterfaceOperationProgrammer.ts
@@ -6,6 +6,13 @@ import { Escaper } from "typia/lib/utils/Escaper";
 import { AutoBeJsonSchemaValidator } from "../utils/AutoBeJsonSchemaValidator";
 
 export namespace AutoBeInterfaceOperationProgrammer {
+  export const fix = (
+    operation: Pick<AutoBeOpenApi.IOperation, "method" | "responseBody">,
+  ): void => {
+    if (operation.method === "delete" && operation.responseBody !== null)
+      operation.responseBody = null;
+  };
+
   export const validate = (props: {
     errors: IValidation.IError[];
     accessor: string;


### PR DESCRIPTION
This pull request introduces a new utility function to ensure that `delete` operations do not have a `responseBody`, and applies this fix across multiple parts of the codebase. The main goal is to enforce OpenAPI conventions and prevent invalid operation definitions.

Key changes include:

### Operation Fix Utility

* Added a `fix` function to `AutoBeInterfaceOperationProgrammer` that sets `responseBody` to `null` for operations with the `delete` method.

### Application of Fix in Operation Processing

* Updated `process` in `orchestrateInterfaceOperation.ts` to call `fix` on each operation before further processing.
* Updated `process` in `orchestrateInterfaceOperationReview.ts` to call `fix` on the operation's content if present.
* Updated `AutoBeInterfaceAuthorizationProgrammer` to call `fix` on all operations before filtering and mapping them for authorization purposes.