### PR TITLE
fix(interface): analyze author is Juntak.

### DIFF
--- a/packages/interface/src/events/AutoBeAnalyzeCompleteEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeCompleteEvent.ts
@@ -18,6 +18,7 @@ import { AutoBeCompleteEventBase } from "./base/AutoBeCompleteEventBase";
  * implementation.
  *
  * @author Kakasoo
+ * @author Juntak
  */
 export interface AutoBeAnalyzeCompleteEvent extends AutoBeCompleteEventBase<"analyzeComplete"> {
   /**

--- a/packages/interface/src/events/AutoBeAnalyzeWriteAllSectionReviewEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeWriteAllSectionReviewEvent.ts
@@ -28,7 +28,7 @@ import { AutoBeProgressEventBase } from "./base/AutoBeProgressEventBase";
  * - **Approved**: All content is ready for document assembly
  * - **Rejected**: Content needs revision, regenerate ALL sections with feedback
  *
- * @author AutoBE
+ * @author Juntak
  */
 export interface AutoBeAnalyzeWriteAllSectionReviewEvent
   extends

--- a/packages/interface/src/events/AutoBeAnalyzeWriteAllUnitReviewEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeWriteAllUnitReviewEvent.ts
@@ -26,7 +26,7 @@ import { AutoBeProgressEventBase } from "./base/AutoBeProgressEventBase";
  * - **Approved**: All structures are valid, proceed to section generation
  * - **Rejected**: Structures need revision, regenerate ALL units with feedback
  *
- * @author AutoBE
+ * @author Juntak
  */
 export interface AutoBeAnalyzeWriteAllUnitReviewEvent
   extends

--- a/packages/interface/src/events/AutoBeAnalyzeWriteModuleEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeWriteModuleEvent.ts
@@ -24,7 +24,7 @@ import { AutoBeProgressEventBase } from "./base/AutoBeProgressEventBase";
  * - Creates the foundational structure for subsequent unit/section sections
  * - Must be approved by review before lower-level generation begins
  *
- * @author AutoBE
+ * @author Juntak
  */
 export interface AutoBeAnalyzeWriteModuleEvent
   extends

--- a/packages/interface/src/events/AutoBeAnalyzeWriteModuleReviewEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeWriteModuleReviewEvent.ts
@@ -25,7 +25,7 @@ import { AutoBeProgressEventBase } from "./base/AutoBeProgressEventBase";
  * - **Approved**: Structure is valid, proceed to unit section generation
  * - **Rejected**: Structure needs revision, provide specific feedback
  *
- * @author AutoBE
+ * @author Juntak
  */
 export interface AutoBeAnalyzeWriteModuleReviewEvent
   extends

--- a/packages/interface/src/events/AutoBeAnalyzeWriteSectionEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeWriteSectionEvent.ts
@@ -24,7 +24,7 @@ import { AutoBeProgressEventBase } from "./base/AutoBeProgressEventBase";
  * - Produces implementation-ready specification content
  * - Must be approved by review before final document assembly
  *
- * @author AutoBE
+ * @author Juntak
  */
 export interface AutoBeAnalyzeWriteSectionEvent
   extends

--- a/packages/interface/src/events/AutoBeAnalyzeWriteSectionReviewEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeWriteSectionReviewEvent.ts
@@ -25,7 +25,7 @@ import { AutoBeProgressEventBase } from "./base/AutoBeProgressEventBase";
  * - **Approved**: Content is valid, ready for document assembly
  * - **Rejected**: Content needs revision, provide specific feedback
  *
- * @author AutoBE
+ * @author Juntak
  */
 export interface AutoBeAnalyzeWriteSectionReviewEvent
   extends

--- a/packages/interface/src/events/AutoBeAnalyzeWriteUnitEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeWriteUnitEvent.ts
@@ -24,7 +24,7 @@ import { AutoBeProgressEventBase } from "./base/AutoBeProgressEventBase";
  * - Provides keywords as hints for section generation
  * - Must be approved by review before sections are generated
  *
- * @author AutoBE
+ * @author Juntak
  */
 export interface AutoBeAnalyzeWriteUnitEvent
   extends

--- a/packages/interface/src/events/AutoBeAnalyzeWriteUnitReviewEvent.ts
+++ b/packages/interface/src/events/AutoBeAnalyzeWriteUnitReviewEvent.ts
@@ -25,7 +25,7 @@ import { AutoBeProgressEventBase } from "./base/AutoBeProgressEventBase";
  * - **Approved**: Structure is valid, proceed to section generation
  * - **Rejected**: Structure needs revision, provide specific feedback
  *
- * @author AutoBE
+ * @author Juntak
  */
 export interface AutoBeAnalyzeWriteUnitReviewEvent
   extends

--- a/packages/interface/src/histories/AutoBeAnalyzeHistory.ts
+++ b/packages/interface/src/histories/AutoBeAnalyzeHistory.ts
@@ -21,7 +21,7 @@ import { AutoBeProcessAggregateCollection } from "./contents/AutoBeProcessAggreg
  * pipeline, ensuring that technical implementation accurately reflects business
  * intentions.
  *
- * @author Samchon
+ * @author Juntak
  */
 export interface AutoBeAnalyzeHistory extends AutoBeAgentHistoryBase<"analyze"> {
   /**

--- a/packages/interface/src/histories/contents/AutoBeAnalyzeModule.ts
+++ b/packages/interface/src/histories/contents/AutoBeAnalyzeModule.ts
@@ -16,7 +16,7 @@ import { AutoBeAnalyzeUnit } from "./AutoBeAnalyzeUnit";
  * The structure mirrors the three-level hierarchy used during generation:
  * Module (#) → Unit (##) → Section (###)
  *
- * @author michael
+ * @author Juntak
  */
 export interface AutoBeAnalyzeModule {
   /**

--- a/packages/interface/src/histories/contents/AutoBeAnalyzeSection.ts
+++ b/packages/interface/src/histories/contents/AutoBeAnalyzeSection.ts
@@ -7,7 +7,7 @@
  * implementation-ready content using EARS format for requirements and Mermaid
  * syntax for diagrams.
  *
- * @author michael
+ * @author Juntak
  */
 export interface AutoBeAnalyzeSection {
   /** Title of the section (### level heading). */

--- a/packages/interface/src/histories/contents/AutoBeAnalyzeUnit.ts
+++ b/packages/interface/src/histories/contents/AutoBeAnalyzeUnit.ts
@@ -12,7 +12,7 @@ import { AutoBeAnalyzeSection } from "./AutoBeAnalyzeSection";
  * about the topics covered, enabling intelligent search and categorization of
  * requirements.
  *
- * @author michael
+ * @author Juntak
  */
 export interface AutoBeAnalyzeUnit {
   /** Title of the unit (## level heading). */


### PR DESCRIPTION
This pull request updates the author annotations in several TypeScript interface files within the `packages/interface/src/events` and `packages/interface/src/histories` directories. The main change is to consistently credit "Juntak" as the author for these files, replacing previous author names.

**Documentation and metadata updates:**

* Updated the `@author` annotation to "Juntak" in the following event interface files:
  - `AutoBeAnalyzeCompleteEvent.ts`
  - `AutoBeAnalyzeWriteAllSectionReviewEvent.ts`
  - `AutoBeAnalyzeWriteAllUnitReviewEvent.ts`
  - `AutoBeAnalyzeWriteModuleEvent.ts`
  - `AutoBeAnalyzeWriteModuleReviewEvent.ts`
  - `AutoBeAnalyzeWriteSectionEvent.ts`
  - `AutoBeAnalyzeWriteSectionReviewEvent.ts`
  - `AutoBeAnalyzeWriteUnitEvent.ts`
  - `AutoBeAnalyzeWriteUnitReviewEvent.ts`

* Updated the `@author` annotation to "Juntak" in the following history interface files:
  - `AutoBeAnalyzeHistory.ts`
  - `AutoBeAnalyzeModule.ts`
  - `AutoBeAnalyzeSection.ts`
  - `AutoBeAnalyzeUnit.ts`