### PR TITLE
fix(agent): table names are not relation properties.

### DIFF
--- a/packages/agent/prompts/REALIZE_COLLECTOR_CORRECT.md
+++ b/packages/agent/prompts/REALIZE_COLLECTOR_CORRECT.md
@@ -113,14 +113,14 @@ parent: props.body.parentId
 
 ```typescript
 // ❌ ERROR (Architectural): ShoppingSaleTagCollector exists
-shopping_sale_tags: {
+tags: {
   create: props.body.tags.map((tag, i) => ({
     id: v4(), name: tag.name, sequence: i,
   })),
 }
 
 // ✅ FIX: Use neighbor collector
-shopping_sale_tags: {
+tags: {
   create: await ArrayUtil.asyncMap(
     props.body.tags,
     (tag, i) => ShoppingSaleTagCollector.collect({ body: tag, sequence: i })
@@ -173,7 +173,7 @@ return {
 ### Schema Compliance
 - [ ] EVERY field name verified against schema
 - [ ] No fabricated fields
-- [ ] Relations use relation names (NOT FK columns)
+- [ ] Relations use schema-defined relation property names
 - [ ] All timestamps included
 
 ### Relation Syntax

--- a/packages/agent/prompts/REALIZE_COLLECTOR_WRITE.md
+++ b/packages/agent/prompts/REALIZE_COLLECTOR_WRITE.md
@@ -114,7 +114,7 @@ export namespace ShoppingSaleCollector {
         : undefined,
 
       // HasMany relations (reuse neighbor collectors)
-      shopping_sale_tags: props.body.tags.length
+      tags: props.body.tags.length
         ? {
             create: await ArrayUtil.asyncMap(
               props.body.tags,
@@ -165,7 +165,7 @@ parent: props.body.parentId
 // If ShoppingSaleTagCollector exists in neighbors:
 
 // ❌ FORBIDDEN - Ignoring existing collector
-shopping_sale_tags: {
+tags: {
   create: props.body.tags.map((tag, i) => ({
     id: v4(),
     name: tag.name,
@@ -174,7 +174,7 @@ shopping_sale_tags: {
 }
 
 // ✅ REQUIRED - Reuse neighbor collector
-shopping_sale_tags: {
+tags: {
   create: await ArrayUtil.asyncMap(
     props.body.tags,
     (tag, i) => ShoppingSaleTagCollector.collect({
@@ -227,7 +227,7 @@ mappings: [
   { member: "parent", kind: "belongsTo", nullable: true, how: "Connect if exists, else undefined" },
 
   { member: "children", kind: "hasMany", nullable: null, how: "Cannot create (reverse relation)" },
-  { member: "bbs_article_comment_files", kind: "hasMany", nullable: null, how: "Nested create with BbsArticleCommentFileCollector" },
+  { member: "files", kind: "hasMany", nullable: null, how: "Nested create with BbsArticleCommentFileCollector" },
 ]
 ```
 

