### PR TITLE
fix(playground): prisma db push for local playground (Fix #1290)

### DIFF
--- a/apps/playground-server/package.json
+++ b/apps/playground-server/package.json
@@ -12,7 +12,7 @@
     "dev": "rimraf bin && tsc -p test/tsconfig.json --watch --noEmit",
     "prepack": "pnpm run build",
     "prepare": "pnpm run build:env && pnpm run build:prisma",
-    "start": "prisma migrate deploy && ts-node src/executable/server.ts",
+    "start": "prisma db push && ts-node src/executable/server.ts",
     "test": "ts-node -P test/tsconfig.json test/index.ts"
   },
   "keywords": [],


### PR DESCRIPTION
This pull request makes a small but important change to how the development server initializes the database. The `start` script in `package.json` now uses `prisma db push` instead of `prisma migrate deploy`. This means that when starting the server, the database schema is synchronized directly with the Prisma schema, rather than running migrations. This can simplify local development and setup.

* Changed the `start` script in `apps/playground-server/package.json` to use `prisma db push` instead of `prisma migrate deploy` for database initialization.