### PR TITLE
fix(agent): introduce cascade deletion to realize agent (Fix #1020)

### DIFF
--- a/packages/agent/prompts/REALIZE_OPERATION_WRITE.md
+++ b/packages/agent/prompts/REALIZE_OPERATION_WRITE.md
@@ -266,7 +266,29 @@ return {
 };
 ```
 
-### 7.5. Manual CREATE Example
+### 7.5. DELETE Operation: Cascade Deletion
+
+All tables use `onDelete: Cascade` in their foreign key relations. When deleting a record, simply delete the target row — the database automatically cascades to all dependent rows.
+
+```typescript
+// ✅ CORRECT - Delete only the target record
+await MyGlobal.prisma.shopping_sales.delete({
+  where: { id: props.saleId },
+});
+
+// ❌ WRONG - Manually deleting child records (unnecessary, cascade handles it)
+await MyGlobal.prisma.shopping_sale_reviews.deleteMany({
+  where: { shopping_sale_id: props.saleId },
+});
+await MyGlobal.prisma.shopping_sale_items.deleteMany({
+  where: { shopping_sale_id: props.saleId },
+});
+await MyGlobal.prisma.shopping_sales.delete({
+  where: { id: props.saleId },
+});
+```
+
+### 7.6. Manual CREATE Example
 
 ```typescript
 export async function postShoppingSaleReview(props: {
@@ -447,3 +469,4 @@ throw new HttpException("Not found", HttpStatus.NOT_FOUND);
 - [ ] Sequential await for findMany + count (NOT Promise.all)
 - [ ] `ArrayUtil.asyncMap` for Pattern A list transforms
 - [ ] Regular `.map()` for Pattern B list transforms
+- [ ] DELETE targets only the parent record (cascade handles children)


### PR DESCRIPTION
This pull request updates the documentation for write operations, specifically clarifying how DELETE operations should be handled when using cascading foreign key constraints. The changes emphasize that developers should only delete the parent record and allow the database to automatically handle the deletion of dependent child records, rather than manually deleting them.

**Documentation updates on DELETE operations:**

* Added a new section explaining that all tables use `onDelete: Cascade` for foreign key relations, and that only the parent record should be deleted—manual deletion of child records is unnecessary. Includes correct and incorrect code examples.
* Updated checklist to remind developers that DELETE operations should target only the parent record, as cascade will handle child records.