### PR TITLE
Fix #1252: Feedback for “AutoBE >  browser doesn't find playground”

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pnpm run playground
 
 To use AutoBE, clone the repository and run the playground application locally. This allows you to chat with AutoBE's AI agents, manage multiple sessions, and use various LLM providers including local models like `qwen3.5-397b-a17b`.
 
-After installation, the playground will be available at http://localhost:5713. You can interact with AutoBE through a chat interface - simply describe what you want to build, and AutoBE will generate the backend application for you.
+After installation, the playground will be available at http://localhost:5173. You can interact with AutoBE through a chat interface - simply describe what you want to build, and AutoBE will generate the backend application for you.
 
 Here's an example conversation script that guides AutoBE to create an "Economic/Political Discussion Board":
 
@@ -52,7 +52,7 @@ Here's an example conversation script that guides AutoBE to create an "Economic/
 
 ![Compilation Success Dashboard](https://autobe.dev/images/demonstrate/replay-z-ai-glm-5.png)
 
-> The playground includes a replay feature at http://localhost:5713/replay/index.html where you can view chat sessions from the AutoBE development team's testing and benchmarks.
+> The playground includes a replay feature at http://localhost:5173/replay/index.html where you can view chat sessions from the AutoBE development team's testing and benchmarks.
 
 ## Documentation Resources
 


### PR DESCRIPTION
Closes #1252

## Before

`README.md` referenced the playground at `http://localhost:5713` in two places, causing users to open a URL where no server was listening. The Vite dev server binds to `5173` by default, so the browser found nothing at the documented address.

## After

Both occurrences of the port in `README.md` now read `5173`:
- The main onboarding paragraph directing users to the chat interface.
- The blockquote pointing to the replay feature at `/replay/index.html`.

## Changes

- **`README.md` line ~43**: `http://localhost:5713` → `http://localhost:5173` (main playground URL)
- **`README.md` line ~55**: `http://localhost:5713/replay/index.html` → `http://localhost:5173/replay/index.html` (replay feature URL)

## Testing

1. Clone the repo and run `pnpm run playground`.
2. Navigate to `http://localhost:5173` — the chat interface loads.
3. Navigate to `http://localhost:5173/replay/index.html` — the replay viewer loads.
4. Confirmed the old `5713` URLs return connection refused.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*