--- a/packages/agent/prompts/REALIZE_OPERATION_WRITE.md
+++ b/packages/agent/prompts/REALIZE_OPERATION_WRITE.md
@@ -175,7 +175,7 @@ export async function patchShoppingSales(props: {
 **Before writing ANY query**:
 1. READ the database schema thoroughly
 2. VERIFY each field name (case-sensitive)
-3. VERIFY relation names (NOT foreign key columns)
+3. VERIFY relation property names from schema
 4. NEVER fabricate, imagine, or guess
 
 **Key Hints from DTO Schema**:

--- a/packages/agent/prompts/REALIZE_TRANSFORMER_CORRECT.md
+++ b/packages/agent/prompts/REALIZE_TRANSFORMER_CORRECT.md
@@ -86,7 +86,7 @@ selectMappings: [
   { member: "id", kind: "scalar", nullable: false, how: "Already correct" },
   { member: "created_at", kind: "scalar", nullable: false, how: "Fix: Missing - add to select()" },
   { member: "user", kind: "belongsTo", nullable: false, how: "Fix: Inline → BbsUserAtSummaryTransformer.select()" },
-  { member: "bbs_article_comment_files", kind: "hasMany", nullable: null, how: "Already correct" },
+  { member: "files", kind: "hasMany", nullable: null, how: "Already correct" },
   { member: "_count", kind: "scalar", nullable: false, how: "Fix: Missing - add for hit/like" },
 ]
 ```
@@ -99,7 +99,7 @@ transformMappings: [
   { property: "createdAt", how: "Fix: Missing .toISOString()" },
   { property: "writer", how: "Fix: Inline → BbsUserAtSummaryTransformer.transform()" },
   { property: "files", how: "Already correct" },
-  { property: "hit", how: "Fix: Missing - from input._count.bbs_article_comment_hits" },
+  { property: "hit", how: "Fix: Missing - from input._count.hits" },
 ]
 ```
 
@@ -220,10 +220,10 @@ export function select() {
 
 // ✅ FIX: Select source data, compute in transform()
 export function select() {
-  return { select: { _count: { select: { shopping_sale_reviews: true } } } };
+  return { select: { _count: { select: { reviews: true } } } };
 }
 export async function transform(input: Payload) {
-  return { reviewCount: input._count.shopping_sale_reviews };  // ✅ Computed
+  return { reviewCount: input._count.reviews };  // ✅ Computed
 }
 ```
 

--- a/packages/agent/prompts/REALIZE_TRANSFORMER_WRITE.md
+++ b/packages/agent/prompts/REALIZE_TRANSFORMER_WRITE.md
@@ -65,7 +65,7 @@ selectMappings: [
   { member: "id", kind: "scalar", nullable: false, how: "For DTO.id" },
   { member: "created_at", kind: "scalar", nullable: false, how: "For DTO.createdAt (.toISOString())" },
   { member: "user", kind: "belongsTo", nullable: false, how: "For DTO.writer (BbsUserAtSummaryTransformer)" },
-  { member: "bbs_article_comment_files", kind: "hasMany", nullable: null, how: "For DTO.files" },
+  { member: "files", kind: "hasMany", nullable: null, how: "For DTO.files" },
   { member: "_count", kind: "scalar", nullable: false, how: "For DTO.hit and DTO.like" },
 ]
 ```
@@ -80,7 +80,7 @@ transformMappings: [
   { property: "createdAt", how: "From input.created_at.toISOString()" },  // x-autobe-database-schema-property: "created_at"
   { property: "writer", how: "Transform with BbsUserAtSummaryTransformer" },
   { property: "files", how: "Array map with BbsArticleCommentFileTransformer" },
-  { property: "hit", how: "From input._count.bbs_article_comment_hits" },
+  { property: "hit", how: "From input._count.hits" },
 ]
 ```
 
@@ -166,22 +166,7 @@ category: await ShoppingCategoryTransformer.transform(input.category),
 
 Algorithm: Split by `.`, remove `I` prefix, join with `At`, append `Transformer`.
 
-### 6.4. 1:N Relation Field Names
-
-```typescript
-// Database schema typically uses full table names for 1:N relations:
-model shopping_sales {
-  shopping_sale_reviews  shopping_sale_reviews[]  // ← Relation field name
-}
-
-// ✅ CORRECT - Use EXACT relation name
-_count: { select: { shopping_sale_reviews: true } }
-
-// ❌ WRONG - Shortened name
-_count: { select: { reviews: true } }  // Does NOT exist!
-```
-
-### 6.5. NULL vs UNDEFINED Handling
+### 6.4. NULL vs UNDEFINED Handling
 
 | Pattern | DTO Signature | Handling |
 |---------|--------------|----------|
@@ -214,7 +199,7 @@ export namespace ShoppingSaleTransformer {
 | DateTime → ISO | `input.created_at.toISOString()` |
 | Decimal → Number | `Number(input.price)` |
 | Nullable DateTime | `input.deleted_at?.toISOString() ?? null` |
-| Aggregation | `input._count.shopping_sale_reviews` |
+| Aggregation | `input._count.reviews` |
 
 ## 8. Computed Fields (Not in DB)
 
@@ -225,13 +210,13 @@ When DTO field doesn't exist in database:
 // Solution: Select source data, compute in transform()
 
 // select()
-_count: { select: { shopping_sale_reviews: true } },
-shopping_sale_reviews: { select: { rating: true } },
+_count: { select: { reviews: true } },
+reviews: { select: { rating: true } },
 
 // transform()
-reviewCount: input._count.shopping_sale_reviews,
-averageRating: input.shopping_sale_reviews.length > 0
-  ? input.shopping_sale_reviews.reduce((sum, r) => sum + r.rating, 0) / input.shopping_sale_reviews.length
+reviewCount: input._count.reviews,
+averageRating: input.reviews.length > 0
+  ? input.reviews.reduce((sum, r) => sum + r.rating, 0) / input.reviews.length
   : 0,
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   agentica:
     '@agentica/core':
-      specifier: ^0.41.3
-      version: 0.41.3
+      specifier: ^0.41.4
+      version: 0.41.4
   libs:
     openai:
       specifier: ^6.15.0
@@ -770,7 +770,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.41.3(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))
+        version: 0.41.4(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))
       '@autobe/interface':
         specifier: workspace:^
         version: link:../interface
@@ -1151,7 +1151,7 @@ importers:
     dependencies:
       '@agentica/core':
         specifier: catalog:agentica
-        version: 0.41.3(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))
+        version: 0.41.4(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))
       '@autobe/agent':
         specifier: workspace:^
         version: link:../packages/agent
@@ -1304,8 +1304,8 @@ importers:
 
 packages:
 
-  '@agentica/core@0.41.3':
-    resolution: {integrity: sha512-PGXCU6IMgXwwOMC6a1XE7Htfpx3EbCNQDSRxZjCl54x5yvz3rIK7KNyhQdzyOTQVTwD2Ahzo+Qi/fPZ3jXcVTQ==}
+  '@agentica/core@0.41.4':
+    resolution: {integrity: sha512-3x2tMTHtvewW5LDfrHy9PKOEOkXhGA5d/v6UU4n/PXquXkjPuezreWBcRrp/jH5FKfbhwRNtG3szQD+EQHe5MA==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.12.0
       '@samchon/openapi': ^6.0.1
@@ -8701,7 +8701,7 @@ packages:
 
 snapshots:
 
-  '@agentica/core@0.41.3(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))':
+  '@agentica/core@0.41.4(@samchon/openapi@6.0.1)(openai@6.15.0(ws@8.18.3)(zod@4.2.1))(typia@11.0.3(typescript@5.9.3))':
     dependencies:
       '@samchon/openapi': 6.0.1
       es-jsonkit: 0.1.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ packages:
   - website
 catalogs:
   agentica:
-    '@agentica/core': ^0.41.3
+    '@agentica/core': ^0.41.4
   samchon:
     '@nestia/benchmark': ^10.0.2
     '@nestia/core': ^10.0.2


### PR DESCRIPTION
This pull request focuses on improving consistency with schema-defined relation and property names throughout the codebase, especially in the agent prompt and transformer files. It also updates the dependency on `@agentica/core` to the latest patch version. The changes standardize field and relation naming, ensuring code matches the schema and reduces confusion or errors when dealing with related data.

**Schema and Relation Name Standardization:**

* Replaced all instances of `shopping_sale_tags` with `tags` in collector prompt files to align with the schema-defined relation property name (`REALIZE_COLLECTOR_WRITE.md`, `REALIZE_COLLECTOR_CORRECT.md`). [[1]](diffhunk://#diff-2713a20a86526312e47231883a889eef5a30c8cd7f9f4afd2833e2d220b64b41L117-R117) [[2]](diffhunk://#diff-2713a20a86526312e47231883a889eef5a30c8cd7f9f4afd2833e2d220b64b41L168-R168) [[3]](diffhunk://#diff-2713a20a86526312e47231883a889eef5a30c8cd7f9f4afd2833e2d220b64b41L177-R177) [[4]](diffhunk://#diff-baab7ce069d61eeba7fdaa8ac2d550450882e3a593babe4aad9563a57e26bb00L116-R123)
* Updated references from `bbs_article_comment_files` to `files` in both collector and transformer prompt files for consistency with the schema (`REALIZE_COLLECTOR_WRITE.md`, `REALIZE_TRANSFORMER_CORRECT.md`, `REALIZE_TRANSFORMER_WRITE.md`). [[1]](diffhunk://#diff-2713a20a86526312e47231883a889eef5a30c8cd7f9f4afd2833e2d220b64b41L230-R230) [[2]](diffhunk://#diff-17b7f403895c2206283c66ef282ba37c14da62603c8e4aa3472314aa9a796aafL89-R89) [[3]](diffhunk://#diff-59aa0d51afcebc0246fd1a2c7d49907f7dadf610293c0790345a0bc19b8535dfL68-R68)
* Changed all `_count.shopping_sale_reviews` and related field names to `_count.reviews` and updated corresponding transform logic to match the schema (`REALIZE_TRANSFORMER_CORRECT.md`, `REALIZE_TRANSFORMER_WRITE.md`). [[1]](diffhunk://#diff-17b7f403895c2206283c66ef282ba37c14da62603c8e4aa3472314aa9a796aafL223-R226) [[2]](diffhunk://#diff-17b7f403895c2206283c66ef282ba37c14da62603c8e4aa3472314aa9a796aafL102-R102) [[3]](diffhunk://#diff-59aa0d51afcebc0246fd1a2c7d49907f7dadf610293c0790345a0bc19b8535dfL83-R83) [[4]](diffhunk://#diff-59aa0d51afcebc0246fd1a2c7d49907f7dadf610293c0790345a0bc19b8535dfL217-R202) [[5]](diffhunk://#diff-59aa0d51afcebc0246fd1a2c7d49907f7dadf610293c0790345a0bc19b8535dfL228-R219)

**Documentation and Prompt Improvements:**

* Clarified checklist and documentation language to specify using schema-defined relation property names instead of generic or FK column names (`REALIZE_COLLECTOR_CORRECT.md`, `REALIZE_OPERATION_WRITE.md`). [[1]](diffhunk://#diff-baab7ce069d61eeba7fdaa8ac2d550450882e3a593babe4aad9563a57e26bb00L176-R176) [[2]](diffhunk://#diff-4ff9e347c1f974a1fbb5ec9256c790aab7a5760d7097f5f2ed1d1c6f871111f4L178-R178)
* Removed outdated documentation about relation field naming, reflecting the new standard (`REALIZE_TRANSFORMER_WRITE.md`).

**Dependency Update:**

* Upgraded `@agentica/core` from version `0.41.3` to `0.41.4` in all relevant lock and workspace files. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R11) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL773-R773) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1154-R1154) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1307-R1308) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8704-R8704) [[6]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL12-R12)